### PR TITLE
Changed ConfigServer to be in module's scope

### DIFF
--- a/JiraPS/JiraPS.psm1
+++ b/JiraPS/JiraPS.psm1
@@ -23,9 +23,16 @@ if (!("System.Net.Http" -as [Type])) {
 #endregion Dependencies
 
 #region Configuration
+$script:serverConfig = ("{0}/AtlassianPS/JiraPS/server_config" -f [Environment]::GetFolderPath('ApplicationData'))
+
+if (-not (Test-Path $script:serverConfig)) {
+    $null = New-Item -Path $script:serverConfig -ItemType File -Force
+}
+$script:JiraServerUrl = [Uri](Get-Content $script:serverConfig)
+
 $script:DefaultContentType = "application/json; charset=utf-8"
 $script:DefaultPageSize = 25
-$script:DefaultHeaders= @{ "Accept-Charset" = "utf-8" }
+$script:DefaultHeaders = @{ "Accept-Charset" = "utf-8" }
 # Bug in PSv3's .Net API
 if ($PSVersionTable.PSVersion.Major -gt 3) {
     $script:DefaultHeaders["Accept"] = "application/json"

--- a/JiraPS/Public/Get-JiraConfigServer.ps1
+++ b/JiraPS/Public/Get-JiraConfigServer.ps1
@@ -2,10 +2,7 @@ function Get-JiraConfigServer {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding()]
     [OutputType([System.String])]
-    param(
-        [String]
-        $ConfigFile
-    )
+    param()
 
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
@@ -15,53 +12,7 @@ function Get-JiraConfigServer {
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] ParameterSetName: $($PsCmdlet.ParameterSetName)"
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] PSBoundParameters: $($PSBoundParameters | Out-String)"
 
-        # Using a default value for this parameter wouldn't handle all cases. We want to make sure
-        # that the user can pass a $null value to the ConfigFile parameter...but if it's null, we
-        # want to default to the script variable just as we would if the parameter was not
-        # provided at all.
-
-        if (-not ($ConfigFile)) {
-            # This file should be in $moduleRoot/Functions/Internal, so PSScriptRoot will be $moduleRoot/Functions
-            $moduleFolder = Split-Path -Path $PSScriptRoot -Parent
-            $ConfigFile = Join-Path -Path $moduleFolder -ChildPath 'config.xml'
-        }
-
-        if (-not (Test-Path -Path $ConfigFile)) {
-            $exception = ([System.IO.FileNotFoundException]"Could not find $ConfigFile")
-            $errorId = 'ConfigFile.NotFound'
-            $errorCategory = 'ObjectNotFound'
-            $errorTarget = $ConfigFile
-            $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
-            $errorItem.ErrorDetails = "Config file [$ConfigFile] does not exist. Use Set-JiraConfigServer first to define the configuration file."
-            $PSCmdlet.ThrowTerminatingError($errorItem)
-        }
-
-        $xml = New-Object -TypeName XML
-        $xml.Load($ConfigFile)
-
-        $xmlConfig = $xml.DocumentElement
-        if ($xmlConfig.LocalName -ne 'Config') {
-            $exception = ([System.IO.FileFormatException]"XML had not the expected format")
-            $errorId = 'ConfigFile.UnexpectedElement'
-            $errorCategory = ParserError
-            $errorTarget = $ConfigFile
-            $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
-            $errorItem.ErrorDetails = "Unexpected document element [$($xmlConfig.LocalName)] in configuration file [$ConfigFile]. You may need to delete the config file and recreate it using Set-JiraConfigServer."
-            $PSCmdlet.ThrowTerminatingError($errorItem)
-        }
-
-        if ($xmlConfig.Server) {
-            Write-Output $xmlConfig.Server
-        }
-        else {
-            $exception = ([System.UriFormatException]"Could not find URI")
-            $errorId = 'ConfigFile.EmptyElement'
-            $errorCategory = OpenError
-            $errorTarget = $ConfigFile
-            $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
-            $errorItem.ErrorDetails = "No Server element is defined in the config file.  Use Set-JiraConfigServer to define one."
-            $PSCmdlet.ThrowTerminatingError($errorItem)
-        }
+        return $script:JiraServerUrl
     }
 
     end {

--- a/JiraPS/Public/Set-JiraConfigServer.ps1
+++ b/JiraPS/Public/Set-JiraConfigServer.ps1
@@ -16,6 +16,8 @@ function Set-JiraConfigServer {
 
     process {
         $script:JiraServerUrl = $Server
+
+        Set-Content -Value $Server -Path "$script:serverConfig"
     }
 
     end {

--- a/JiraPS/Public/Set-JiraConfigServer.ps1
+++ b/JiraPS/Public/Set-JiraConfigServer.ps1
@@ -7,10 +7,7 @@ function Set-JiraConfigServer {
         [ValidateNotNullOrEmpty()]
         [Alias('Uri')]
         [Uri]
-        $Server,
-
-        [String]
-        $ConfigFile
+        $Server
     )
 
     begin {
@@ -18,59 +15,7 @@ function Set-JiraConfigServer {
     }
 
     process {
-        Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] ParameterSetName: $($PsCmdlet.ParameterSetName)"
-        Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] PSBoundParameters: $($PSBoundParameters | Out-String)"
-
-        # Using a default value for this parameter wouldn't handle all cases. We want to make sure
-        # that the user can pass a $null value to the ConfigFile parameter...but if it's null, we
-        # want to default to the script variable just as we would if the parameter was not
-        # provided at all.
-
-        if (-not ($ConfigFile)) {
-            # This file should be in $moduleRoot/Functions/Internal, so PSScriptRoot will be $moduleRoot/Functions
-            $moduleFolder = Split-Path -Path $PSScriptRoot -Parent
-            $ConfigFile = Join-Path -Path $moduleFolder -ChildPath 'config.xml'
-        }
-
-        Write-Debug "[$($MyInvocation.MyCommand.Name)] Config file path: $ConfigFile"
-        if (-not (Test-Path -Path $ConfigFile)) {
-            Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] Creating new Config file"
-            $xml = [XML] '<Config></Config>'
-        }
-        else {
-            Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] Using existing Config file"
-            $xml = New-Object -TypeName XML
-            $xml.Load($ConfigFile)
-        }
-
-        $xmlConfig = $xml.DocumentElement
-        if ($xmlConfig.LocalName -ne 'Config') {
-            $exception = ([System.ArgumentException]"Invalid Document")
-            $errorId = 'InvalidObject.InvalidDocument'
-            $errorCategory = 'InvalidData'
-            $errorTarget = $_
-            $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
-            $errorItem.ErrorDetails = "Unexpected document element [$($xmlConfig.LocalName)] in configuration file. You may need to delete the config file and recreate it using this function."
-            $PSCmdlet.ThrowTerminatingError($errorItem)
-        }
-
-        $fixedServer = $Server.AbsoluteUri.Trim('/')
-
-        if ($xmlConfig.Server) {
-            $xmlConfig.Server = $fixedServer
-        }
-        else {
-            $xmlServer = $xml.CreateElement('Server')
-            $xmlServer.InnerText = $fixedServer
-            [void] $xmlConfig.AppendChild($xmlServer)
-        }
-
-        try {
-            $xml.Save($ConfigFile)
-        }
-        catch {
-            throw $_
-        }
+        $script:JiraServerUrl = $Server
     }
 
     end {

--- a/Tests/Functions/Get-JiraConfigServer.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraConfigServer.Unit.Tests.ps1
@@ -39,12 +39,9 @@ Describe "Get-JiraConfigServer" -Tag 'Unit' {
 
         $jiraServer = 'http://jiraserver.example.com'
 
-        It "returns empty if no server has been set" {
-            Get-JiraConfigServer | Should -BeNullOrEmpty
-        }
-
         It "returns the server stored in the module's session" {
             $script:JiraServerUrl = $jiraServer
+
             Get-JiraConfigServer | Should -Be $jiraServer
         }
     }

--- a/Tests/Functions/Get-JiraConfigServer.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraConfigServer.Unit.Tests.ps1
@@ -39,16 +39,13 @@ Describe "Get-JiraConfigServer" -Tag 'Unit' {
 
         $jiraServer = 'http://jiraserver.example.com'
 
-        $configFile = Join-Path -Path $TestDrive -ChildPath 'config.xml'
-
-        It "Throws an exception if the config file does not exist" {
-            { Get-JiraConfigServer -ConfigFile $configFile } | Should Throw
+        It "returns empty if no server has been set" {
+            Get-JiraConfigServer | Should -BeNullOrEmpty
         }
 
-        It "Returns the defined Server in the config.xml file" {
-            Set-JiraConfigServer -Server $jiraServer -ConfigFile $configFile
-            $s = Get-JiraConfigServer -ConfigFile $configFile
-            $s | Should Be $jiraServer
+        It "returns the server stored in the module's session" {
+            $script:JiraServerUrl = $jiraServer
+            Get-JiraConfigServer | Should -Be $jiraServer
         }
     }
 }

--- a/Tests/Functions/Set-JiraConfigServer.Unit.Tests.ps1
+++ b/Tests/Functions/Set-JiraConfigServer.Unit.Tests.ps1
@@ -44,5 +44,11 @@ Describe "Set-JiraConfigServer" -Tag 'Unit' {
 
             $script:JiraServerUrl | Should -Be "$jiraServer/"
         }
+
+        It "stores the server address in a config file" {
+            $script:serverConfig | Should -Exist
+
+            Get-Content $script:serverConfig | Should -Be "$jiraServer/"
+        }
     }
 }

