### PR TITLE
fixes 320 - assignment when similar users exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [NEXT VERSION] - YYYY-MM-DD
+
+### Added
+
+- Parameter for retrieving information about a specific user with `Get-JiraUser` (#328, [@michalporeba])
+  - this implementations will be changed with the next major update in favor of #306
+
 ## [2.9] - 2018-12-12
 
 ### Added
@@ -20,7 +27,6 @@
 - Changed CI/CD pipeline from AppVeyor to Azure DevOps (#317, [@lipkau])
 - Fixed missing properties on `Get-JiraUser` (#321, [@lipkau])
 - Fixed `-DateStarted` on `Add-JiraIssueWorklog` (#324, [@lipkau])
-
 
 ## [2.8] - 2018-06-28
 
@@ -311,6 +317,7 @@ which is in turn inspired by the [Vagrant](https://github.com/mitchellh/vagrant/
   [@LiamLeane]: https://github.com/LiamLeane
   [@lipkau]: https://github.com/lipkau
   [@lukhase]: https://github.com/lukhase
+  [@michalporeba]: https://github.com/michalporeba
   [@padgers]: https://github.com/padgers
   [@ThePSAdmin]: https://github.com/ThePSAdmin
   [@tuxgoose]: https://github.com/tuxgoose

--- a/JiraPS/Public/Get-JiraUser.ps1
+++ b/JiraPS/Public/Get-JiraUser.ps1
@@ -11,6 +11,10 @@ function Get-JiraUser {
         [Parameter( Position = 0, Mandatory, ParameterSetName = 'ByInputObject' )]
         [Object[]] $InputObject,
 
+        [Parameter( ParameterSetName = 'ByInputObject' )]
+        [Parameter( ParameterSetName = 'ByUserName' )]
+        [Switch]$Exact,
+
         [Switch]
         $IncludeInactive,
 
@@ -27,11 +31,7 @@ function Get-JiraUser {
         [Parameter()]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty,
-
-        [Parameter( ParameterSetName = 'ByInputObject' )]
-        [Parameter( ParameterSetName = 'ByUserName' )]
-        [Switch]$Exact
+        $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
     begin {

--- a/JiraPS/Public/Get-JiraUser.ps1
+++ b/JiraPS/Public/Get-JiraUser.ps1
@@ -27,7 +27,9 @@ function Get-JiraUser {
         [Parameter()]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        $Credential = [System.Management.Automation.PSCredential]::Empty,
+
+        [Switch]$Exact
     )
 
     begin {
@@ -37,6 +39,7 @@ function Get-JiraUser {
 
         $selfResourceUri = "$server/rest/api/latest/myself"
         $searchResourceUri = "$server/rest/api/latest/user/search?username={0}"
+        $exactResourceUri = "$server/rest/api/latest/user?username={0}"
 
         if ($IncludeInactive) {
             $searchResourceUri += "&includeInactive=true"
@@ -80,7 +83,7 @@ function Get-JiraUser {
                 $PsCmdlet.ParameterSetName = "ByUserName"
             }
             "ByUserName" {
-                $resourceURi = $searchResourceUri
+                $resourceURi = if ($Exact) { $exactResourceUri } else { $searchResourceUri }
 
                 foreach ($user in $UserName) {
                     Write-Verbose "[$($MyInvocation.MyCommand.Name)] Processing [$user]"

--- a/JiraPS/Public/Get-JiraUser.ps1
+++ b/JiraPS/Public/Get-JiraUser.ps1
@@ -29,7 +29,8 @@ function Get-JiraUser {
         [System.Management.Automation.Credential()]
         $Credential = [System.Management.Automation.PSCredential]::Empty,
 
-        [Parameter()]
+        [Parameter( ParameterSetName = 'ByInputObject' )]
+        [Parameter( ParameterSetName = 'ByUserName' )]
         [Switch]$Exact
     )
 

--- a/JiraPS/Public/Get-JiraUser.ps1
+++ b/JiraPS/Public/Get-JiraUser.ps1
@@ -29,6 +29,7 @@ function Get-JiraUser {
         [System.Management.Automation.Credential()]
         $Credential = [System.Management.Automation.PSCredential]::Empty,
 
+        [Parameter()]
         [Switch]$Exact
     )
 

--- a/JiraPS/Public/Set-JiraIssue.ps1
+++ b/JiraPS/Public/Set-JiraIssue.ps1
@@ -96,7 +96,7 @@ function Set-JiraIssue {
                 $validAssignee = $true
             }
             else {
-                if ($assigneeObj = Get-JiraUser -UserName $Assignee -Credential $Credential) {
+                if ($assigneeObj = Get-JiraUser -UserName $Assignee -Credential $Credential -Exact) {
                     Write-Debug "[$($MyInvocation.MyCommand.Name)] User found (name=[$($assigneeObj.Name)],RestUrl=[$($assigneeObj.RestUrl)])"
                     $assigneeString = $assigneeObj.Name
                     $validAssignee = $true

--- a/Tests/Functions/Get-JiraUser.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraUser.Unit.Tests.ps1
@@ -144,7 +144,7 @@ Describe "Get-JiraUser" -Tag 'Unit' {
 
             $getResult | Should Not BeNullOrEmpty
 
-            Assert-MockCalled -CommandName Invoke-JiraMethod -Exactly 1 -Scope It -ParameterFilter {$URI -like "$jiraServer/rest/api/*/user/search?*username=$testUsername*"} {
+            Assert-MockCalled -CommandName Invoke-JiraMethod -Exactly 1 -Scope It -ParameterFilter {$URI -like "$jiraServer/rest/api/*/user/search?*username=$testUsername*"}
             Assert-MockCalled -CommandName Invoke-JiraMethod -Exactly 1 -Scope It -ParameterFilter {$URI -like "$jiraServer/rest/api/*/user?username=$testUsername&expand=groups"}
         }
 

--- a/Tests/Functions/Get-JiraUser.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraUser.Unit.Tests.ps1
@@ -149,7 +149,7 @@ Describe "Get-JiraUser" -Tag 'Unit' {
         }
 
         It "Gets information about a provided Jira exact user" {
-            $getResult = Get-JiraUser -UserName $testUsername
+            $getResult = Get-JiraUser -UserName $testUsername -Exact
 
             $getResult | Should Not BeNullOrEmpty
 

--- a/Tests/Functions/Get-JiraUser.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraUser.Unit.Tests.ps1
@@ -108,6 +108,12 @@ Describe "Get-JiraUser" -Tag 'Unit' {
             ConvertFrom-Json -InputObject $restResult
         }
 
+        # Get exact user
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/*/user?username=$testUsername"} {
+            ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
+            ConvertFrom-Json -InputObject $restResult
+        }
+
         # Viewing a specific user. The main difference here is that this includes groups, and the first does not.
         Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/*/user?username=$testUsername&expand=groups"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
@@ -138,6 +144,16 @@ Describe "Get-JiraUser" -Tag 'Unit' {
 
             $getResult | Should Not BeNullOrEmpty
 
+            Assert-MockCalled -CommandName Invoke-JiraMethod -Exactly 1 -Scope It -ParameterFilter {$URI -like "$jiraServer/rest/api/*/user/search?*username=$testUsername*"} {
+            Assert-MockCalled -CommandName Invoke-JiraMethod -Exactly 1 -Scope It -ParameterFilter {$URI -like "$jiraServer/rest/api/*/user?username=$testUsername&expand=groups"}
+        }
+
+        It "Gets information about a provided Jira exact user" {
+            $getResult = Get-JiraUser -UserName $testUsername
+
+            $getResult | Should Not BeNullOrEmpty
+
+            Assert-MockCalled -CommandName Invoke-JiraMethod -Exactly 1 -Scope It -ParameterFilter {$Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/*/user?username=$testUsername"}
             Assert-MockCalled -CommandName Invoke-JiraMethod -Exactly 1 -Scope It -ParameterFilter {$URI -like "$jiraServer/rest/api/*/user?username=$testUsername&expand=groups"}
         }
 

--- a/docs/en-US/commands/Get-JiraUser.md
+++ b/docs/en-US/commands/Get-JiraUser.md
@@ -30,7 +30,7 @@ Get-JiraUser [-UserName] <String[]> [-IncludeInactive] [[-MaxResults] <UInt32>] 
 ### ByInputObject
 
 ```powershell
-Get-JiraUser [-InputObject] <Object[]> [-IncludeInactive] [-Credential <PSCredential>] [<CommonParameters>]
+Get-JiraUser [-InputObject] <Object[]> [-IncludeInactive] [-Credential <PSCredential>] [-Exact] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/docs/en-US/commands/Get-JiraUser.md
+++ b/docs/en-US/commands/Get-JiraUser.md
@@ -24,7 +24,7 @@ Get-JiraUser [-Credential <PSCredential>] [<CommonParameters>]
 ### ByUserName
 
 ```powershell
-Get-JiraUser [-UserName] <String[]> [-IncludeInactive] [[-MaxResults] <UInt32>] [[-Skip] <UInt64>] [-Credential <PSCredential>] [<CommonParameters>]
+Get-JiraUser [-UserName] <String[]> [-IncludeInactive] [[-MaxResults] <UInt32>] [[-Skip] <UInt64>] [-Credential <PSCredential>] [-Exact] [<CommonParameters>]
 ```
 
 ### ByInputObject
@@ -45,7 +45,7 @@ This function returns information regarding a specified user from Jira.
 Get-JiraUser -UserName user1
 ```
 
-Returns information about the user user1
+Returns information about all users with username like user1
 
 ### EXAMPLE 2
 
@@ -62,6 +62,14 @@ Get-JiraUser -Credential $cred
 ```
 
 This example returns the JIRA user that is executing the command.
+
+### EXAMPLE 4
+
+```powershell 
+Get-JiraUser -UserName user1 -Exact 
+```
+
+Returns information about user user1
 
 ## PARAMETERS
 

--- a/docs/en-US/commands/Get-JiraUser.md
+++ b/docs/en-US/commands/Get-JiraUser.md
@@ -174,6 +174,20 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+```yaml
+Type: SwitchParameter
+Parameter Sets: ByUserName,ByInputObject
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+
+
 ### CommonParameters
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.

--- a/docs/en-US/commands/Get-JiraUser.md
+++ b/docs/en-US/commands/Get-JiraUser.md
@@ -66,7 +66,7 @@ This example returns the JIRA user that is executing the command.
 ### EXAMPLE 4
 
 ```powershell 
-Get-JiraUser -UserName user1 -Exact 
+Get-JiraUser -UserName user1 -Exact
 ```
 
 Returns information about user user1
@@ -100,6 +100,22 @@ Aliases:
 
 Required: True
 Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Exact
+
+Limits the search to users where the username is exactly the term searched for.
+
+```yaml
+Type: Switch
+Parameter Sets: ByUserName, ByInputObject
+Aliases:
+
+Required: False
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -173,20 +189,6 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: ByUserName,ByInputObject
-Aliases:
-
-Required: False
-Position: Named
-Default value: False
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-
 
 ### CommonParameters
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 -->
<!-- markdownlint-disable MD041 -->
<!-- Provide a general summary of your changes in the Title above -->

### Description

Adds `-Exact` parameter to the `Get-JiraUser` which internally switches from using search to get user. 
It is then used in the `Set-JiraIssue` when the `-Assignee` is set.

### Motivation and Context

closes #320 
closes #49
is continued by #306
Assigning users failing when `Get-JiraUser` for a specific username returns more than one user

### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

- [X] My code follows the code style of this project.
- [X] I have added Pester Tests that describe what my changes should do.
- [X] I have updated the documentation accordingly.
