### PR TITLE
Fix issue 229 - New-JiraIssue should take params from pipeline.

### DIFF
--- a/JiraPS/Public/New-JiraIssue.ps1
+++ b/JiraPS/Public/New-JiraIssue.ps1
@@ -2,49 +2,59 @@ function New-JiraIssue {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( SupportsShouldProcess )]
     param(
-        [Parameter( Mandatory )]
+        [Parameter( Mandatory, ValueFromPipelineByPropertyName )]
         [String]
         $Project,
 
-        [Parameter( Mandatory )]
+        [Parameter( Mandatory, ValueFromPipelineByPropertyName )]
         [String]
         $IssueType,
 
-        [Parameter( Mandatory )]
+        [Parameter( Mandatory, ValueFromPipelineByPropertyName )]
         [String]
         $Summary,
 
+        [Parameter( ValueFromPipelineByPropertyName )]
         [Int]
         $Priority,
 
+        [Parameter( ValueFromPipelineByPropertyName )]
         [String]
         $Description,
 
+        [Parameter( ValueFromPipelineByPropertyName )]
         [AllowNull()]
         [AllowEmptyString()]
         [String]
         $Reporter,
 
+        [Parameter( ValueFromPipelineByPropertyName )]
         [String[]]
         $Labels,
 
+        [Parameter( ValueFromPipelineByPropertyName )]
         [String]
         $Parent,
 
+        [Parameter( ValueFromPipelineByPropertyName )]
         [Alias('FixVersions')]
         [String[]]
         $FixVersion,
 
+        [Parameter( ValueFromPipelineByPropertyName )]
         [PSCustomObject]
         $Fields,
 
-        [Parameter()]
+        [Parameter( ValueFromPipelineByPropertyName )]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
         $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
     begin {
+    }
+
+    process {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
         $server = Get-JiraConfigServer -ErrorAction Stop -Debug:$false
@@ -52,9 +62,7 @@ function New-JiraIssue {
         $createmeta = Get-JiraIssueCreateMetadata -Project $Project -IssueType $IssueType -Credential $Credential -ErrorAction Stop -Debug:$false
 
         $resourceURi = "$server/rest/api/latest/issue"
-    }
 
-    process {
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] ParameterSetName: $($PsCmdlet.ParameterSetName)"
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] PSBoundParameters: $($PSBoundParameters | Out-String)"
 
@@ -161,9 +169,9 @@ function New-JiraIssue {
             # This will fetch the created issue to return it with all it'a properties
             Write-Output (Get-JiraIssue -Key $result.Key -Credential $Credential)
         }
+        Write-Verbose "[$($MyInvocation.MyCommand.Name)] Complete"
     }
 
     end {
-        Write-Verbose "[$($MyInvocation.MyCommand.Name)] Complete"
     }
 }

--- a/JiraPS/Public/New-JiraIssue.ps1
+++ b/JiraPS/Public/New-JiraIssue.ps1
@@ -45,18 +45,17 @@ function New-JiraIssue {
         [PSCustomObject]
         $Fields,
 
-        [Parameter( ValueFromPipelineByPropertyName )]
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
         $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
     begin {
+        Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
     }
 
     process {
-        Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
-
         $server = Get-JiraConfigServer -ErrorAction Stop -Debug:$false
 
         $createmeta = Get-JiraIssueCreateMetadata -Project $Project -IssueType $IssueType -Credential $Credential -ErrorAction Stop -Debug:$false

--- a/Tests/New-JiraIssue.Tests.ps1
+++ b/Tests/New-JiraIssue.Tests.ps1
@@ -80,6 +80,8 @@
             'Description' = 'Test description';
         }
 
+        $pipelineParams = New-Object -TypeName PSCustomObject -Property $newParams
+
         Context "Sanity checking" {
             $command = Get-Command -Name New-JiraIssue
 
@@ -97,6 +99,13 @@
         Context "Behavior testing" {
             It "Creates an issue in JIRA" {
                 { New-JiraIssue @newParams } | Should Not Throw
+                # The String in the ParameterFilter is made from the keywords
+                # we should expect to see in the JSON that should be sent,
+                # including the summary provided in the test call above.
+                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Post' -and $URI -like "$jiraServer/rest/api/*/issue" }
+            }
+            It "Creates an issue in JIRA from pipeline" {
+                { $pipelineParams | New-JiraIssue } | Should Not Throw
                 # The String in the ParameterFilter is made from the keywords
                 # we should expect to see in the JSON that should be sent,
                 # including the summary provided in the test call above.

--- a/docs/en-US/commands/New-JiraIssue.md
+++ b/docs/en-US/commands/New-JiraIssue.md
@@ -82,6 +82,16 @@ This illustrates how to use splatting for the example above.
 
 Read more about splatting: about_Splatting
 
+### EXAMPLE 4
+
+```powershell
+"project,summary,assignee,IssueType,Priority,Description" > "./data.csv"
+"CS,Some Title 1,admin,Minor,1,Some Description 1" >> "./data.csv"
+"CS,Some Title 2,admin,Minor,1,Some Description 2" >> "./data.csv"
+import-csv "./data.csv" | New-JiraIssue
+```
+This example illuetrates how to prepare multiple new stories and pipe them to be created all at once.
+
 ## PARAMETERS
 
 ### -Project


### PR DESCRIPTION
### Description
The here was due to how PowerShell handles input via the pipeline, see an in depth explanation with examples here: https://learn-powershell.net/2013/05/07/tips-on-implementing-pipeline-support/.
The function will be unable to use $Profile in the begin block, so i moved that code into the Process block. This is necessary so that multiple new issues can be passed in and processed one after the other.

### Motivation and Context
This resolves https://github.com/AtlassianPS/JiraPS/issues/229 and allows a user to fill an excel sheet or other object with new issues and pipe them into new issue.
closes #229 

### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have added Pester Tests that describe what my changes should do.
- [x] I have updated the documentation accordingly.
