### PR TITLE
Fix #209 - Indexing into Null Object

### DIFF
--- a/JiraPS/Internal/Invoke-JiraMethod.ps1
+++ b/JiraPS/Internal/Invoke-JiraMethod.ps1
@@ -119,13 +119,15 @@ function Invoke-JiraMethod {
             }
         }
 
-        if (Get-Member -Name "Errors" -InputObject $result -ErrorAction SilentlyContinue) {
-            Write-Debug "[Invoke-JiraMethod] An error response was received from JIRA; resolving"
-            Resolve-JiraError $result -WriteError
-        }
-        else {
-            Write-Debug "[Invoke-JiraMethod] Outputting results from JIRA"
-            Write-Output $result
+        if ($result) {
+            if (Get-Member -Name "Errors" -InputObject $result -ErrorAction SilentlyContinue) {
+                Write-Debug "[Invoke-JiraMethod] An error response was received from JIRA; resolving"
+                Resolve-JiraError $result -WriteError
+            }
+            else {
+                Write-Debug "[Invoke-JiraMethod] Outputting results from JIRA"
+                Write-Output $result
+            }
         }
     }
     else {


### PR DESCRIPTION
### Description
Invoke-JiraMethod was trying to invoke `Get-Member` on `$result`.
For when `$result` is empty, the module was writing a non-API related error in the error stream.
Now `$result` is check before using it.

### Motivation and Context
closes #209 

### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have added Pester Tests that describe what my changes should do.
- [ ] I have updated the documentation accordingly.
