### PR TITLE
Improved handling of Credential parameter

### DIFF
--- a/JiraPS/Private/Resolve-JiraIssueObject.ps1
+++ b/JiraPS/Private/Resolve-JiraIssueObject.ps1
@@ -28,8 +28,10 @@ function Resolve-JiraIssueObject {
         $InputObject,
 
         # Authentication credentials
-        [PSCredential]
-        $Credential
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
     # As we are not able to use proper type casting in the parameters, this is a workaround

--- a/JiraPS/Public/Add-JiraGroupMember.ps1
+++ b/JiraPS/Public/Add-JiraGroupMember.ps1
@@ -16,8 +16,10 @@ function Add-JiraGroupMember {
           Once we have custom classes, this can also accept ValueFromPipeline
         #>
 
-        [PSCredential]
-        $Credential,
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty,
 
         [Switch]
         $PassThru

--- a/JiraPS/Public/Add-JiraIssueAttachment.ps1
+++ b/JiraPS/Public/Add-JiraIssueAttachment.ps1
@@ -54,8 +54,10 @@ function Add-JiraIssueAttachment {
         [String[]]
         $FilePath,
 
-        [PSCredential]
-        $Credential,
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty,
 
         [Switch]
         $PassThru

--- a/JiraPS/Public/Add-JiraIssueComment.ps1
+++ b/JiraPS/Public/Add-JiraIssueComment.ps1
@@ -37,8 +37,10 @@ function Add-JiraIssueComment {
         [String]
         $VisibleRole = 'All Users',
 
-        [PSCredential]
-        $Credential
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
     begin {

--- a/JiraPS/Public/Add-JiraIssueLink.ps1
+++ b/JiraPS/Public/Add-JiraIssueLink.ps1
@@ -60,8 +60,10 @@ function Add-JiraIssueLink {
         [String]
         $Comment,
 
-        [PSCredential]
-        $Credential
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
     begin {

--- a/JiraPS/Public/Add-JiraIssueWatcher.ps1
+++ b/JiraPS/Public/Add-JiraIssueWatcher.ps1
@@ -36,8 +36,10 @@
         [Object]
         $Issue,
 
-        [PSCredential]
-        $Credential
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
     begin {

--- a/JiraPS/Public/Add-JiraIssueWorklog.ps1
+++ b/JiraPS/Public/Add-JiraIssueWorklog.ps1
@@ -45,8 +45,10 @@ function Add-JiraIssueWorklog {
         [String]
         $VisibleRole = 'All Users',
 
-        [PSCredential]
-        $Credential
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
     begin {

--- a/JiraPS/Public/Get-JiraComponent.ps1
+++ b/JiraPS/Public/Get-JiraComponent.ps1
@@ -36,8 +36,10 @@ function Get-JiraComponent {
         [Int[]]
         $ComponentId,
 
-        [PSCredential]
-        $Credential
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
     begin {

--- a/JiraPS/Public/Get-JiraField.ps1
+++ b/JiraPS/Public/Get-JiraField.ps1
@@ -5,8 +5,10 @@
         [String[]]
         $Field,
 
-        [PSCredential]
-        $Credential
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
     begin {

--- a/JiraPS/Public/Get-JiraFilter.ps1
+++ b/JiraPS/Public/Get-JiraFilter.ps1
@@ -37,8 +37,10 @@
         [Object[]]
         $InputObject,
 
-        [PSCredential]
-        $Credential
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
     begin {

--- a/JiraPS/Public/Get-JiraGroup.ps1
+++ b/JiraPS/Public/Get-JiraGroup.ps1
@@ -7,8 +7,10 @@ function Get-JiraGroup {
         [String[]]
         $GroupName,
 
-        [PSCredential]
-        $Credential
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
     begin {

--- a/JiraPS/Public/Get-JiraGroupMember.ps1
+++ b/JiraPS/Public/Get-JiraGroupMember.ps1
@@ -35,8 +35,10 @@ function Get-JiraGroupMember {
         [Int]
         $MaxResults = 0,
 
-        [PSCredential]
-        $Credential
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
     begin {

--- a/JiraPS/Public/Get-JiraIssue.ps1
+++ b/JiraPS/Public/Get-JiraIssue.ps1
@@ -3,6 +3,7 @@ function Get-JiraIssue {
     param(
         [Parameter( Position = 0, Mandatory, ParameterSetName = 'ByIssueKey' )]
         [ValidateNotNullOrEmpty()]
+        [Alias('Issue')]
         [String[]]
         $Key,
 
@@ -80,8 +81,10 @@ function Get-JiraIssue {
         [Int]
         $PageSize = 50,
 
-        [PSCredential]
-        $Credential
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
     begin {

--- a/JiraPS/Public/Get-JiraIssueAttachment.ps1
+++ b/JiraPS/Public/Get-JiraIssueAttachment.ps1
@@ -31,8 +31,10 @@ function Get-JiraIssueAttachment {
         [String]
         $FileName,
 
-        [PSCredential]
-        $Credential
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
     begin {

--- a/JiraPS/Public/Get-JiraIssueComment.ps1
+++ b/JiraPS/Public/Get-JiraIssueComment.ps1
@@ -28,8 +28,10 @@ function Get-JiraIssueComment {
         [Object]
         $Issue,
 
-        [PSCredential]
-        $Credential
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
     begin {

--- a/JiraPS/Public/Get-JiraIssueCreateMetadata.ps1
+++ b/JiraPS/Public/Get-JiraIssueCreateMetadata.ps1
@@ -9,8 +9,10 @@ function Get-JiraIssueCreateMetadata {
         [String]
         $IssueType,
 
-        [PSCredential]
-        $Credential
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
     begin {

--- a/JiraPS/Public/Get-JiraIssueEditMetadata.ps1
+++ b/JiraPS/Public/Get-JiraIssueEditMetadata.ps1
@@ -9,8 +9,10 @@ function Get-JiraIssueEditMetadata {
           Once we have custom classes, this should be a JiraPS.Issue
         #>
 
-        [PSCredential]
-        $Credential
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
     begin {

--- a/JiraPS/Public/Get-JiraIssueLink.ps1
+++ b/JiraPS/Public/Get-JiraIssueLink.ps1
@@ -5,7 +5,10 @@ function Get-JiraIssueLink {
         [Int[]]
         $Id,
 
-        [PSCredential] $Credential
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
     begin {

--- a/JiraPS/Public/Get-JiraIssueLinkType.ps1
+++ b/JiraPS/Public/Get-JiraIssueLinkType.ps1
@@ -27,8 +27,10 @@ function Get-JiraIssueLinkType {
         [Object]
         $LinkType,
 
-        [PSCredential]
-        $Credential
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
     begin {

--- a/JiraPS/Public/Get-JiraIssueType.ps1
+++ b/JiraPS/Public/Get-JiraIssueType.ps1
@@ -5,8 +5,10 @@
         [String[]]
         $IssueType,
 
-        [PSCredential]
-        $Credential
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
     begin {

--- a/JiraPS/Public/Get-JiraIssueWatcher.ps1
+++ b/JiraPS/Public/Get-JiraIssueWatcher.ps1
@@ -28,8 +28,10 @@
         [Object]
         $Issue,
 
-        [PSCredential]
-        $Credential
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
     begin {

--- a/JiraPS/Public/Get-JiraPriority.ps1
+++ b/JiraPS/Public/Get-JiraPriority.ps1
@@ -5,8 +5,10 @@ function Get-JiraPriority {
         [Int[]]
         $Id,
 
-        [PSCredential]
-        $Credential
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
     begin {

--- a/JiraPS/Public/Get-JiraProject.ps1
+++ b/JiraPS/Public/Get-JiraProject.ps1
@@ -5,8 +5,10 @@ function Get-JiraProject {
         [String[]]
         $Project,
 
-        [PSCredential]
-        $Credential
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
     begin {

--- a/JiraPS/Public/Get-JiraRemoteLink.ps1
+++ b/JiraPS/Public/Get-JiraRemoteLink.ps1
@@ -31,8 +31,10 @@ function Get-JiraRemoteLink {
         [Int]
         $LinkId,
 
-        [PSCredential]
-        $Credential
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
     begin {

--- a/JiraPS/Public/Get-JiraServerInformation.ps1
+++ b/JiraPS/Public/Get-JiraServerInformation.ps1
@@ -1,8 +1,10 @@
 function Get-JiraServerInformation {
     [CmdletBinding()]
     param(
-        [PSCredential]
-        $Credential
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
     begin {

--- a/JiraPS/Public/Get-JiraUser.ps1
+++ b/JiraPS/Public/Get-JiraUser.ps1
@@ -13,8 +13,10 @@ function Get-JiraUser {
         [Switch]
         $IncludeInactive,
 
-        [PSCredential]
-        $Credential
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
     begin {

--- a/JiraPS/Public/Get-JiraVersion.ps1
+++ b/JiraPS/Public/Get-JiraVersion.ps1
@@ -24,8 +24,10 @@
         [String[]]
         $Name,
 
-        [PSCredential]
-        $Credential
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
     begin {

--- a/JiraPS/Public/Invoke-JiraIssueTransition.ps1
+++ b/JiraPS/Public/Invoke-JiraIssueTransition.ps1
@@ -41,8 +41,10 @@ function Invoke-JiraIssueTransition {
         [String]
         $Comment,
 
-        [PSCredential]
-        $Credential,
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty,
 
         [Switch]
         $Passthru

--- a/JiraPS/Public/Invoke-JiraMethod.ps1
+++ b/JiraPS/Public/Invoke-JiraMethod.ps1
@@ -28,8 +28,10 @@ function Invoke-JiraMethod {
         [Switch]
         $StoreSession,
 
-        [PSCredential]
-        $Credential,
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty,
 
         [ValidateNotNullOrEmpty()]
         [System.Management.Automation.PSCmdlet]
@@ -89,10 +91,10 @@ function Invoke-JiraMethod {
             $splatParameters.Remove("WebSession")
         }
 
-        if ($session = Get-JiraSession -ErrorAction SilentlyContinue) {
-            if (-not ($Credential)) {
+        if ((-not $Credential) -or ($Credential -eq [System.Management.Automation.PSCredential]::Empty)) {
+            $splatParameters.Remove("Credential")
+            if ($session = Get-JiraSession -ErrorAction SilentlyContinue) {
                 $splatParameters["WebSession"] = $session.WebSession
-                $splatParameters.Remove("Credential")
             }
         }
 

--- a/JiraPS/Public/New-JiraGroup.ps1
+++ b/JiraPS/Public/New-JiraGroup.ps1
@@ -6,8 +6,10 @@
         [String[]]
         $GroupName,
 
-        [PSCredential]
-        $Credential
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
     begin {

--- a/JiraPS/Public/New-JiraIssue.ps1
+++ b/JiraPS/Public/New-JiraIssue.ps1
@@ -37,8 +37,10 @@ function New-JiraIssue {
         [PSCustomObject]
         $Fields,
 
-        [PSCredential]
-        $Credential
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
     begin {

--- a/JiraPS/Public/New-JiraSession.ps1
+++ b/JiraPS/Public/New-JiraSession.ps1
@@ -3,7 +3,8 @@ function New-JiraSession {
     [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseShouldProcessForStateChangingFunctions', '')]
     param(
         [Parameter( Mandatory )]
-        [PSCredential]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
         $Credential,
 
         [Hashtable]

--- a/JiraPS/Public/New-JiraUser.ps1
+++ b/JiraPS/Public/New-JiraUser.ps1
@@ -16,8 +16,10 @@ function New-JiraUser {
         [Boolean]
         $Notify = $true,
 
-        [PSCredential]
-        $Credential
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
     begin {

--- a/JiraPS/Public/New-JiraVersion.ps1
+++ b/JiraPS/Public/New-JiraVersion.ps1
@@ -80,8 +80,10 @@
         [DateTime]
         $StartDate,
 
-        [PSCredential]
-        $Credential
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
     begin {

--- a/JiraPS/Public/Remove-JiraGroup.ps1
+++ b/JiraPS/Public/Remove-JiraGroup.ps1
@@ -28,8 +28,10 @@
         [Object[]]
         $Group,
 
-        [PSCredential]
-        $Credential,
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty,
 
         [Switch]
         $Force

--- a/JiraPS/Public/Remove-JiraGroupMember.ps1
+++ b/JiraPS/Public/Remove-JiraGroupMember.ps1
@@ -55,8 +55,10 @@ function Remove-JiraGroupMember {
         [Object[]]
         $User,
 
-        [PSCredential]
-        $Credential,
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty,
 
         [Switch]
         $PassThru,

--- a/JiraPS/Public/Remove-JiraIssueAttachment.ps1
+++ b/JiraPS/Public/Remove-JiraIssueAttachment.ps1
@@ -38,8 +38,10 @@ function Remove-JiraIssueAttachment {
         [String[]]
         $FileName,
 
-        [PSCredential]
-        $Credential,
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty,
 
         [Switch]
         $Force

--- a/JiraPS/Public/Remove-JiraIssueLink.ps1
+++ b/JiraPS/Public/Remove-JiraIssueLink.ps1
@@ -30,8 +30,10 @@ function Remove-JiraIssueLink {
         [Object[]]
         $IssueLink,
 
-        [PSCredential]
-        $Credential
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
     begin {

--- a/JiraPS/Public/Remove-JiraIssueWatcher.ps1
+++ b/JiraPS/Public/Remove-JiraIssueWatcher.ps1
@@ -32,8 +32,10 @@
         [Object]
         $Issue,
 
-        [PSCredential]
-        $Credential
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
     begin {

--- a/JiraPS/Public/Remove-JiraRemoteLink.ps1
+++ b/JiraPS/Public/Remove-JiraRemoteLink.ps1
@@ -32,8 +32,10 @@ function Remove-JiraRemoteLink {
         [Int[]]
         $LinkId,
 
-        [PSCredential]
-        $Credential,
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty,
 
         [Switch]
         $Force

--- a/JiraPS/Public/Remove-JiraUser.ps1
+++ b/JiraPS/Public/Remove-JiraUser.ps1
@@ -28,8 +28,10 @@ function Remove-JiraUser {
         [Object[]]
         $User,
 
-        [PSCredential]
-        $Credential,
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty,
 
         [Switch]
         $Force

--- a/JiraPS/Public/Remove-JiraVersion.ps1
+++ b/JiraPS/Public/Remove-JiraVersion.ps1
@@ -27,8 +27,10 @@
         [Object[]]
         $Version,
 
-        [PSCredential]
-        $Credential,
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty,
 
         [Switch]
         $Force

--- a/JiraPS/Public/Set-JiraIssue.ps1
+++ b/JiraPS/Public/Set-JiraIssue.ps1
@@ -50,8 +50,10 @@ function Set-JiraIssue {
         [String]
         $AddComment,
 
-        [PSCredential]
-        $Credential,
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty,
 
         [Switch]
         $PassThru

--- a/JiraPS/Public/Set-JiraIssueLabel.ps1
+++ b/JiraPS/Public/Set-JiraIssueLabel.ps1
@@ -45,8 +45,10 @@
         [Switch]
         $Clear,
 
-        [PSCredential]
-        $Credential,
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty,
 
         [Switch]
         $PassThru

--- a/JiraPS/Public/Set-JiraUser.ps1
+++ b/JiraPS/Public/Set-JiraUser.ps1
@@ -60,8 +60,10 @@ function Set-JiraUser {
         [Hashtable]
         $Property,
 
-        [PSCredential]
-        $Credential,
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty,
 
         [Switch]
         $PassThru

--- a/JiraPS/Public/Set-JiraVersion.ps1
+++ b/JiraPS/Public/Set-JiraVersion.ps1
@@ -1,25 +1,6 @@
 ﻿function Set-JiraVersion {
-    <#
-    .SYNOPSIS
-        Modifies an existing Version in JIRA
-    .DESCRIPTION
-        This function modifies the Version for an existing Project in JIRA.
-    .EXAMPLE
-        Get-JiraVersion -Project $Project -Name "Old-Name" | Set-JiraVersion -Name 'New-Name'
-        This example assigns the modifies the existing version with a new name 'New-Name'.
-    .EXAMPLE
-        Get-JiraVersion -ID 162401 | Set-JiraVersion -Description 'Descriptive String'
-        This example assigns the modifies the existing version with a new name 'New-Name'.
-     .INPUTS
-        [JiraPS.Version]
-     .OUTPUTS
-        [JiraPS.Version]
-     .NOTES
-       This function requires either the -Credential parameter to be passed or a persistent JIRA session. See New-JiraSession for more details.  If neither are supplied, this function will run with anonymous access to JIRA.
-    #>
     [CmdletBinding( SupportsShouldProcess )]
     param(
-        # Version to be changed
         [Parameter( Mandatory, ValueFromPipeline )]
         [ValidateNotNullOrEmpty()]
         [ValidateScript(
@@ -46,32 +27,24 @@
         [Object[]]
         $Version,
 
-        # New Name of the Version.
         [String]
         $Name,
 
-        # New Description of the Version.
         [String]
         $Description,
 
-        # New value for Archived.
         [Bool]
         $Archived,
 
-        # New value for Released.
         [Bool]
         $Released,
 
-        # New Date of the release.
         [DateTime]
         $ReleaseDate,
 
-        # New Date of the user release.
         [DateTime]
         $StartDate,
 
-        # The new Project where this version should be in.
-        # This can be the ID of the Project, or the Project Object
         [ValidateScript(
             {
                 if (("JiraPS.Project" -notin $_.PSObject.TypeNames) -and (($_ -isnot [String]))) {
@@ -96,10 +69,10 @@
         [Object]
         $Project,
 
-        # Credentials to use to connect to JIRA.
-        # If not specified, this function will use anonymous access.
-        [PSCredential]
-        $Credential
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
     begin {


### PR DESCRIPTION
### Description
Changed the way Credentials are passed to the functions.
These changes are 100% backwards compatible but add new functionality:

```powershell
Get-JiraIssue -Credential "lipkau"
```
`lipkau` is a string. This was not possible before this change.
Now, `-Credential` will call `Get-Credential -UserName $_` when a string is provided.


### Motivation and Context
Improve usability

### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have added Pester Tests that describe what my changes should do.
- [ ] I have updated the documentation accordingly.
