### PR TITLE
Fix usage of New-JiraIssue in Jira Environment with mixed classic and "next gen" projects

### DIFF
--- a/JiraPS/Private/ConvertTo-JiraProject.ps1
+++ b/JiraPS/Private/ConvertTo-JiraProject.ps1
@@ -20,6 +20,7 @@ function ConvertTo-JiraProject {
                 'Roles'       = $i.roles
                 'RestUrl'     = $i.self
                 'Components'  = $i.components
+                'Style'       = $i.style
             }
 
             if ($i.projectCategory) {

--- a/JiraPS/Public/Get-JiraIssueCreateMetadata.ps1
+++ b/JiraPS/Public/Get-JiraIssueCreateMetadata.ps1
@@ -29,7 +29,17 @@ function Get-JiraIssueCreateMetadata {
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] PSBoundParameters: $($PSBoundParameters | Out-String)"
 
         $projectObj = Get-JiraProject -Project $Project -Credential $Credential -ErrorAction Stop
-        $issueTypeObj = Get-JiraIssueType -IssueType $IssueType -Credential $Credential -ErrorAction Stop
+        $issueTypeObj = $projectObj.IssueTypes | Where-Object -FilterScript {$_.Id -eq $IssueType -or $_.Name -eq $IssueType}
+
+        if ($null -eq $issueTypeObj.Id)
+        {
+            $errorMessage = @{
+                Category         = "InvalidResult"
+                CategoryActivity = "Validating parameters"
+                Message          = "No issue types were found in the project [$Project] for the given issue type [$IssueType]. Use Get-JiraIssueType for more details."
+            }
+            Write-Error @errorMessage
+        }
 
         $parameter = @{
             URI        = $resourceURi -f $projectObj.Id, $issueTypeObj.Id

--- a/JiraPS/Public/New-JiraIssue.ps1
+++ b/JiraPS/Public/New-JiraIssue.ps1
@@ -97,7 +97,7 @@ function New-JiraIssue {
         }
         elseif ($ProjectObj.Style -eq "next-gen"){
             Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] Adding reporter as next-gen projects must have reporter set."
-            $requestBody["reporter"] = @{"name" = "$((Get-JiraUser -UserName ((Get-JiraSession).UserName)).Name)"}
+            $requestBody["reporter"] = @{"name" = "$((Get-JiraUser -Credential $Credential).Name)"}
         }
 
         if ($Parent) {

--- a/JiraPS/Public/New-JiraIssue.ps1
+++ b/JiraPS/Public/New-JiraIssue.ps1
@@ -66,7 +66,17 @@ function New-JiraIssue {
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] PSBoundParameters: $($PSBoundParameters | Out-String)"
 
         $ProjectObj = Get-JiraProject -Project $Project -Credential $Credential -ErrorAction Stop -Debug:$false
-        $IssueTypeObj = Get-JiraIssueType -IssueType $IssueType -Credential $Credential -ErrorAction Stop -Debug:$false
+        $issueTypeObj = $projectObj.IssueTypes | Where-Object -FilterScript {$_.Id -eq $IssueType -or $_.Name -eq $IssueType}
+
+        if ($null -eq $issueTypeObj.Id)
+        {
+            $errorMessage = @{
+                Category         = "InvalidResult"
+                CategoryActivity = "Validating parameters"
+                Message          = "No issue types were found in the project [$Project] for the given issue type [$IssueType]. Use Get-JiraIssueType for more details."
+            }
+            Write-Error @errorMessage
+        }
 
         $requestBody = @{
             "project"   = @{"id" = $ProjectObj.Id}
@@ -84,6 +94,10 @@ function New-JiraIssue {
 
         if ($PSCmdlet.MyInvocation.BoundParameters.ContainsKey("Reporter")) {
             $requestBody["reporter"] = @{"name" = "$Reporter"}
+        }
+        elseif ($ProjectObj.Style -eq "next-gen"){
+            Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] Adding reporter as next-gen projects must have reporter set."
+            $requestBody["reporter"] = @{"name" = "$((Get-JiraUser -UserName ((Get-JiraSession).UserName)).Name)"}
         }
 
         if ($Parent) {

--- a/Tests/Functions/Get-JiraIssueCreateMetadata.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraIssueCreateMetadata.Unit.Tests.ps1
@@ -218,20 +218,17 @@ Describe "Get-JiraIssueCreateMetadata" -Tag 'Unit' {
         }
 
         Mock Get-JiraProject -ModuleName JiraPS {
+            $issueObject = [PSCustomObject] @{
+                ID   = 2
+                Name = 'Test Issue Type'
+            }
+            $issueObject.PSObject.TypeNames.Insert(0, 'JiraPS.IssueType')
             $object = [PSCustomObject] @{
                 ID   = 10003
                 Name = 'Test Project'
             }
+            Add-Member -InputObject $object -MemberType NoteProperty -Name "IssueTypes" -Value $issueObject
             $object.PSObject.TypeNames.Insert(0, 'JiraPS.Project')
-            return $object
-        }
-
-        Mock Get-JiraIssueType -ModuleName JiraPS {
-            $object = [PSCustomObject] @{
-                ID   = 2
-                Name = 'Test Issue Type'
-            }
-            $object.PSObject.TypeNames.Insert(0, 'JiraPS.IssueType')
             return $object
         }
 

--- a/Tests/Functions/New-JiraIssue.Unit.Tests.ps1
+++ b/Tests/Functions/New-JiraIssue.Unit.Tests.ps1
@@ -39,6 +39,7 @@ Describe "New-JiraIssue" -Tag 'Unit' {
 
 
         $jiraServer = 'https://jira.example.com'
+        $issueTypeTest = 1
 
         Mock Get-JiraConfigServer {
             $jiraServer
@@ -56,19 +57,17 @@ Describe "New-JiraIssue" -Tag 'Unit' {
         }
 
         Mock Get-JiraProject {
+            $issueObject = [PSCustomObject] @{
+                ID   = $issueTypeTest
+                Name = 'Test Issue Type'
+            }
+            $issueObject.PSObject.TypeNames.Insert(0, 'JiraPS.IssueType')
             $object = [PSCustomObject] @{
                 'ID'  = $Project
                 'Key' = "TEST"
             }
+            Add-Member -InputObject $object -MemberType NoteProperty -Name "IssueTypes" -Value $issueObject
             $object.PSObject.TypeNames.Insert(0, 'JiraPS.Project')
-            return $object
-        }
-
-        Mock Get-JiraIssueType {
-            $object = [PSCustomObject] @{
-                'ID' = $IssueType;
-            }
-            $object.PSObject.TypeNames.Insert(0, 'JiraPS.IssueType')
             return $object
         }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 -->
<!-- markdownlint-disable MD041 -->
<!-- Provide a general summary of your changes in the Title above -->

### Description

<!-- Describe your changes in detail -->

Modified ConvertTo-JiraProject to store the 'style' value returned from project REST API so a given project can be differentiated between next-gen or classic.

Modified New-JiraIssue (and similarly to Get-JiraIssueCreateMetadata) to avoid use of Get-JiraIssueType - all the data that required this cmdlet to be called is already stored in $projectObj. Additionally, Get-JiraIssueType does not support mixed environments with classic and next-gen projects. The original errors we got were a result of Get-JiraIssueType returning multiple IDs for a given Issue Type name.

New-JiraIssue also had an issue with the "reporter" field being unset on a next-gen project. Classic projects seems to automatically set the reporter field to the current user if not set, but next-gen projects do not seem to behave the same, so I modified New-JiraIssue to force setting the reporter field if the target project is flagged 'next-gen' from the style field.

Finally, added some more helpful error handling in both New-JiraIssue and Get-JiraIssueCreateMetadata - previously an unhelpful error message was presented to the user if the selected Issue Type was not valid for the input Project, after this fix the error returned to the user is explicit about the input Issue Type being invalid for the Project.

Unit tests for the two Public functions needed to be updated to provide the requisite IssueTypes data on the Mock Get-JiraProject stubs.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here as follows: -->
<!-- closes #1, closes #2, ... -->

With current develop branch, New-JiraIssue presents an error in our staging and development Jira instances:

New-JiraIssue -Project "TP1" -IssueType "Task" -Summary "Test test 123" -Priority 1 -Description "Test test 321"
Get-Member : You must specify an object for the Get-Member cmdlet.
At C:\shareDocs\Programming\JiraPS\JiraPS\Private\ConvertTo-JiraCreateMetaField.ps1:14 char:28
+ ... eldNames = (Get-Member -InputObject $fields -MemberType '*Property'). ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : CloseError: (:) [Get-Member], InvalidOperationException
    + FullyQualifiedErrorId : NoObjectInGetMember,Microsoft.PowerShell.Commands.GetMemberCommand

### Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have added Pester Tests that describe what my changes should do.
- [ ] I have updated the documentation accordingly.
