### PR TITLE
Transition with Resolution

### DIFF
--- a/JiraPS/Internal/Invoke-JiraMethod.ps1
+++ b/JiraPS/Internal/Invoke-JiraMethod.ps1
@@ -119,13 +119,15 @@ function Invoke-JiraMethod {
             }
         }
 
-        if (Get-Member -Name "Errors" -InputObject $result -ErrorAction SilentlyContinue) {
-            Write-Debug "[Invoke-JiraMethod] An error response was received from JIRA; resolving"
-            Resolve-JiraError $result -WriteError
-        }
-        else {
-            Write-Debug "[Invoke-JiraMethod] Outputting results from JIRA"
-            Write-Output $result
+        if ($result) {
+            if (Get-Member -Name "Errors" -InputObject $result -ErrorAction SilentlyContinue) {
+                Write-Debug "[Invoke-JiraMethod] An error response was received from JIRA; resolving"
+                Resolve-JiraError $result -WriteError
+            }
+            else {
+                Write-Debug "[Invoke-JiraMethod] Outputting results from JIRA"
+                Write-Output $result
+            }
         }
     }
     else {


### PR DESCRIPTION
### Description
Our implementation of Jira requires the setting of the Resolution during the transition.  For example when an issue is marked as "Resolved",  you can choose a resolution like "Duplicate", "Fixed", "Later"....

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
This change is needed in our implementation of Jira to allow the setting of the resolution during Transitiontime.

### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

 --- the way i implemented it, could cause issues in a different Jira configuration.

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.

I added a new parameter to this module called Resolution
I updated the $props variable on line 96 to send the proper json to update the resolution field.
[Invoke-JiraIssueTransition.zip](https://github.com/AtlassianPS/JiraPS/files/1817874/Invoke-JiraIssueTransition.zip)


