### PR TITLE
Hotfix/fix username wildcard search

### DIFF
--- a/JiraPS/Public/Get-JiraUser.ps1
+++ b/JiraPS/Public/Get-JiraUser.ps1
@@ -3,7 +3,7 @@ function Get-JiraUser {
     [CmdletBinding( DefaultParameterSetName = 'Self' )]
     param(
         [Parameter( Position = 0, Mandatory, ValueFromPipelineByPropertyName, ParameterSetName = 'ByUserName' )]
-        [ValidateNotNullOrEmpty()]
+        [AllowEmptyString()]
         [Alias('User', 'Name')]
         [String[]]
         $UserName,

--- a/docs/en-US/commands/Get-JiraUser.md
+++ b/docs/en-US/commands/Get-JiraUser.md
@@ -71,6 +71,14 @@ Get-JiraUser -UserName user1 -Exact
 
 Returns information about user user1
 
+### EXAMPLE 5
+
+```powershell
+Get-JiraUser -UserName ""
+```
+
+Returns information about all users. The empty string "" matches all users.
+
 ## PARAMETERS
 
 ### -UserName


### PR DESCRIPTION
<!-- markdownlint-disable MD002 -->
<!-- markdownlint-disable MD041 -->
<!-- Provide a general summary of your changes in the Title above -->

### Description

<!-- Describe your changes in detail -->
Allow UserName parameter of Get-JiraUser to take an empty string.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
Atlassian API no longer returns user list using '%' as a wildcard. Empty string works as a wildcard.
Reference: https://community.atlassian.com/t5/Answers-Developer-Questions/How-do-I-get-users-list-using-REST-API/qaq-p/470324#M118831
<!-- If it fixes an open issue, please link to the issue here as follows: -->
<!-- closes #1, closes #2, ... -->
closes #360 

### Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have added Pester Tests that describe what my changes should do.
- [x] I have updated the documentation accordingly.
