### PR TITLE
Get-JiraUser -Filter parameter added

### DIFF
--- a/Tests/Get-JiraUser.Tests.ps1
+++ b/Tests/Get-JiraUser.Tests.ps1
@@ -133,7 +133,7 @@ Describe "Get-JiraUser" {
         }
 
         It "Allow it search for multiple users" {
-            Get-JiraUser -UserName "%"
+            Get-JiraUser -Filter "%"
 
             Assert-MockCalled -CommandName Invoke-JiraMethod -Exactly 1 -Scope It -ParameterFilter {
                 $URI -like "$jiraServer/rest/api/*/user/search?*username=%25*"
@@ -141,7 +141,7 @@ Describe "Get-JiraUser" {
         }
 
         It "Allows to change the max number of users to be returned" {
-            Get-JiraUser -UserName "%" -MaxResults 100
+            Get-JiraUser -Filter "%" -MaxResults 100
 
             Assert-MockCalled -CommandName Invoke-JiraMethod -Exactly 1 -Scope It -ParameterFilter {
                 $URI -like "$jiraServer/rest/api/*/user/search?*maxResults=100*"
@@ -149,7 +149,7 @@ Describe "Get-JiraUser" {
         }
 
         It "Can skip a certain amount of results" {
-            Get-JiraUser -UserName "%" -Skip 10
+            Get-JiraUser -Filter "%" -Skip 10
 
             Assert-MockCalled -CommandName Invoke-JiraMethod -Exactly 1 -Scope It -ParameterFilter {
                 $URI -like "$jiraServer/rest/api/*/user/search?*startAt=10*"

--- a/docs/en-US/commands/Get-JiraUser.md
+++ b/docs/en-US/commands/Get-JiraUser.md
@@ -24,7 +24,13 @@ Get-JiraUser [-Credential <PSCredential>] [<CommonParameters>]
 ### ByUserName
 
 ```powershell
-Get-JiraUser [-UserName] <String[]> [-IncludeInactive] [[-MaxResults] <UInt32>] [[-Skip] <UInt64>] [-Credential <PSCredential>] [<CommonParameters>]
+Get-JiraUser [-UserName] <String[]> [-Credential <PSCredential>] [<CommonParameters>]
+```
+
+### ByFilter
+
+```powershell
+Get-JiraUser [-Filter] <String[]> [-IncludeInactive] [[-MaxResults] <UInt32>] [[-Skip] <UInt64>] [-Credential <PSCredential>] [<CommonParameters>]
 ```
 
 ### ByInputObject
@@ -50,12 +56,20 @@ Returns information about the user user1
 ### EXAMPLE 2
 
 ```powershell
+Get-JiraUser -Filter 'John'
+```
+
+Returns information about all user(s) whose username, display name or email address matches 'John'. The string is matched to the starting letters of any word in the searched fields. For example, 'and' matches to the username 'Andrei' but not 'Alexander'
+
+### EXAMPLE 3
+
+```powershell
 Get-ADUser -filter "Name -like 'John*Smith'" | Select-Object -ExpandProperty samAccountName | Get-JiraUser -Credential $cred
 ```
 
 This example searches Active Directory for "John*Smith", then obtains their JIRA user accounts.
 
-### EXAMPLE 3
+### EXAMPLE 4
 
 ```powershell
 Get-JiraUser -Credential $cred
@@ -67,12 +81,28 @@ This example returns the JIRA user that is executing the command.
 
 ### -UserName
 
-Name of the user to search for.
+Name of the user to return information for.
 
 ```yaml
 Type: String[]
 Parameter Sets: ByUserName
 Aliases: User, Name
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Filter
+
+Name of the user to search for.
+
+```yaml
+Type: String[]
+Parameter Sets: ByFilter
+Aliases:
 
 Required: True
 Position: 1
@@ -103,7 +133,7 @@ Include inactive users in the search
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: (All)
+Parameter Sets: ByFilter
 Aliases:
 
 Required: False
@@ -121,7 +151,7 @@ Maximum number of user to be returned.
 
 ```yaml
 Type: UInt32
-Parameter Sets: ByUserName
+Parameter Sets: ByFilter
 Aliases:
 
 Required: False
@@ -139,7 +169,7 @@ Defaults to 0.
 
 ```yaml
 Type: UInt64
-Parameter Sets: ByUserName
+Parameter Sets: ByFilter
 Aliases:
 
 Required: False


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

### Description
Get-JiraUser tries to be too helpful, sometimes returning multiple users when a unique Jira username was specified. This is as a result of always searching for matching users when the -UserName parameter is specified.
This PR modifies Get-JiraUser in line with the suggestion in #49. The existing -UserName parameter meaning is changed. It no longer searches and now returns only a single user with an exactly matching username.
A new parameter, -Filter, has been added which provides the search capability previously provided by -UserName.
For a single user, one server round trip is now saved when using -UserName, as groups are expanded in the initial call.

### Outstanding Questions
I was not sure of the best behaviour for pipeline input. Suggestions and comments appreciated.

### Motivation and Context
closes #49

### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have added Pester Tests that describe what my changes should do.
- [x] I have updated the documentation accordingly.
