### PR TITLE
JiraPS - Add-JiraIssueWorklog fix

### DIFF
--- a/JiraPS/Public/Add-JiraIssueWorklog.ps1
+++ b/JiraPS/Public/Add-JiraIssueWorklog.ps1
@@ -75,7 +75,6 @@ function Add-JiraIssueWorklog {
         # We can't validate pipeline input here, since pipeline input doesn't exist in the Begin block.
     }
 
-
     process {
         Write-Debug "[Add-JiraIssueWorklog] Checking Issue parameter"
         if ($Issue.PSObject.TypeNames[0] -eq 'JiraPS.Issue') {

--- a/JiraPS/Public/Add-JiraIssueWorklog.ps1
+++ b/JiraPS/Public/Add-JiraIssueWorklog.ps1
@@ -50,7 +50,7 @@ function Add-JiraIssueWorklog {
             ValueFromPipeline = $true,
             ValueFromPipelineByPropertyName = $true
         )]
-        [TimeSpan] $TimeSpent,
+        [String] $TimeSpent,
 
         # Date/time started to be logged
         [Parameter(
@@ -74,6 +74,7 @@ function Add-JiraIssueWorklog {
         Write-Debug "[Add-JiraIssueWorklog] Begin"
         # We can't validate pipeline input here, since pipeline input doesn't exist in the Begin block.
     }
+
 
     process {
         Write-Debug "[Add-JiraIssueWorklog] Checking Issue parameter"
@@ -104,12 +105,12 @@ function Add-JiraIssueWorklog {
         #$issueObj = Get-JiraIssue -InputObject $Issue -Credential $Credential
 
         $url = "$($issueObj.RestURL)/worklog"
-
+		
         Write-Debug "[Add-JiraIssueWorklog] Creating request body from comment"
         $props = @{
             'comment'   = $Comment;
-            'started'   = $DateStarted.ToString();
-            'timeSpent' = $TimeSpent.TotalSeconds.ToString();
+            'started'   = $DateStarted.tostring("yyyy-MM-ddTHH:mm:ss.00+0000");
+            'timeSpent' = $TimeSpent.ToString();
         }
 
         # If the visible role should be all users, the visibility block shouldn't be passed at


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

### Description
This pull request was created to contribute to project adjusting the Module Method "Add-JiraIssueWorklog" to work better with Powershell DateTime method and Jira's API documentation.

### Motivation and Context
I'm facing the problem with my jira, and I believe for other people should be happen also. The problem is, the method Add-JiraWorklog.ps1 its not working because the type of data inserted couldn't be converted to format whitch JIra accepts. (As mentioned in JIra's api guide https://docs.atlassian.com/jira/REST/server/#api/2/issue-addWorklog)
`        "started": {
            "type": "string"
        },`
`
        "timeSpent": {
            "type": "string"
        }
`


and as configured today the powershell cannot convert to specified type. Loking at Jira's documentation example:

 "timeSpent": "60",
 "started": "2017-06-29T13:12:36.317+0000",

closes https://github.com/AtlassianPS/JiraPS/issues/153


### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have added Pester Tests that describe what my changes should do.
- [ ] I have updated the documentation accordingly.