### PR TITLE
Added `-Id` parameter to Remove-JiraFilter

### DIFF
--- a/JiraPS/Public/Remove-JiraFilter.ps1
+++ b/JiraPS/Public/Remove-JiraFilter.ps1
@@ -1,10 +1,14 @@
 function Remove-JiraFilter {
-    [CmdletBinding( ConfirmImpact = "Medium", SupportsShouldProcess )]
+    [CmdletBinding( ConfirmImpact = "Medium", SupportsShouldProcess, DefaultParameterSetName = 'ByInputObject' )]
     param(
-        [Parameter( Mandatory, ValueFromPipeline )]
+        [Parameter( Position = 0, Mandatory, ValueFromPipeline, ParameterSetName = 'ByInputObject' )]
         [ValidateNotNullOrEmpty()]
         [PSTypeName('JiraPS.Filter')]
         $InputObject,
+
+        [Parameter( Position = 0, Mandatory, ValueFromPipeline, ParameterSetName = 'ById')]
+        [UInt32[]]
+        $Id,
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -19,6 +23,12 @@ function Remove-JiraFilter {
     process {
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] ParameterSetName: $($PsCmdlet.ParameterSetName)"
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] PSBoundParameters: $($PSBoundParameters | Out-String)"
+
+        if ($PSCmdlet.ParameterSetName -eq 'ById') {
+            $InputObject = foreach ($_id in $Id) {
+                Get-JiraFilter -Id $_id
+            }
+        }
 
         foreach ($filter in $InputObject) {
             $parameter = @{

--- a/Tests/Remove-JiraFilter.Tests.ps1
+++ b/Tests/Remove-JiraFilter.Tests.ps1
@@ -96,9 +96,16 @@ Describe 'Remove-JiraFilter' {
 
         Context "Behavior testing" {
             Get-JiraFilter -Id 12844
-            It "Invokes the Jira API to delete a filter" {
+            It "deletes a filter based on one or more InputObjects" {
                 { Get-JiraFilter -Id 12844 | Remove-JiraFilter } | Should Not Throw
 
+                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -Scope It -ParameterFilter {$Method -eq 'Delete' -and $URI -like '*/rest/api/*/filter/12844'}
+            }
+
+            It "deletes a filter based on one ore more filter ids" {
+                { Remove-JiraFilter -Id 12844 } | Should Not Throw
+
+                Assert-MockCalled -CommandName Get-JiraFilter -ModuleName JiraPS -Exactly -Times 1 -Scope It
                 Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -Scope It -ParameterFilter {$Method -eq 'Delete' -and $URI -like '*/rest/api/*/filter/12844'}
             }
         }
@@ -128,8 +135,30 @@ Describe 'Remove-JiraFilter' {
                 Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 2 -Scope It
             }
 
+            It "Accepts an ID of a filter" {
+                { Remove-JiraFilter -Id 12345 } | Should Not Throw
+
+                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -Scope It
+            }
+
+            It "Accepts multiple IDs of filters" {
+                { Remove-JiraFilter -Id 12345, 12345 } | Should Not Throw
+
+                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 2 -Scope It
+            }
+
+            It "Accepts multiple IDs of filters over the pipeline" {
+                { 12345, 12345 | Remove-JiraFilter } | Should Not Throw
+
+                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 2 -Scope It
+            }
+
+            It "fails if a negative number is passed as ID" {
+                { Remove-JiraFilter -Id -1 } | Should Throw
+            }
+
             It "fails if something other than [JiraPS.Filter] is provided" {
-                { "12345" | Remove-JiraFilter -ErrorAction Stop } | Should Throw
+                { Get-Date | Remove-JiraFilter -ErrorAction Stop } | Should Throw
                 { Remove-JiraFilter "12345" -ErrorAction Stop} | Should Throw
             }
         }

--- a/docs/en-US/commands/Remove-JiraFilter.md
+++ b/docs/en-US/commands/Remove-JiraFilter.md
@@ -15,8 +15,16 @@ Removes an existing filter.
 
 ## SYNTAX
 
+### byInputObject (Default)
+
 ```powershell
-Remove-JiraFilter [-InputObject] <Object> [-WhatIf] [-Confirm] [<CommonParameters>]
+Remove-JiraFilter [-InputObject] <JiraPS.Filter> [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### byId (Default)
+
+```powershell
+Remove-JiraFilter [-Id] <UInt32[]> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -59,6 +67,18 @@ Get-JiraFilter -Favorite | Remove-JiraFilter -Confirm
 
 Asks for each favorite filter confirmation to delete it.
 
+### Example 5
+
+```powershell
+$listOfFilters = 1,2,3,4
+$listOfFilters | Remove-JiraFilter
+```
+
+Remove filters with id "1", "2", "3" and "4".
+
+This input allows for the ID of the filters to be stored in an array and passed to
+the command. (eg: `Get-Content` from a file with the ids)
+
 ## PARAMETERS
 
 ### -InputObject
@@ -69,7 +89,25 @@ Object can be retrieved with `Get-JiraFilter`
 
 ```yaml
 Type: JiraPS.Filter
-Parameter Sets: (All)
+Parameter Sets: ByInputObject
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Id
+
+Id of the filter to be deleted.
+
+Accepts integers over the pipeline.
+
+```yaml
+Type: UInt32[]
+Parameter Sets: ById
 Aliases:
 
 Required: True


### PR DESCRIPTION
### Description
by adding the `-Id` parameter, Remove-JiraFilter is able to take an Integer over the pipeline.
This enables the used to get the data from a file (or similar)

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here as follows: -->
<!-- closes #1, closes #2, ... -->

### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have added Pester Tests that describe what my changes should do.
- [x] I have updated the documentation accordingly.
