### PR TITLE
Added parameter alias

### DIFF
--- a/JiraPS/Public/Get-JiraIssue.ps1
+++ b/JiraPS/Public/Get-JiraIssue.ps1
@@ -81,11 +81,8 @@ function Get-JiraIssue {
         [Int]
         $PageSize = 50,
 
-        [Parameter()]
-        [ValidateNotNull()]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        $Credential
     )
 
     begin {

--- a/JiraPS/Public/Get-JiraIssue.ps1
+++ b/JiraPS/Public/Get-JiraIssue.ps1
@@ -3,6 +3,7 @@ function Get-JiraIssue {
     param(
         [Parameter( Position = 0, Mandatory, ParameterSetName = 'ByIssueKey' )]
         [ValidateNotNullOrEmpty()]
+        [Alias('Issue')]
         [String[]]
         $Key,
 
@@ -80,8 +81,11 @@ function Get-JiraIssue {
         [Int]
         $PageSize = 50,
 
-        [PSCredential]
-        $Credential
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
     begin {

--- a/docs/en-US/about_JiraPS.md
+++ b/docs/en-US/about_JiraPS.md
@@ -33,7 +33,7 @@ Set-JiraConfigServer -Server "https://jira.server.com"
 $cred = Get-Credential
 
 # Get the date from the issue "PR-123"
-Get-JiraIssue -Issue "PR-123" -Credential $cred
+Get-JiraIssue -Key "PR-123" -Credential $cred
 ```
 
 JiraPS uses the information provided by `Set-JiraConfigServer` to resolve what server to connect to.


### PR DESCRIPTION
### Description
In the documentation of the module, an example was using the parameter `-Issue` for `Get-JiraIssue`.
This parameter has never existed and was thus a bug in the documentation.
This change fixes the documentation and introduces an alias for the parameter `-Key` named `-Issue`.

### Motivation and Context
closes #262 

### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have added Pester Tests that describe what my changes should do.
- [x] I have updated the documentation accordingly.
