### PR TITLE
Get-JiraIssueAttachmentFile: Set Accept header based on Mime time of attachment

### DIFF
--- a/JiraPS/Public/Get-JiraIssueAttachmentFile.ps1
+++ b/JiraPS/Public/Get-JiraIssueAttachmentFile.ps1
@@ -52,7 +52,7 @@ function Get-JiraIssueAttachmentFile {
             $iwParameters = @{
                 Uri        = $_Attachment.Content
                 Method     = 'Get'
-                Headers    = @{"Accept" = $_Attachment.MediaType}
+                Headers    = @{"Accept" = $_Attachment.MimeType}
                 OutFile    = $filename
                 Credential = $Credential
             }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 -->
<!-- markdownlint-disable MD041 -->
<!-- Provide a general summary of your changes in the Title above -->

### Description

The attachment objects have a `MimeType` property.  This should be used to set the `Accept` header in the request to download the actual attachment; however the existing code refers to (non-existing) `MediaType` property on the Powershell object, thereby setting the Accept header value to null. 

### Motivation and Context

A partial fix for apparently "successful" download of file attachments. Without this change the pipeline output is `True` for each attachment downloaded, but the attachment did not download.  This PR doesn't change the fautly error handling, but implements a trivial underlying fix to constructing the request to fetch the download.
I believe that the error handling code needs to be fixed too, but I've not had a chance to do that.

### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

- [X] My code follows the code style of this project.
- [ ] I have added Pester Tests that describe what my changes should do.
- [ ] I have updated the documentation accordingly.
