### PR TITLE
Fixed DateTime format

### DIFF
--- a/JiraPS/Public/Add-JiraIssueWorklog.ps1
+++ b/JiraPS/Public/Add-JiraIssueWorklog.ps1
@@ -73,6 +73,11 @@ function Add-JiraIssueWorklog {
             Write-Error @errorMessage
         }
 
+        # Harmonize DateStarted:
+        # `Get-Date -Date "01.01.2000"` does not return the local timezone
+        # which is required by the API
+        $DateStarted = [DateTime]::new($DateStarted.Ticks, 'Local')
+
         $requestBody = @{
             'comment'          = $Comment
             # We need to fix the date with a RegEx replace because the API does not like:


### PR DESCRIPTION
### Description

Fixed the string representation of DateTime for DateStarted.
The API requires the timezone, which is not always available in `[DateTime]`.
Eg: `Get-Date -Date "01.01.2000"`

### Motivation and Context

closes #324 

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have added Pester Tests that describe what my changes should do.
- [ ] I have updated the documentation accordingly.
