### PR TITLE
Improve error-handler to accommodate for ErrorDetails and non-JSON/HTML responses

### DIFF
--- a/JiraPS/JiraPS.psm1
+++ b/JiraPS/JiraPS.psm1
@@ -10,7 +10,12 @@
 # Load Web assembly when needed
 # PowerShell Core has the assembly preloaded
 if (!("System.Web.HttpUtility" -as [Type])) {
-    Add-Type -Assembly System.Web
+    Add-Type -AssemblyName "System.Web"
+}
+# Load System.Net.Http when needed
+# PowerShell Core has the assembly preloaded
+if (!("System.Net.Http.HttpRequestException" -as [Type])) {
+    Add-Type -AssemblyName "System.Net.Http"
 }
 #endregion Dependencies
 

--- a/JiraPS/Public/Invoke-JiraMethod.ps1
+++ b/JiraPS/Public/Invoke-JiraMethod.ps1
@@ -162,9 +162,8 @@ function Invoke-JiraMethod {
                         $result = ConvertFrom-Json -InputObject $responseBody
 
                     } catch [ArgumentException] { # handle $responseBody being neither JSON nor HTML
-                        $result = @{
+                        $result = [PSCustomObject]@{
                             errorMessages = @(
-                                "Non-JSON/HTML response returned from JIRA API"
                                 $responseBody
                             )
                         }

--- a/JiraPS/Public/Invoke-JiraMethod.ps1
+++ b/JiraPS/Public/Invoke-JiraMethod.ps1
@@ -131,7 +131,13 @@ function Invoke-JiraMethod {
             }
         }
 
-        Test-ServerResponse -InputObject $webResponse -Cmdlet $Cmdlet
+        if ($WebResponse.ErrorDetails) {
+            Test-ServerResponse -InputObject $webResponse.Exception.Response -Cmdlet $Cmdlet
+        } Else {
+            Test-ServerResponse -InputObject $webResponse -Cmdlet $Cmdlet
+        }
+
+
 
         Write-Debug "[$($MyInvocation.MyCommand.Name)] Executed WebRequest. Access `$webResponse to see details"
 

--- a/JiraPS/Public/Invoke-JiraMethod.ps1
+++ b/JiraPS/Public/Invoke-JiraMethod.ps1
@@ -150,7 +150,9 @@ function Invoke-JiraMethod {
                     $readStream = New-Object -TypeName System.IO.StreamReader -ArgumentList ($webResponse.GetResponseStream())
                     $responseBody = $readStream.ReadToEnd()
                     $readStream.Close()
+                }
 
+                If ($responseBody) {
                     # Clear the body in case it is not a JSON (but rather html)
                     if ($responseBody -match "^[\s\t]*\<html\>") { $responseBody = '{"errorMessages": "Invalid server response. HTML returned."}' }
 

--- a/JiraPS/Public/Invoke-JiraMethod.ps1
+++ b/JiraPS/Public/Invoke-JiraMethod.ps1
@@ -158,7 +158,18 @@ function Invoke-JiraMethod {
 
                     Write-Verbose "[$($MyInvocation.MyCommand.Name)] Retrieved body of HTTP response for more information about the error (`$responseBody)"
                     Write-Debug "[$($MyInvocation.MyCommand.Name)] Got the following error as `$responseBody"
-                    $result = ConvertFrom-Json -InputObject $responseBody
+                    try {
+                        $result = ConvertFrom-Json -InputObject $responseBody
+
+                    } catch [ArgumentException] { # handle $responseBody being neither JSON nor HTML
+                        $result = @{
+                            errorMessages = @(
+                                "Non-JSON/HTML response returned from JIRA API"
+                                $responseBody
+                            )
+                        }
+                    }
+
                 }
 
             }

--- a/JiraPS/Public/Invoke-JiraMethod.ps1
+++ b/JiraPS/Public/Invoke-JiraMethod.ps1
@@ -120,8 +120,10 @@ function Invoke-JiraMethod {
             # Invoke-WebRequest is hard-coded to throw an exception if the Web request returns a 4xx or 5xx error.
             # This is the best workaround I can find to retrieve the actual results of the request.
             $webResponse = $_
+            # ErrorDetails behavior is erratic and may not always be available
+            # See https://windowsserver.uservoice.com/forums/301869-powershell/suggestions/17142518--errordetails-is-null-when-invoke-webrequest-or
+            # PSv6+ appears to be unaffected
             if ($webResponse.ErrorDetails) {
-                # In PowerShellCore (v6+), the response body is available as string
                 $responseBody = $webResponse.ErrorDetails.Message
             }
             else {

--- a/JiraPS/Public/Invoke-JiraMethod.ps1
+++ b/JiraPS/Public/Invoke-JiraMethod.ps1
@@ -193,7 +193,7 @@ function Invoke-JiraMethod {
         }
 
         if ($result) {
-            if (Get-Member -Name "Errors" -InputObject $result -ErrorAction SilentlyContinue) {
+            if (Get-Member -Name "Errors","errorMessages" -InputObject $result -ErrorAction SilentlyContinue) {
                 Resolve-JiraError $result -WriteError -Cmdlet $Cmdlet
             }
             else {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

### Description
<!-- Describe your changes in detail -->
This PR modifies `Invoke-JiraMethod` to improve error-parsing under certain conditions. 

More specifically, the following changes have been made:
* Appropriately parse errors in the event the Jira API returns an error in a manner that populates the `ErrorDetails` field on the associated exception. (see #276)
* Handle API responses that are neither valid JSON nor HTML.
* Catch errors that only include the `errorMessages` property versus the `errors` property.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here as follows: -->
<!-- closes #1, closes #2, ... -->
If Jira (or the web server/proxy used to access it) is using Chunked transfer encoding, for instance, this field may not be populated (see [this PowerShell UserVoice post](https://windowsserver.uservoice.com/forums/301869-powershell/suggestions/17142518--errordetails-is-null-when-invoke-webrequest-or)).

This PR resolves #276.

### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] I have added Pester Tests that describe what my changes should do.
- [X] I have updated the documentation accordingly.