--- a/Tests/Functions/Set-JiraConfigServer.Unit.Tests.ps1
+++ b/Tests/Functions/Set-JiraConfigServer.Unit.Tests.ps1
@@ -39,37 +39,10 @@ Describe "Set-JiraConfigServer" -Tag 'Unit' {
 
         $jiraServer = 'http://jiraserver.example.com'
 
-        $configFile = Join-Path -Path $TestDrive -ChildPath 'config.xml'
-        Set-JiraConfigServer -Server $jiraServer -ConfigFile $configFile
+        It "stores the server address in the module session" {
+            Set-JiraConfigServer -Server $jiraServer
 
-        It "Ensures that a config.xml file exists" {
-            $configFile | Should Exist
-        }
-
-        $xml = New-Object -TypeName Xml
-        $xml.Load($configFile)
-        $xmlServer = $xml.Config.Server
-
-        It "Ensures that the XML file has a Config.Server element" {
-            $xmlServer | Should Not BeNullOrEmpty
-        }
-
-        It "Sets the config file's Server value " {
-            $xmlServer | Should Be $jiraServer
-        }
-
-        It "Trims whitespace from the provided Server parameter" {
-            Set-JiraConfigServer -Server "$jiraServer " -ConfigFile $configFile
-            $xml = New-Object -TypeName Xml
-            $xml.Load($configFile)
-            $xml.Config.Server | Should Be $jiraServer
-        }
-
-        It "Trims trailing slasher from the provided Server parameter" {
-            Set-JiraConfigServer -Server "$jiraServer/" -ConfigFile $configFile
-            $xml = New-Object -TypeName Xml
-            $xml.Load($configFile)
-            $xml.Config.Server | Should Be $jiraServer
+            $script:JiraServerUrl | Should -Be "$jiraServer/"
         }
     }
 }

