### PR TITLE
Added -Exact flag to Get-JiraUser

### DIFF
--- a/JiraPS/Public/Invoke-JiraIssueTransition.ps1
+++ b/JiraPS/Public/Invoke-JiraIssueTransition.ps1
@@ -109,7 +109,7 @@ function Invoke-JiraIssueTransition {
                 $validAssignee = $true
             }
             else {
-                if ($assigneeObj = Get-JiraUser -InputObject $Assignee -Credential $Credential) {
+                if ($assigneeObj = Get-JiraUser -InputObject $Assignee -Credential $Credential -Exact) {
                     Write-Debug "[$($MyInvocation.MyCommand.Name)] User found (name=[$($assigneeObj.Name)],RestUrl=[$($assigneeObj.RestUrl)])"
                     $assigneeString = $assigneeObj.Name
                     $validAssignee = $true


### PR DESCRIPTION
<!-- markdownlint-disable MD002 -->
<!-- markdownlint-disable MD041 -->
<!-- Provide a general summary of your changes in the Title above -->

### Description

If JIRA has usernames such as "jsmith", "jsmithy", "jsmith1", "jsmithson" and you are trying to assign the ticket to "jsmith" it will fail because the assignee field needs a single user object to get a single string from but Get-JiraUser is returning an array of user objects.

By adding the Exact flag to the Get-JiraUser function within the Invoke-JiraIssueTransition this issue is resolved as only one user object is returned.

### Motivation and Context

If JIRA has usernames such as "jsmith", "jsmithy", "jsmith1", "jsmithson" and you are trying to assign the ticket to "jsmith" it will fail because the assignee field needs a single user object to get a single string from but Get-JiraUser is returning an array of user objects.
closes #349

### Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have added Pester Tests that describe what my changes should do.
- [ ] I have updated the documentation accordingly.
