### PR TITLE
feature/issue 314 - Ability to add worklog during issue transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ See [`about_JiraPS_MigrationV3`](https://atlassianps.org/docs/JiraPS/about/migra
 
 ### Added
 
+- Added `-TimeSpent` to `Invoke-JiraIssueTransition`, allowing a worklog entry to be recorded as part of an issue transition. (#343, [@alexsuslin])
 - Added `Get-JiraStatus` to retrieve Jira statuses by id or name, or list all statuses.
 - Added `-IncludeHistory` to `Get-JiraIssue` to request changelog expansion and include issue history entries in the returned issue object (`-GetHistory` alias retained for compatibility).
 - Added `-Unassign` switch to `Set-JiraIssue` and `Invoke-JiraIssueTransition` as the explicit way to remove the assignee from an issue.

--- a/JiraPS/Public/Invoke-JiraIssueTransition.ps1
+++ b/JiraPS/Public/Invoke-JiraIssueTransition.ps1
@@ -28,6 +28,9 @@
         [String]
         $Comment,
 
+        [TimeSpan]
+        $TimeSpent,
+
         [Parameter()]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
@@ -181,6 +184,17 @@
             $requestBody.update.comment += , @{
                 'add' = @{
                     'body' = Resolve-JiraTextFieldPayload -Text $Comment -IsCloud $isCloud
+                }
+            }
+        }
+
+        if ($PSBoundParameters.ContainsKey('TimeSpent')) {
+            Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] Adding worklog"
+            $dateStarted = [DateTime]::new((Get-Date).Ticks, 'Local')
+            $requestBody.update.worklog += , @{
+                'add' = @{
+                    'started'          = $dateStarted.ToString("o") -replace "\.(\d{3})\d*([\+\-]\d{2}):", ".`$1`$2"
+                    'timeSpentSeconds' = $TimeSpent.TotalSeconds.ToString()
                 }
             }
         }

--- a/Tests/Functions/Public/Invoke-JiraIssueTransition.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Invoke-JiraIssueTransition.Unit.Tests.ps1
@@ -165,6 +165,7 @@ InModuleScope JiraPS {
                     @{ parameter = "Issue"; type = "AtlassianPS.JiraPS.Issue" }
                     @{ parameter = "Transition"; type = "Object" }
                     @{ parameter = "Comment"; type = "String" }
+                    @{ parameter = "TimeSpent"; type = "TimeSpan" }
                     @{ parameter = "Assignee"; type = "User" }
                     @{ parameter = "Unassign"; type = "Switch" }
                     @{ parameter = "Fields"; type = "PSCustomObject" }
@@ -305,6 +306,17 @@ InModuleScope JiraPS {
                         $Method -eq 'Post' -and
                         $URI -like "*/rest/api/2/issue/$issueID/transitions" -and
                         $Body -like '*body*test comment*'
+                    }
+                }
+
+                It "adds a worklog if provided to the -TimeSpent parameter" {
+                    { Invoke-JiraIssueTransition -Issue $issueKey -Transition 11 -TimeSpent ([TimeSpan]::FromMinutes(15)) } | Should -Not -Throw
+
+                    Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Times 1 -ParameterFilter {
+                        $Method -eq 'Post' -and
+                        $URI -like "*/rest/api/2/issue/$issueID/transitions" -and
+                        $Body -like '*worklog*timeSpentSeconds*900*' -and
+                        $Body -match '"started":\s*"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}[\+\-]\d{4}"'
                     }
                 }
             }

--- a/docs/en-US/commands/Invoke-JiraIssueTransition.md
+++ b/docs/en-US/commands/Invoke-JiraIssueTransition.md
@@ -18,7 +18,7 @@ Performs an issue transition on a JIRA issue changing it's status
 
 ```powershell
 Invoke-JiraIssueTransition -Issue <Issue> -Transition <Object> [-Fields <psobject>]
- [-Assignee <User>] [-Comment <string>] [-Credential <pscredential>] [-Passthru]
+ [-Assignee <User>] [-Comment <string>] [-TimeSpent <timespan>] [-Credential <pscredential>] [-Passthru]
  [<CommonParameters>]
 ```
 
@@ -26,7 +26,7 @@ Invoke-JiraIssueTransition -Issue <Issue> -Transition <Object> [-Fields <psobjec
 
 ```powershell
 Invoke-JiraIssueTransition -Issue <Issue> -Transition <Object> [-Fields <psobject>] [-Unassign]
- [-Comment <string>] [-Credential <pscredential>] [-Passthru] [<CommonParameters>]
+ [-Comment <string>] [-TimeSpent <timespan>] [-Credential <pscredential>] [-Passthru] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -57,11 +57,11 @@ Invokes transition ID 11 on issue TEST-01.
 ### EXAMPLE 2
 
 ```powershell
-Invoke-JiraIssueTransition -Issue TEST-01 -Transition 11 -Comment 'Transition comment'
+Invoke-JiraIssueTransition -Issue TEST-01 -Transition 11 -Comment 'Transition comment' -TimeSpent ([TimeSpan]::FromMinutes(15))
 ```
 
-Invokes transition ID 11 on issue TEST-01 with a comment.
-Requires the comment field to be configured visible for transition.
+Invokes transition ID 11 on issue TEST-01 with a comment and a 15-minute worklog.
+Requires the comment and worklog fields to be configured visible for transition.
 
 ### EXAMPLE 3
 
@@ -257,6 +257,29 @@ ParameterSets:
 - Name: (All)
   Position: Named
   IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -TimeSpent
+
+Time spent to record as a worklog during the transition.
+
+The worklog field must be configured to appear on the transition screen to use this parameter.
+
+```yaml
+Type: TimeSpan
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
   ValueFromPipeline: false
   ValueFromPipelineByPropertyName: false
   ValueFromRemainingArguments: false


### PR DESCRIPTION
<!-- markdownlint-disable MD002 -->
<!-- markdownlint-disable MD041 -->
### Description

Invoke-JiraIssueTransition now have additional parameter -TimeSpent where user can add worklog time he is working on this issue

### Motivation and Context

I would like to resolve the issue and specify worklog time

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

- [x] My code follows the code style of this project.
- [x] I have added Pester Tests that describe what my changes should do.
- [x] I have updated the documentation accordingly.