--- a/Tests/JiraPS.Tests.ps1
+++ b/Tests/JiraPS.Tests.ps1
@@ -26,8 +26,13 @@ Describe "General project validation" -Tag Unit {
 
         Remove-Module $env:BHProjectName -ErrorAction SilentlyContinue
         # Import-Module $env:BHManifestToTest
+
+        $configFile = ("{0}/AtlassianPS/JiraPS/server_config" -f [Environment]::GetFolderPath('ApplicationData'))
+        $oldConfig = Get-Content $configFile
     }
     AfterAll {
+        Set-Content -Value $oldConfig -Path $configFile -Force
+
         Remove-Module $env:BHProjectName -ErrorAction SilentlyContinue
         Remove-Module BuildHelpers -ErrorAction SilentlyContinue
         Remove-Item -Path Env:\BH*
@@ -58,6 +63,14 @@ Describe "General project validation" -Tag Unit {
     It "module uses a valid version" {
         [Version](Get-Metadata -Path $env:BHManifestToTest -PropertyName ModuleVersion) | Should -Not -BeNullOrEmpty
         [Version](Get-Metadata -Path $env:BHManifestToTest -PropertyName ModuleVersion) | Should -BeOfType [Version]
+    }
+
+    It "module uses the previous server config when loaded" {
+        Set-Content -Value "https://example.com" -Path $configFile -Force
+
+        Import-Module $env:BHManifestToTest -Force
+
+        Get-JiraConfigServer | Should -Be "https://example.com/"
     }
 
     # It "module is imported with default prefix" {

--- a/docs/en-US/commands/Get-JiraConfigServer.md
+++ b/docs/en-US/commands/Get-JiraConfigServer.md
@@ -7,6 +7,7 @@ schema: 2.0.0
 layout: documentation
 permalink: /docs/JiraPS/commands/Get-JiraConfigServer/
 ---
+
 # Get-JiraConfigServer
 
 ## SYNOPSIS
@@ -23,8 +24,6 @@ Get-JiraConfigServer [[-ConfigFile] <String>] [<CommonParameters>]
 
 This function returns the configured URL for the JIRA server that JiraPS should manipulate.
 
-By default, this is stored in a config.xml file at the module's root path.
-
 ## EXAMPLES
 
 ### EXAMPLE 1
@@ -33,33 +32,9 @@ By default, this is stored in a config.xml file at the module's root path.
 Get-JiraConfigServer
 ```
 
-Returns the server URL of the JIRA server configured in the JiraPS config file.
-
-### EXAMPLE 2
-
-```powershell
-Get-JiraConfigServer -ConfigFile C:\jiraconfig.xml
-```
-
-Returns the server URL of the JIRA server configured at C:\jiraconfig.xml.
+Returns the server URL of the JIRA server configured for the JiraPS module.
 
 ## PARAMETERS
-
-### -ConfigFile
-
-Path to the configuration file, if not the default.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: 1
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
 
 ### CommonParameters
 
@@ -76,7 +51,8 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 Support for multiple configuration files is limited at this point in time, but enhancements are planned for a future update.
 
-<TODO: link to issue for tracking>
+<https://github.com/AtlassianPS/JiraPS/issues/45>
+<https://github.com/AtlassianPS/JiraPS/issues/194>
 
 ## RELATED LINKS
 

--- a/docs/en-US/commands/Set-JiraConfigServer.md
+++ b/docs/en-US/commands/Set-JiraConfigServer.md
@@ -7,6 +7,7 @@ schema: 2.0.0
 layout: documentation
 permalink: /docs/JiraPS/commands/Set-JiraConfigServer/
 ---
+
 # Set-JiraConfigServer
 
 ## SYNOPSIS
@@ -16,14 +17,12 @@ Defines the configured URL for the JIRA server
 ## SYNTAX
 
 ```powershell
-Set-JiraConfigServer [-Server] <Uri> [[-ConfigFile] <String>] [<CommonParameters>]
+Set-JiraConfigServer [-Server] <Uri> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
 This function defines the configured URL for the JIRA server that JiraPS should manipulate.
-
-By default, this is stored in a config.xml file at the module's root path.
 
 ## EXAMPLES
 
@@ -33,7 +32,7 @@ By default, this is stored in a config.xml file at the module's root path.
 Set-JiraConfigServer 'https://jira.example.com:8080'
 ```
 
-This example defines the server URL of the JIRA server configured in the JiraPS config file.
+This example defines the server URL of the JIRA server configured for the JiraPS module.
 
 ## PARAMETERS
 
@@ -48,24 +47,6 @@ Aliases: Uri
 
 Required: True
 Position: 1
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -ConfigFile
-
-Path where the file with the configuration will be stored.
-
-> This parameter is not yet implemented
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: 2
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False


### PR DESCRIPTION
### Description

Have `Set-JiraConfigServer` store the server in the module's session instead of in a file.

### Motivation and Context

Several issues were raised asking for help because the `config.xml` could not be written (or changed)

### Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have added Pester Tests that describe what my changes should do.
- [x] I have updated the documentation accordingly.
