### PR TITLE
Fixed the way a string of an user is resolved

### DIFF
--- a/JiraPS/Public/Remove-JiraGroupMember.ps1
+++ b/JiraPS/Public/Remove-JiraGroupMember.ps1
@@ -95,7 +95,7 @@ function Remove-JiraGroupMember {
                 Write-Verbose "[$($MyInvocation.MyCommand.Name)] Processing [$_user]"
                 Write-Debug "[$($MyInvocation.MyCommand.Name)] Processing `$_user [$_user]"
 
-                $userObj = Get-JiraUser -InputObject $_user -Credential $Credential -ErrorAction Stop
+                $userObj = Get-JiraUser -UserName $_user -Credential $Credential -ErrorAction Stop
 
                 # if ($groupMembers -contains $userObj.Name) {
                 # TODO: test what jira says

--- a/Tests/Remove-JiraGroupMember.Tests.ps1
+++ b/Tests/Remove-JiraGroupMember.Tests.ps1
@@ -1,86 +1,103 @@
 Describe "Remove-JiraGroupMember" {
-
-    Import-Module "$PSScriptRoot/../JiraPS" -Force -ErrorAction Stop
+    BeforeAll {
+        Remove-Module JiraPS -ErrorAction SilentlyContinue
+        Import-Module "$PSScriptRoot/../JiraPS" -Force -ErrorAction Stop
+    }
 
     InModuleScope JiraPS {
 
         . "$PSScriptRoot/Shared.ps1"
 
+        #region Definitions
         $jiraServer = 'http://jiraserver.example.com'
 
         $testGroupName = 'testGroup'
         $testUsername1 = 'testUsername1'
         $testUsername2 = 'testUsername2'
+        #endregion Definitions
 
+        #region Mocks
         Mock Get-JiraConfigServer -ModuleName JiraPS {
             Write-Output $jiraServer
         }
 
         Mock Get-JiraGroup -ModuleName JiraPS {
-            $object = [PSCustomObject] @{
-                'Name' = $testGroupName
-                'Size' = 2
+            [PSCustomObject]@{
+                PSTypeName = "JiraPS.Group"
+                Name       = $testGroupName
+                Size       = 2
             }
-            $object.PSObject.TypeNames.Insert(0, 'JiraPS.Group')
-            return $object
         }
 
         Mock Get-JiraUser -ModuleName JiraPS {
-            $object = [PSCustomObject] @{
-                'Name' = "$InputObject"
+            if ($InputObject) {
+                $obj = [PSCustomObject]@{
+                    PSTypeName = "JiraPS.User"
+                    Name       = "$InputObject"
+                }
             }
-            $object.PSObject.TypeNames.Insert(0, 'JiraPS.User')
-            return $object
+            else {
+                $obj = [PSCustomObject]@{
+                    PSTypeName = "JiraPS.User"
+                    Name       = "$UserName"
+                }
+            }
+            $obj | Add-Member -MemberType ScriptMethod -Name "ToString" -Force -Value {
+                Write-Output "$($this.Name)"
+            }
+            $obj
         }
 
         Mock Get-JiraGroupMember -ModuleName JiraPS {
-            $object = [PSCustomObject] @{
-                'Name' = $testUsername1
+            [PSCustomObject]@{
+                PSTypeName = "JiraPS.Group"
+                Name       = $testUsername1
             }
-            $object.PSObject.TypeNames.Insert(0, 'JiraPS.Group')
-            return $object
         }
 
         Mock Invoke-JiraMethod -ModuleName JiraPS {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
         }
+        #endregion Mocks
 
         #############
         # Tests
         #############
         Context "Sanity checking" {
+            $command = Get-Command -Name Remove-JiraGroupMember
 
-            It "Accepts a group name as a String to the -Group parameter" {
-                { Remove-JiraGroupMember -Group $testGroupName -User $testUsername1 -Force } | Should Not Throw
-                Assert-MockCalled -CommandName Invoke-JiraMethod -ParameterFilter {$URI -match $testGroupName} -Exactly -Times 1 -Scope It
-            }
-
-            It "Accepts a JiraPS.Group object to the -Group parameter" {
-                $group = Get-JiraGroup -GroupName $testGroupName
-                { Remove-JiraGroupMember -Group $testGroupName -User $testUsername1 -Force } | Should Not Throw
-                Assert-MockCalled -CommandName Invoke-JiraMethod -ParameterFilter {$URI -match $testGroupName} -Exactly -Times 1 -Scope It
-            }
-
-            It "Accepts pipeline input from Get-JiraGroup" {
-                { Get-JiraGroup -GroupName $testGroupName | Remove-JiraGroupMember -User $testUsername1 -Force} | Should Not Throw
-                Assert-MockCalled -CommandName Invoke-JiraMethod -ParameterFilter {$URI -match $testGroupName} -Exactly -Times 1 -Scope It
-            }
+            defParam $command 'Group'
+            defParam $command 'User'
+            defParam $command 'Credential'
+            defParam $command 'PassThru'
+            defParam $command 'Force'
         }
 
         Context "Behavior testing" {
-
             It "Tests to see if a provided user is currently a member of the provided JIRA group before attempting to remove them" {
                 { Remove-JiraGroupMember -Group $testGroupName -User $testUsername1 -Force } | Should Not Throw
-                Assert-MockCalled -CommandName Get-JiraGroup -Exactly -Times 1 -Scope It
+
+                Assert-MockCalled -CommandName Get-JiraGroup -ModuleName "JiraPS" -Exactly -Times 1 -Scope It
             }
 
             It "Removes a user from a JIRA group if the user is a member" {
                 { Remove-JiraGroupMember -Group $testGroupName -User $testUsername1 -Force } | Should Not Throw
-                Assert-MockCalled -CommandName Invoke-JiraMethod -ParameterFilter {$Method -eq 'Delete' -and $URI -like "$jiraServer/rest/api/*/group/user?groupname=$testGroupName&username=$testUsername1"} -Exactly -Times 1 -Scope It
+
+                $assertMockCalledSplat = @{
+                    CommandName     = 'Invoke-JiraMethod'
+                    ModuleName      = "JiraPS"
+                    ParameterFilter = {
+                        $Method -eq 'Delete' -and
+                        $URI -like "$jiraServer/rest/api/*/group/user?groupname=$testGroupName&username=$testUsername1"
+                    }
+                    Exactly         = $true
+                    Times           = 1
+                    Scope           = 'It'
+                }
+                Assert-MockCalled @assertMockCalledSplat
             }
 
             It "Removes multiple users to a JIRA group if they are passed to the -User parameter" {
-
                 # Override our previous mock so we have two group members
                 Mock Get-JiraGroupMember -ModuleName JiraPS {
                     @(
@@ -95,12 +112,104 @@ Describe "Remove-JiraGroupMember" {
 
                 # Should use the REST method twice, since at present, you can only delete one group member per API call
                 { Remove-JiraGroupMember -Group $testGroupName -User $testUsername1, $testUsername2 -Force } | Should Not Throw
-                Assert-MockCalled -CommandName Invoke-JiraMethod -ParameterFilter {$Method -eq 'Delete' -and $URI -like "$jiraServer/rest/api/*/group/user?groupname=$testGroupName&username=*"} -Exactly -Times 2 -Scope It
+
+                $assertMockCalledSplat = @{
+                    CommandName     = 'Invoke-JiraMethod'
+                    ModuleName      = "JiraPS"
+                    ParameterFilter = {
+                        $Method -eq 'Delete' -and
+                        $URI -like "$jiraServer/rest/api/*/group/user?groupname=$testGroupName&username=*"
+                    }
+                    Exactly         = $true
+                    Times           = 2
+                    Scope           = 'It'
+                }
+                Assert-MockCalled @assertMockCalledSplat
             }
         }
 
-        # Context "Error checking" {
+        Context "Input testing" {
+            It "Accepts a group name as a String to the -Group parameter" {
+                { Remove-JiraGroupMember -Group $testGroupName -User $testUsername1 -Force } | Should Not Throw
 
-        # }
+                $assertMockCalledSplat = @{
+                    CommandName     = 'Invoke-JiraMethod'
+                    ModuleName      = "JiraPS"
+                    ParameterFilter = {
+                        $Method -eq "Delete" -and
+                        $URI -like "*/rest/api/*/group/user*" -and
+                        $URI -match "groupname=$testGroupName" -and
+                        $URI -match "username=$testUsername1"
+                    }
+                    Exactly         = $true
+                    Times           = 1
+                    Scope           = 'It'
+                }
+                Assert-MockCalled @assertMockCalledSplat
+            }
+
+            It "Accepts a JiraPS.Group object to the -Group parameter" {
+                {
+                    $group = Get-JiraGroup -GroupName $testGroupName
+                    Remove-JiraGroupMember -Group $group -User $testUsername1 -Force
+                } | Should Not Throw
+
+                $assertMockCalledSplat = @{
+                    CommandName     = 'Invoke-JiraMethod'
+                    ModuleName      = "JiraPS"
+                    ParameterFilter = {
+                        $Method -eq "Delete" -and
+                        $URI -like "*/rest/api/*/group/user*" -and
+                        $URI -match "groupname=$testGroupName" -and
+                        $URI -match "username=$testUsername1"
+                    }
+                    Exactly         = $true
+                    Times           = 1
+                    Scope           = 'It'
+                }
+                Assert-MockCalled @assertMockCalledSplat
+            }
+
+            It "Accepts pipeline input from Get-JiraGroup" {
+                { Get-JiraGroup -GroupName $testGroupName | Remove-JiraGroupMember -User $testUsername1 -Force} | Should Not Throw
+
+                $assertMockCalledSplat = @{
+                    CommandName     = 'Invoke-JiraMethod'
+                    ModuleName      = "JiraPS"
+                    ParameterFilter = {
+                        $Method -eq "Delete" -and
+                        $URI -like "*/rest/api/*/group/user*" -and
+                        $URI -match "groupname=$testGroupName" -and
+                        $URI -match "username=$testUsername1"
+                    }
+                    Exactly         = $true
+                    Times           = 1
+                    Scope           = 'It'
+                }
+                Assert-MockCalled @assertMockCalledSplat
+            }
+
+            It "Accepts a JiraPS.User as input for -User parameter" {
+                {
+                    $user = Get-JiraUser -UserName $testUsername1
+                    Remove-JiraGroupMember -Group $testGroupName -User $user -Force
+                } | Should Not Throw
+
+                $assertMockCalledSplat = @{
+                    CommandName     = 'Invoke-JiraMethod'
+                    ModuleName      = "JiraPS"
+                    ParameterFilter = {
+                        $Method -eq "Delete" -and
+                        $URI -like "*/rest/api/*/group/user*" -and
+                        $URI -match "groupname=$testGroupName" -and
+                        $URI -match "username=$testUsername1"
+                    }
+                    Exactly         = $true
+                    Times           = 1
+                    Scope           = 'It'
+                }
+                Assert-MockCalled @assertMockCalledSplat
+            }
+        }
     }
 }


### PR DESCRIPTION
### Description
When `Remove-JiraGroupMember` uses a `[String]` for `-User`, `Get-JiraUser` does not resolve properly resolve the input.
This is fixed by using `-UserName` instead of `-InputObject` on `Get-JiraUser`

### Motivation and Context
closes #299

### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have added Pester Tests that describe what my changes should do.
- [ ] I have updated the documentation accordingly.
