### PR TITLE
Issue 45

### DIFF
--- a/JiraPS/JiraPS.psm1
+++ b/JiraPS/JiraPS.psm1
@@ -30,10 +30,10 @@ if (-not (Test-Path $script:configPath)) {
     $null = New-Item -Path $script:configPath -ItemType Directory -Force
 }
 
-if (Test-Path $script:serversConfig) {
-    $script:JiraServerConfigs = Get-Content $script:serversConfig | ConvertFrom-Json
-} elseif (Test-Path "$script:configPath\server_config") {
-    $serverUrl = Get-Content "$script:configPath\server_config"
+if (Test-Path -Path $script:serversConfig) {
+    $script:JiraServerConfigs = Get-Content -Path $script:serversConfig -Raw | ConvertFrom-Json
+} elseif (Test-Path -Path "$script:configPath\server_config") {
+    $serverUrl = Get-Content -Path "$script:configPath\server_config"
 
     $script:JiraServerConfigs = @{
         Default = (New-Object psobject -Property @{ Server = $serverUrl })

--- a/JiraPS/JiraPS.psm1
+++ b/JiraPS/JiraPS.psm1
@@ -1,4 +1,4 @@
-﻿#region Dependencies
+#region Dependencies
 # Load the ConfluencePS namespace from C#
 # if (!("" -as [Type])) {
 #     Add-Type -Path (Join-Path $PSScriptRoot JiraPS.Types.cs) -ReferencedAssemblies Microsoft.CSharp, Microsoft.PowerShell.Commands.Utility, System.Management.Automation
@@ -23,7 +23,7 @@ if (!("System.Net.Http" -as [Type])) {
 #endregion Dependencies
 
 #region Configuration
-$script:configPath = ("{0}/AtlassianPS/JiraPS" -f [Environment]::GetFolderPath('ApplicationData'))
+$script:configPath = "$($env:APPDATA)/AtlassianPS/JiraPS"
 $script:serversConfig = "$script:configPath\servers.json"
 
 if (-not (Test-Path $script:configPath)) {

--- a/JiraPS/JiraPS.psm1
+++ b/JiraPS/JiraPS.psm1
@@ -23,12 +23,24 @@ if (!("System.Net.Http" -as [Type])) {
 #endregion Dependencies
 
 #region Configuration
-$script:serverConfig = ("{0}/AtlassianPS/JiraPS/server_config" -f [Environment]::GetFolderPath('ApplicationData'))
+$sciprt:configPath = ("{0}/AtlassianPS/JiraPS" -f [Environment]::GetFolderPath('ApplicationData'))
+$script:serversConfig = "$script:configPath\servers.json"
 
-if (-not (Test-Path $script:serverConfig)) {
-    $null = New-Item -Path $script:serverConfig -ItemType File -Force
+if (-not (Test-Path $sciprt:configPath)) {
+    $null = New-Item -Path $sciprt:configPath -ItemType Directory -Force
 }
-$script:JiraServerUrl = [Uri](Get-Content $script:serverConfig)
+
+if (Test-Path $sciprt:serversConfig) {
+    $script:JiraServerConfigs = Get-Content $script:serversConfig | ConvertFrom-Json
+} elseif (Test-Path "$sciprt:configPath\server_config") {
+    $serverUrl = Get-Content "$sciprt:configPath\server_config"
+
+    $script:JiraServerConfigs = @{
+        Default = (New-Object psobject -Property @{ Server = $serverUrl })
+    }
+} else {
+    $script:JiraServerConfigs = @{}
+}
 
 $script:DefaultContentType = "application/json; charset=utf-8"
 $script:DefaultPageSize = 25

--- a/JiraPS/JiraPS.psm1
+++ b/JiraPS/JiraPS.psm1
@@ -23,7 +23,7 @@ if (!("System.Net.Http" -as [Type])) {
 #endregion Dependencies
 
 #region Configuration
-$script:configPath = "$($env:APPDATA)/AtlassianPS/JiraPS"
+$script:configPath = ("{0}/AtlassianPS/JiraPS" -f [Environment]::GetFolderPath('ApplicationData'))
 $script:serversConfig = "$script:configPath\servers.json"
 
 if (-not (Test-Path $script:configPath)) {

--- a/JiraPS/JiraPS.psm1
+++ b/JiraPS/JiraPS.psm1
@@ -23,17 +23,17 @@ if (!("System.Net.Http" -as [Type])) {
 #endregion Dependencies
 
 #region Configuration
-$sciprt:configPath = ("{0}/AtlassianPS/JiraPS" -f [Environment]::GetFolderPath('ApplicationData'))
+$script:configPath = ("{0}/AtlassianPS/JiraPS" -f [Environment]::GetFolderPath('ApplicationData'))
 $script:serversConfig = "$script:configPath\servers.json"
 
-if (-not (Test-Path $sciprt:configPath)) {
-    $null = New-Item -Path $sciprt:configPath -ItemType Directory -Force
+if (-not (Test-Path $script:configPath)) {
+    $null = New-Item -Path $script:configPath -ItemType Directory -Force
 }
 
-if (Test-Path $sciprt:serversConfig) {
+if (Test-Path $script:serversConfig) {
     $script:JiraServerConfigs = Get-Content $script:serversConfig | ConvertFrom-Json
-} elseif (Test-Path "$sciprt:configPath\server_config") {
-    $serverUrl = Get-Content "$sciprt:configPath\server_config"
+} elseif (Test-Path "$script:configPath\server_config") {
+    $serverUrl = Get-Content "$script:configPath\server_config"
 
     $script:JiraServerConfigs = @{
         Default = (New-Object psobject -Property @{ Server = $serverUrl })
@@ -42,7 +42,7 @@ if (Test-Path $sciprt:serversConfig) {
     $script:JiraServerConfigs = @{}
 }
 
-$sciprt:JiraSessions = @{}
+$script:JiraSessions = @{}
 
 $script:DefaultContentType = "application/json; charset=utf-8"
 $script:DefaultPageSize = 25

--- a/JiraPS/JiraPS.psm1
+++ b/JiraPS/JiraPS.psm1
@@ -42,6 +42,8 @@ if (Test-Path $sciprt:serversConfig) {
     $script:JiraServerConfigs = @{}
 }
 
+$sciprt:JiraSessions = @{}
+
 $script:DefaultContentType = "application/json; charset=utf-8"
 $script:DefaultPageSize = 25
 $script:DefaultHeaders = @{ "Accept-Charset" = "utf-8" }
@@ -57,7 +59,6 @@ $script:PagingContainers = @(
     "values"
     "worklogs"
 )
-$script:SessionTransformationMethod = "ConvertTo-JiraSession"
 #endregion Configuration
 
 #region LoadFunctions

--- a/JiraPS/Private/ConvertTo-JiraSession.ps1
+++ b/JiraPS/Private/ConvertTo-JiraSession.ps1
@@ -19,50 +19,73 @@ function ConvertTo-JiraSession {
         $ServerConfig
     )
 
+    begin {
+        $newSessionScript = [scriptblock]{
+
+            $webSession = New-Object -TypeName Microsoft.PowerShell.Commands.WebRequestSession
+
+            if ($Credential) {
+                $webSession.Credentials = $Credential
+            }
+
+            $props = @{
+                Name = $null
+                WebSession = $webSession
+                ServerConfig = $ServerConfig
+            }
+
+            $result = New-Object -TypeName PSObject -Property $props
+            $result.PSObject.TypeNames.Insert(0, 'JiraPS.Session')
+            $result | Add-Member -MemberType ScriptMethod -Name "ToString" -Force -Value {
+                Write-Output "JiraSession[JSessionID=$($this.JSessionID)]"
+            }
+
+            Write-Output $result
+        }
+    }
+
     process {
         Write-Debug "[$($MyInvocation.MyCommand.Name)] Converting `$InputObject to custom object"
 
-        if ("JiraPS.Session" -in $InputObject.TypeNames) {
-            Write-Output $InputObject
-            return
-        }
 
-        if ($InputObject -is [string]) {
 
-            if (-not $script:JiraSessions.ContainsKey($InputObject)) {
-                $exception = ([System.InvalidOperationException]"Can not find $name session!")
-                $errorId = 'JiraSession.NotFound'
-                $errorCategory = 'InvalidOperation'
-                $errorTarget = $_
-                $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
-                $errorItem.ErrorDetails = "Wrong value for InputObject parameter provided. Use New-JiraSession to solve the problem."
-                $PSCmdlet.ThrowTerminatingError($errorItem)
+        switch ($PSCmdlet.ParameterSetName)
+        {
+            "ByInputObject" {
+                if ($InputObject -eq $null) {
+                    $InputObject = "Default"
+                }
+
+                if ("JiraPS.Session" -in $InputObject.PSObject.TypeNames) {
+                    Write-Output $InputObject
+                    return
+                }
+
+                if ($InputObject -is [string]) {
+
+                    if (-not $script:JiraSessions.ContainsKey($InputObject)) {
+                        $exception = ([System.InvalidOperationException]"Can not find $InputObject session!")
+                        $errorId = 'JiraSession.NotFound'
+                        $errorCategory = 'InvalidOperation'
+                        $errorTarget = $_
+                        $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
+                        $errorItem.ErrorDetails = "Wrong value for InputObject parameter provided. Use New-JiraSession to solve the problem."
+                        $PSCmdlet.ThrowTerminatingError($errorItem)
+                    }
+
+                    Write-Output $script:JiraSessions[$InputObject]
+                    return
+                }
+
+                if ($InputObject -is [pscredential]) {
+                    $session = &$newSessionScript
+                    $session.WebSession.Credentials = $InputObject
+                    Write-Output $session
+                }
             }
-
-            Write-Output $script:JiraSessions[$InputObject]
-            return
+            "ByArgs" {
+                &$newSessionScript
+            }
         }
-
-        $webSession = New-Object -TypeName Microsoft.PowerShell.Commands.WebRequestSession
-
-        if ((-not $Credential -or $Credential -ne [pscredential]::Empty) -and $InputObject -is [pscredential]) {
-            $Credential = $InputObject
-        }
-
-        $webSession.Credentials = $Credential
-
-        $props = @{
-            Name = $null
-            WebSession = $webSession
-            ServerConfig = $ServerConfig
-        }
-
-        $result = New-Object -TypeName PSObject -Property $props
-        $result.PSObject.TypeNames.Insert(0, 'JiraPS.Session')
-        $result | Add-Member -MemberType ScriptMethod -Name "ToString" -Force -Value {
-            Write-Output "JiraSession[JSessionID=$($this.JSessionID)]"
-        }
-
-        Write-Output $result
     }
 }

--- a/JiraPS/Private/ConvertTo-JiraSession.ps1
+++ b/JiraPS/Private/ConvertTo-JiraSession.ps1
@@ -1,7 +1,7 @@
 function ConvertTo-JiraSession {
     [CmdletBinding()]
     param(
-        [Parameter( Mandatory, ValueFromPipeline, ParameterSetName = "ByInputObject" )]
+        [Parameter( ValueFromPipeline, ParameterSetName = "ByInputObject" )]
         [psobject]
         $InputObject,
 

--- a/JiraPS/Private/ConvertTo-JiraSession.ps1
+++ b/JiraPS/Private/ConvertTo-JiraSession.ps1
@@ -84,7 +84,9 @@ function ConvertTo-JiraSession {
                 }
             }
             "ByArgs" {
-                &$newSessionScript
+                $session = &$newSessionScript
+                $session.Name = $Name
+                Write-Output $session
             }
         }
     }

--- a/JiraPS/Private/Resolve-JiraError.ps1
+++ b/JiraPS/Private/Resolve-JiraError.ps1
@@ -1,4 +1,4 @@
-﻿function Resolve-JiraError {
+function Resolve-JiraError {
     [CmdletBinding()]
     param(
         [Parameter( ValueFromPipeline )]

--- a/JiraPS/Private/Resolve-JiraIssueObject.ps1
+++ b/JiraPS/Private/Resolve-JiraIssueObject.ps1
@@ -26,11 +26,9 @@ function Resolve-JiraIssueObject {
         [Object]
         $InputObject,
 
-        # Authentication credentials
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     # As we are not able to use proper type casting in the parameters, this is a workaround
@@ -42,10 +40,10 @@ function Resolve-JiraIssueObject {
     }
     elseif ("JiraPS.Issue" -in $InputObject.PSObject.TypeNames -and $InputObject.Key) {
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] Resolve Issue to object"
-        return (Get-JiraIssue -Key $InputObject.Key -Credential $Credential -ErrorAction Stop)
+        return (Get-JiraIssue -Key $InputObject.Key -Session $Session -ErrorAction Stop)
     }
     else {
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] Resolve Issue to object"
-        return (Get-JiraIssue -Key $InputObject.ToString() -Credential $Credential -ErrorAction Stop)
+        return (Get-JiraIssue -Key $InputObject.ToString() -Session $Session -ErrorAction Stop)
     }
 }

--- a/JiraPS/Private/Resolve-JiraUser.ps1
+++ b/JiraPS/Private/Resolve-JiraUser.ps1
@@ -29,11 +29,9 @@ function Resolve-JiraUser {
         [Switch]
         $Exact,
 
-        # Authentication credentials
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     # As we are not able to use proper type casting in the parameters, this is a workaround
@@ -45,6 +43,6 @@ function Resolve-JiraUser {
     }
     else {
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] Resolve User to object"
-        return (Get-JiraUser -UserName $InputObject -Exact:$Exact -Credential $Credential -ErrorAction Stop)
+        return (Get-JiraUser -UserName $InputObject -Exact:$Exact -Session $Session -ErrorAction Stop)
     }
 }

--- a/JiraPS/Public/Add-JiraFilterPermission.ps1
+++ b/JiraPS/Public/Add-JiraFilterPermission.ps1
@@ -1,4 +1,4 @@
-﻿function Add-JiraFilterPermission {
+function Add-JiraFilterPermission {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( SupportsShouldProcess, DefaultParameterSetName = 'ByInputObject' )]
     # [OutputType( [JiraPS.FilterPermission] )]

--- a/JiraPS/Public/Add-JiraFilterPermission.ps1
+++ b/JiraPS/Public/Add-JiraFilterPermission.ps1
@@ -21,10 +21,9 @@
         [Parameter()]
         [String]$Value,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     begin {
@@ -63,7 +62,7 @@
                 URI        = $resourceURi -f $_filter.RestURL
                 Method     = "POST"
                 Body       = ConvertTo-Json $body
-                Credential = $Credential
+                Session    = $Session
             }
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
             if ($PSCmdlet.ShouldProcess($_filter.Name, "Add Permission [$Type - $Value]")) {

--- a/JiraPS/Public/Add-JiraGroupMember.ps1
+++ b/JiraPS/Public/Add-JiraGroupMember.ps1
@@ -29,9 +29,7 @@ function Add-JiraGroupMember {
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/latest/group/user?groupname={0}"
+        $resourceURi = "rest/api/latest/group/user?groupname={0}"
     }
 
     process {

--- a/JiraPS/Public/Add-JiraIssueAttachment.ps1
+++ b/JiraPS/Public/Add-JiraIssueAttachment.ps1
@@ -53,10 +53,9 @@ function Add-JiraIssueAttachment {
         [String[]]
         $FilePath,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty,
+        [Alias("Credential")]
+        [psobject]
+        $Session,
 
         [Switch]
         $PassThru
@@ -83,7 +82,7 @@ function Add-JiraIssueAttachment {
         }
 
         # Find the proper object for the Issue
-        $issueObj = Resolve-JiraIssueObject -InputObject $Issue -Credential $Credential
+        $issueObj = Resolve-JiraIssueObject -InputObject $Issue -Session $Session
 
         foreach ($file in $FilePath) {
             $file = Resolve-FilePath -Path $file
@@ -115,7 +114,7 @@ Content-Type: application/octet-stream
                 Body       = $bodyLines
                 Headers    = $headers
                 RawBody    = $true
-                Credential = $Credential
+                Session    = $Session
             }
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
             if ($PSCmdlet.ShouldProcess($IssueObj.Key, "Adding attachment '$($fileName)'.")) {

--- a/JiraPS/Public/Add-JiraIssueComment.ps1
+++ b/JiraPS/Public/Add-JiraIssueComment.ps1
@@ -37,10 +37,9 @@ function Add-JiraIssueComment {
         [String]
         $VisibleRole = 'All Users',
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     begin {
@@ -54,7 +53,7 @@ function Add-JiraIssueComment {
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] PSBoundParameters: $($PSBoundParameters | Out-String)"
 
         # Find the proper object for the Issue
-        $issueObj = Resolve-JiraIssueObject -InputObject $Issue -Credential $Credential
+        $issueObj = Resolve-JiraIssueObject -InputObject $Issue -Session $Session
 
         $requestBody = @{
             'body' = $Comment
@@ -74,7 +73,7 @@ function Add-JiraIssueComment {
             URI        = $resourceURi -f $issueObj.RestURL
             Method     = "POST"
             Body       = ConvertTo-Json -InputObject $requestBody
-            Credential = $Credential
+            Session    = $Session
         }
         Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
         if ($PSCmdlet.ShouldProcess($issueObj.Key)) {

--- a/JiraPS/Public/Add-JiraIssueLink.ps1
+++ b/JiraPS/Public/Add-JiraIssueLink.ps1
@@ -68,9 +68,7 @@ function Add-JiraIssueLink {
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/latest/issueLink"
+        $resourceURi = "rest/api/latest/issueLink"
     }
 
     process {

--- a/JiraPS/Public/Add-JiraIssueLink.ps1
+++ b/JiraPS/Public/Add-JiraIssueLink.ps1
@@ -59,10 +59,9 @@ function Add-JiraIssueLink {
         [String]
         $Comment,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     begin {
@@ -77,7 +76,7 @@ function Add-JiraIssueLink {
 
         foreach ($_issue in $Issue) {
             # Find the proper object for the Issue
-            $issueObj = Resolve-JiraIssueObject -InputObject $_issue -Credential $Credential
+            $issueObj = Resolve-JiraIssueObject -InputObject $_issue -Session $Session
 
             foreach ($_issueLink in $IssueLink) {
                 if ($_issueLink.inwardIssue) {
@@ -108,7 +107,7 @@ function Add-JiraIssueLink {
                     URI        = $resourceURi
                     Method     = "POST"
                     Body       = ConvertTo-Json -InputObject $body
-                    Credential = $Credential
+                    Session    = $Session
                 }
                 Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
                 if ($PSCmdlet.ShouldProcess($issueObj.Key)) {

--- a/JiraPS/Public/Add-JiraIssueWatcher.ps1
+++ b/JiraPS/Public/Add-JiraIssueWatcher.ps1
@@ -1,4 +1,4 @@
-﻿function Add-JiraIssueWatcher {
+function Add-JiraIssueWatcher {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( SupportsShouldProcess )]
     param(

--- a/JiraPS/Public/Add-JiraIssueWatcher.ps1
+++ b/JiraPS/Public/Add-JiraIssueWatcher.ps1
@@ -36,10 +36,9 @@
         [Object]
         $Issue,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     begin {
@@ -53,7 +52,7 @@
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] PSBoundParameters: $($PSBoundParameters | Out-String)"
 
         # Find the proper object for the Issue
-        $issueObj = Resolve-JiraIssueObject -InputObject $Issue -Credential $Credential
+        $issueObj = Resolve-JiraIssueObject -InputObject $Issue -Session $Session
 
         foreach ($_watcher in $Watcher) {
             Write-Verbose "[$($MyInvocation.MyCommand.Name)] Processing [$_watcher]"
@@ -63,7 +62,7 @@
                 URI        = $resourceURi -f $issueObj.RestURL
                 Method     = "POST"
                 Body       = '"{0}"' -f $_watcher
-                Credential = $Credential
+                Session    = $Session
             }
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
             if ($PSCmdlet.ShouldProcess($issueObj.Key, "Adding user '$_watcher' as watcher.")) {

--- a/JiraPS/Public/Add-JiraIssueWorklog.ps1
+++ b/JiraPS/Public/Add-JiraIssueWorklog.ps1
@@ -45,10 +45,9 @@ function Add-JiraIssueWorklog {
         [String]
         $VisibleRole = 'All Users',
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     begin {
@@ -62,7 +61,7 @@ function Add-JiraIssueWorklog {
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] PSBoundParameters: $($PSBoundParameters | Out-String)"
 
         # Find the proper object for the Issue
-        $issueObj = Resolve-JiraIssueObject -InputObject $Issue -Credential $Credential
+        $issueObj = Resolve-JiraIssueObject -InputObject $Issue -Session $Session
 
         if (-not $issueObj) {
             $errorMessage = @{
@@ -101,7 +100,7 @@ function Add-JiraIssueWorklog {
             URI        = $resourceURi -f $issueObj.RestURL
             Method     = "POST"
             Body       = ConvertTo-Json -InputObject $requestBody
-            Credential = $Credential
+            Session    = $Session
         }
         Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
         if ($PSCmdlet.ShouldProcess($issueObj.Key)) {

--- a/JiraPS/Public/Find-JiraFilter.ps1
+++ b/JiraPS/Public/Find-JiraFilter.ps1
@@ -76,9 +76,7 @@ function Find-JiraFilter {
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $searchURi = "$server/rest/api/latest/filter/search"
+        $searchURi = "rest/api/latest/filter/search"
 
         [String]$Fields = $Fields -join ','
     }

--- a/JiraPS/Public/Find-JiraFilter.ps1
+++ b/JiraPS/Public/Find-JiraFilter.ps1
@@ -68,9 +68,9 @@ function Find-JiraFilter {
         [Validateset('description','favourite_count','is_favourite','id','name','owner')]
         [string]$Sort,
 
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     begin {
@@ -90,20 +90,20 @@ function Find-JiraFilter {
                 expand = $Fields
             }
             Paging       = $true
-            Credential   = $Credential
+            Session      = $Session
         }
         if ($PSCmdlet.MyInvocation.BoundParameters.ContainsKey('AccountId')) {
             $parameter['GetParameter']['accountId'] = $AccountId
         }
         elseif ($PSCmdlet.ParameterSetName -eq 'ByOwner') {
-            $userObj = Get-JiraUser -InputObject $Owner -Credential $Credential -ErrorAction Stop
+            $userObj = Get-JiraUser -InputObject $Owner -Session $Session -ErrorAction Stop
             $parameter['GetParameter']['accountId'] = $userObj.AccountId
         }
         if ($PSCmdlet.MyInvocation.BoundParameters.ContainsKey('GroupName')) {
             $parameter['GetParameter']['groupName'] = $GroupName
         }
         if ($PSCmdlet.MyInvocation.BoundParameters.ContainsKey('Project')) {
-            $projectObj = Get-JiraProject -Project $Project -Credential $Credential -ErrorAction Stop
+            $projectObj = Get-JiraProject -Project $Project -Session $Session -ErrorAction Stop
             $parameter['GetParameter']['projectId'] = $projectObj.Id
         }
         if ($PSCmdlet.MyInvocation.BoundParameters.ContainsKey('Sort')) {

--- a/JiraPS/Public/Get-JiraComponent.ps1
+++ b/JiraPS/Public/Get-JiraComponent.ps1
@@ -36,10 +36,9 @@ function Get-JiraComponent {
         [Int[]]
         $ComponentId,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     begin {
@@ -64,7 +63,7 @@ function Get-JiraComponent {
                     $parameter = @{
                         URI        = $resourceURi -f "/project/$_project/components"
                         Method     = "GET"
-                        Credential = $Credential
+                        Session    = $Session
                     }
                     Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
                     $result = Invoke-JiraMethod @parameter
@@ -80,7 +79,7 @@ function Get-JiraComponent {
                     $parameter = @{
                         URI        = $resourceURi -f "/component/$_id"
                         Method     = "GET"
-                        Credential = $Credential
+                        Session    = $Session
                     }
                     Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
                     $result = Invoke-JiraMethod @parameter

--- a/JiraPS/Public/Get-JiraComponent.ps1
+++ b/JiraPS/Public/Get-JiraComponent.ps1
@@ -45,9 +45,7 @@ function Get-JiraComponent {
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/latest{0}"
+        $resourceURi = "rest/api/latest{0}"
     }
 
     process {

--- a/JiraPS/Public/Get-JiraConfigServer.ps1
+++ b/JiraPS/Public/Get-JiraConfigServer.ps1
@@ -1,9 +1,8 @@
 function Get-JiraConfigServer {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding()]
-    [OutputType([System.String])]
+    [OutputType([psobject])]
     param(
-        [Parameter( Mandatory )]
         [string]
         $Name = "Default"
     )
@@ -15,6 +14,16 @@ function Get-JiraConfigServer {
     process {
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] ParameterSetName: $($PsCmdlet.ParameterSetName)"
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] PSBoundParameters: $($PSBoundParameters | Out-String)"
+
+        if (-not $script:JiraServerConfigs.ContainsKey($Name)) {
+            $exception = ([System.InvalidOperationException]"Can not find $name configuration!")
+            $errorId = 'ConfigServer.NotFound'
+            $errorCategory = 'InvalidOperation'
+            $errorTarget = $_
+            $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
+            $errorItem.ErrorDetails = "Wrong value for Name parameter provided. Use Set-JiraConfigServer to solve the problem."
+            $PSCmdlet.ThrowTerminatingError($errorItem)
+        }
 
         return $script:JiraServerConfigs[$Name]
     }

--- a/JiraPS/Public/Get-JiraConfigServer.ps1
+++ b/JiraPS/Public/Get-JiraConfigServer.ps1
@@ -2,7 +2,11 @@ function Get-JiraConfigServer {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding()]
     [OutputType([System.String])]
-    param()
+    param(
+        [Parameter( Mandatory )]
+        [string]
+        $Name = "Default"
+    )
 
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
@@ -12,7 +16,7 @@ function Get-JiraConfigServer {
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] ParameterSetName: $($PsCmdlet.ParameterSetName)"
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] PSBoundParameters: $($PSBoundParameters | Out-String)"
 
-        return ($script:JiraServerUrl -replace "\/$", "")
+        return $script:JiraServerConfigs[$Name]
     }
 
     end {

--- a/JiraPS/Public/Get-JiraConfigServer.ps1
+++ b/JiraPS/Public/Get-JiraConfigServer.ps1
@@ -15,7 +15,9 @@ function Get-JiraConfigServer {
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] ParameterSetName: $($PsCmdlet.ParameterSetName)"
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] PSBoundParameters: $($PSBoundParameters | Out-String)"
 
-        if (-not $script:JiraServerConfigs.ContainsKey($Name)) {
+        $config = $script:JiraServerConfigs.$Name
+
+        if (-not $config) {
             $exception = ([System.InvalidOperationException]"Can not find $name configuration!")
             $errorId = 'ConfigServer.NotFound'
             $errorCategory = 'InvalidOperation'
@@ -25,7 +27,7 @@ function Get-JiraConfigServer {
             $PSCmdlet.ThrowTerminatingError($errorItem)
         }
 
-        return $script:JiraServerConfigs[$Name]
+        return $config
     }
 
     end {

--- a/JiraPS/Public/Get-JiraField.ps1
+++ b/JiraPS/Public/Get-JiraField.ps1
@@ -15,9 +15,7 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/latest/field"
+        $resourceURi = "rest/api/latest/field"
     }
 
     process {

--- a/JiraPS/Public/Get-JiraField.ps1
+++ b/JiraPS/Public/Get-JiraField.ps1
@@ -1,4 +1,4 @@
-﻿function Get-JiraField {
+function Get-JiraField {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( DefaultParameterSetName = '_All' )]
     param(

--- a/JiraPS/Public/Get-JiraField.ps1
+++ b/JiraPS/Public/Get-JiraField.ps1
@@ -6,10 +6,9 @@
         [String[]]
         $Field,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     begin {
@@ -27,7 +26,7 @@
                 $parameter = @{
                     URI        = $resourceURi
                     Method     = "GET"
-                    Credential = $Credential
+                    Session    = $Session
                 }
                 Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
                 $result = Invoke-JiraMethod @parameter
@@ -39,7 +38,7 @@
                     Write-Verbose "[$($MyInvocation.MyCommand.Name)] Processing [$_field]"
                     Write-Debug "[$($MyInvocation.MyCommand.Name)] Processing `$_field [$_field]"
 
-                    $allFields = Get-JiraField -Credential $Credential
+                    $allFields = Get-JiraField -Session $Session
 
                     Write-Output ($allFields | Where-Object -FilterScript {($_.Id -eq $_field) -or ($_.Name -like $_field)})
                 }

--- a/JiraPS/Public/Get-JiraFilter.ps1
+++ b/JiraPS/Public/Get-JiraFilter.ps1
@@ -51,9 +51,7 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/latest/filter/{0}"
+        $resourceURi = "rest/api/latest/filter/{0}"
     }
 
     process {

--- a/JiraPS/Public/Get-JiraFilter.ps1
+++ b/JiraPS/Public/Get-JiraFilter.ps1
@@ -1,4 +1,4 @@
-﻿function Get-JiraFilter {
+function Get-JiraFilter {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding(DefaultParameterSetName = 'ByFilterID')]
     param(

--- a/JiraPS/Public/Get-JiraFilter.ps1
+++ b/JiraPS/Public/Get-JiraFilter.ps1
@@ -42,10 +42,9 @@
         [Switch]
         $Favorite,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     begin {
@@ -67,7 +66,7 @@
                     $parameter = @{
                         URI        = $resourceURi -f $_id
                         Method     = "GET"
-                        Credential = $Credential
+                        Session    = $Session
                     }
                     Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
                     $result = Invoke-JiraMethod @parameter
@@ -88,14 +87,14 @@
                         Write-Verbose "[$($MyInvocation.MyCommand.Name)] ID is assumed to be [$thisId] via ToString()"
                     }
 
-                    Write-Output (Get-JiraFilter -Id $thisId -Credential $Credential)
+                    Write-Output (Get-JiraFilter -Id $thisId -Session $Session)
                 }
             }
             "MyFavorite" {
                 $parameter = @{
                     URI        = $resourceURi -f "favourite"
                     Method     = "GET"
-                    Credential = $Credential
+                    Session    = $Session
                 }
                 Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
                 $result = Invoke-JiraMethod @parameter

--- a/JiraPS/Public/Get-JiraFilterPermission.ps1
+++ b/JiraPS/Public/Get-JiraFilterPermission.ps1
@@ -13,10 +13,9 @@ function Get-JiraFilterPermission {
         [UInt32[]]
         $Id,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     begin {
@@ -37,7 +36,7 @@ function Get-JiraFilterPermission {
             $parameter = @{
                 URI        = $resourceURi -f $_filter.RestURL
                 Method     = "GET"
-                Credential = $Credential
+                Session    = $Session
             }
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
             $result = Invoke-JiraMethod @parameter

--- a/JiraPS/Public/Get-JiraGroup.ps1
+++ b/JiraPS/Public/Get-JiraGroup.ps1
@@ -17,9 +17,7 @@ function Get-JiraGroup {
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/latest/group?groupname={0}"
+        $resourceURi = "rest/api/latest/group?groupname={0}"
     }
 
     process {

--- a/JiraPS/Public/Get-JiraGroup.ps1
+++ b/JiraPS/Public/Get-JiraGroup.ps1
@@ -8,10 +8,9 @@ function Get-JiraGroup {
         [String[]]
         $GroupName,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     begin {
@@ -33,7 +32,7 @@ function Get-JiraGroup {
             $parameter = @{
                 URI        = $resourceURi -f $escapedGroupName
                 Method     = "GET"
-                Credential = $Credential
+                Session    = $Session
             }
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
             $result = Invoke-JiraMethod @parameter

--- a/JiraPS/Public/Get-JiraGroupMember.ps1
+++ b/JiraPS/Public/Get-JiraGroupMember.ps1
@@ -48,9 +48,7 @@ function Get-JiraGroupMember {
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/latest/group/member"
+        $resourceURi = "rest/api/latest/group/member"
 
         if ($PageSize -gt 50) {
             Write-Warning "JIRA's API may not properly support MaxResults values higher than 50 for this method. If you receive inconsistent results, do not pass the MaxResults parameter to this function to return all results."

--- a/JiraPS/Public/Get-JiraGroupMember.ps1
+++ b/JiraPS/Public/Get-JiraGroupMember.ps1
@@ -39,10 +39,9 @@ function Get-JiraGroupMember {
         [UInt32]
         $PageSize = $script:DefaultPageSize,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     begin {
@@ -59,7 +58,7 @@ function Get-JiraGroupMember {
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] ParameterSetName: $($PsCmdlet.ParameterSetName)"
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] PSBoundParameters: $($PSBoundParameters | Out-String)"
 
-        $groupObj = Get-JiraGroup -GroupName $Group -Credential $Credential -ErrorAction Stop
+        $groupObj = Get-JiraGroup -GroupName $Group -Session $Session -ErrorAction Stop
 
         foreach ($_group in $groupObj) {
             Write-Verbose "[$($MyInvocation.MyCommand.Name)] Processing [$_group]"
@@ -74,7 +73,7 @@ function Get-JiraGroupMember {
                 }
                 OutputType   = "JiraUser"
                 Paging       = $true
-                Credential   = $Credential
+                Session      = $Session
             }
             if ($IncludeInactive) {
                 $parameter["includeInactiveUsers"] = $true

--- a/JiraPS/Public/Get-JiraIssue.ps1
+++ b/JiraPS/Public/Get-JiraIssue.ps1
@@ -85,10 +85,9 @@ function Get-JiraIssue {
         [UInt32]
         $PageSize = $script:DefaultPageSize,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     begin {
@@ -119,7 +118,7 @@ function Get-JiraIssue {
                         URI          = $resourceURi -f $_key
                         Method       = "GET"
                         GetParameter = $getParameter
-                        Credential   = $Credential
+                        Session      = $Session
                     }
 
                     Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
@@ -134,7 +133,7 @@ function Get-JiraIssue {
                     Write-Verbose "[$($MyInvocation.MyCommand.Name)] Processing [$_issue]"
                     Write-Debug "[$($MyInvocation.MyCommand.Name)] Processing `$_issue [$_issue]"
 
-                    Write-Output (Get-JiraIssue -Key $_issue.Key -Fields $Fields -Credential $Credential)
+                    Write-Output (Get-JiraIssue -Key $_issue.Key -Fields $Fields -Session $Session)
                 }
             }
             'ByJQL' {
@@ -150,7 +149,7 @@ function Get-JiraIssue {
                     }
                     OutputType   = "JiraIssue"
                     Paging       = $true
-                    Credential   = $Credential
+                    Session      = $Session
                 }
                 if ($Fields) {
                     $parameter["GetParameter"]["fields"] = $Fields
@@ -174,7 +173,7 @@ function Get-JiraIssue {
                 Invoke-JiraMethod @parameter
             }
             'ByFilter' {
-                $filterObj = (Get-JiraFilter -InputObject $Filter -Credential $Credential -ErrorAction Stop).searchurl
+                $filterObj = (Get-JiraFilter -InputObject $Filter -Session $Session -ErrorAction Stop).searchurl
                 <#
                   #ToDo:CustomClass
                   Once we have custom classes, this will no longer be necessary
@@ -190,7 +189,7 @@ function Get-JiraIssue {
                     }
                     OutputType   = "JiraIssue"
                     Paging       = $true
-                    Credential   = $Credential
+                    Session      = $Session
 
                 }
                 if ($Fields) {

--- a/JiraPS/Public/Get-JiraIssue.ps1
+++ b/JiraPS/Public/Get-JiraIssue.ps1
@@ -94,10 +94,8 @@ function Get-JiraIssue {
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $searchURi = "$server/rest/api/latest/search"
-        $resourceURi = "$server/rest/api/latest/issue/{0}"
+        $searchURi = "rest/api/latest/search"
+        $resourceURi = "rest/api/latest/issue/{0}"
 
         [String]$Fields = $Fields -join ","
     }

--- a/JiraPS/Public/Get-JiraIssueAttachment.ps1
+++ b/JiraPS/Public/Get-JiraIssueAttachment.ps1
@@ -31,10 +31,9 @@ function Get-JiraIssueAttachment {
         [String]
         $FileName,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     begin {
@@ -46,7 +45,7 @@ function Get-JiraIssueAttachment {
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] PSBoundParameters: $($PSBoundParameters | Out-String)"
 
         # Find the proper object for the Issue
-        $issueObj = Resolve-JiraIssueObject -InputObject $Issue -Credential $Credential
+        $issueObj = Resolve-JiraIssueObject -InputObject $Issue -Session $Session
 
         if ($issueObj.Attachment) {
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Found Attachments on the Issue."

--- a/JiraPS/Public/Get-JiraIssueAttachmentFile.ps1
+++ b/JiraPS/Public/Get-JiraIssueAttachmentFile.ps1
@@ -27,10 +27,9 @@ function Get-JiraIssueAttachmentFile {
         [String]
         $Path,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     begin {
@@ -54,7 +53,7 @@ function Get-JiraIssueAttachmentFile {
                 Method     = 'Get'
                 Headers    = @{"Accept" = $_Attachment.MimeType}
                 OutFile    = $filename
-                Credential = $Credential
+                Session    = $Session
             }
 
             $result = Invoke-JiraMethod @iwParameters

--- a/JiraPS/Public/Get-JiraIssueComment.ps1
+++ b/JiraPS/Public/Get-JiraIssueComment.ps1
@@ -28,10 +28,9 @@ function Get-JiraIssueComment {
         [Object]
         $Issue,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     begin {
@@ -43,7 +42,7 @@ function Get-JiraIssueComment {
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] PSBoundParameters: $($PSBoundParameters | Out-String)"
 
         # Find the proper object for the Issue
-        $issueObj = Resolve-JiraIssueObject -InputObject $Issue -Credential $Credential
+        $issueObj = Resolve-JiraIssueObject -InputObject $Issue -Session $Session
 
         $parameter = @{
             URI          = "{0}/comment" -f $issueObj.RestURL
@@ -53,7 +52,7 @@ function Get-JiraIssueComment {
             }
             OutputType   = "JiraComment"
             Paging       = $true
-            Credential   = $Credential
+            Session      = $Session
         }
 
         Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"

--- a/JiraPS/Public/Get-JiraIssueCreateMetadata.ps1
+++ b/JiraPS/Public/Get-JiraIssueCreateMetadata.ps1
@@ -10,10 +10,9 @@ function Get-JiraIssueCreateMetadata {
         [String]
         $IssueType,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     begin {
@@ -26,7 +25,7 @@ function Get-JiraIssueCreateMetadata {
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] ParameterSetName: $($PsCmdlet.ParameterSetName)"
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] PSBoundParameters: $($PSBoundParameters | Out-String)"
 
-        $projectObj = Get-JiraProject -Project $Project -Credential $Credential -ErrorAction Stop
+        $projectObj = Get-JiraProject -Project $Project -Session $Session -ErrorAction Stop
         $issueTypeObj = $projectObj.IssueTypes | Where-Object -FilterScript {$_.Id -eq $IssueType -or $_.Name -eq $IssueType}
 
         if ($null -eq $issueTypeObj.Id)
@@ -42,7 +41,7 @@ function Get-JiraIssueCreateMetadata {
         $parameter = @{
             URI        = $resourceURi -f $projectObj.Id, $issueTypeObj.Id
             Method     = "GET"
-            Credential = $Credential
+            Session    = $Session
         }
         Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
         $result = Invoke-JiraMethod @parameter

--- a/JiraPS/Public/Get-JiraIssueCreateMetadata.ps1
+++ b/JiraPS/Public/Get-JiraIssueCreateMetadata.ps1
@@ -19,9 +19,7 @@ function Get-JiraIssueCreateMetadata {
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/latest/issue/createmeta?projectIds={0}&issuetypeIds={1}&expand=projects.issuetypes.fields"
+        $resourceURi = "rest/api/latest/issue/createmeta?projectIds={0}&issuetypeIds={1}&expand=projects.issuetypes.fields"
     }
 
     process {

--- a/JiraPS/Public/Get-JiraIssueEditMetadata.ps1
+++ b/JiraPS/Public/Get-JiraIssueEditMetadata.ps1
@@ -10,10 +10,9 @@ function Get-JiraIssueEditMetadata {
           Once we have custom classes, this should be a JiraPS.Issue
         #>
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     begin {
@@ -33,7 +32,7 @@ function Get-JiraIssueEditMetadata {
               When the Input is typecasted to a JiraPS.Issue, the `self` of the issue can be used
             #>
             Method     = "GET"
-            Credential = $Credential
+            Session    = $Session
         }
         Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
         $result = Invoke-JiraMethod @parameter

--- a/JiraPS/Public/Get-JiraIssueEditMetadata.ps1
+++ b/JiraPS/Public/Get-JiraIssueEditMetadata.ps1
@@ -19,9 +19,7 @@ function Get-JiraIssueEditMetadata {
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/latest/issue/{0}/editmeta"
+        $resourceURi = "rest/api/latest/issue/{0}/editmeta"
     }
 
     process {

--- a/JiraPS/Public/Get-JiraIssueLink.ps1
+++ b/JiraPS/Public/Get-JiraIssueLink.ps1
@@ -6,10 +6,9 @@ function Get-JiraIssueLink {
         [Int[]]
         $Id,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     begin {
@@ -40,7 +39,7 @@ function Get-JiraIssueLink {
             $parameter = @{
                 URI        = $resourceURi -f $_id
                 Method     = "GET"
-                Credential = $Credential
+                Session    = $Session
             }
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
             $result = Invoke-JiraMethod @parameter

--- a/JiraPS/Public/Get-JiraIssueLink.ps1
+++ b/JiraPS/Public/Get-JiraIssueLink.ps1
@@ -15,9 +15,7 @@ function Get-JiraIssueLink {
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/2/issueLink/{0}"
+        $resourceURi = "rest/api/2/issueLink/{0}"
     }
 
     process {

--- a/JiraPS/Public/Get-JiraIssueLinkType.ps1
+++ b/JiraPS/Public/Get-JiraIssueLinkType.ps1
@@ -27,10 +27,9 @@ function Get-JiraIssueLinkType {
         [Object]
         $LinkType,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     begin {
@@ -48,7 +47,7 @@ function Get-JiraIssueLinkType {
                 $parameter = @{
                     URI        = $resourceURi -f ""
                     Method     = "GET"
-                    Credential = $Credential
+                    Session    = $Session
                 }
                 Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
                 $result = Invoke-JiraMethod @parameter
@@ -62,7 +61,7 @@ function Get-JiraIssueLinkType {
                     $parameter = @{
                         URI        = $resourceURi -f "/$LinkType"
                         Method     = "GET"
-                        Credential = $Credential
+                        Session    = $Session
                     }
                     Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
                     $result = Invoke-JiraMethod @parameter
@@ -70,7 +69,7 @@ function Get-JiraIssueLinkType {
                     Write-Output (ConvertTo-JiraIssueLinkType -InputObject $result)
                 }
                 else {
-                    Write-Output (Get-JiraIssueLinkType -Credential $Credential | Where-Object { $_.Name -like $LinkType })
+                    Write-Output (Get-JiraIssueLinkType -Session $Session | Where-Object { $_.Name -like $LinkType })
                 }
             }
         }

--- a/JiraPS/Public/Get-JiraIssueLinkType.ps1
+++ b/JiraPS/Public/Get-JiraIssueLinkType.ps1
@@ -36,9 +36,7 @@ function Get-JiraIssueLinkType {
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/latest/issueLinkType{0}"
+        $resourceURi = "rest/api/latest/issueLinkType{0}"
     }
 
     process {

--- a/JiraPS/Public/Get-JiraIssueType.ps1
+++ b/JiraPS/Public/Get-JiraIssueType.ps1
@@ -15,9 +15,7 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/latest/issuetype"
+        $resourceURi = "rest/api/latest/issuetype"
     }
 
     process {

--- a/JiraPS/Public/Get-JiraIssueType.ps1
+++ b/JiraPS/Public/Get-JiraIssueType.ps1
@@ -1,4 +1,4 @@
-﻿function Get-JiraIssueType {
+function Get-JiraIssueType {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( DefaultParameterSetName = '_All' )]
     param(

--- a/JiraPS/Public/Get-JiraIssueType.ps1
+++ b/JiraPS/Public/Get-JiraIssueType.ps1
@@ -6,10 +6,9 @@
         [String[]]
         $IssueType,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     begin {
@@ -27,7 +26,7 @@
                 $parameter = @{
                     URI        = $resourceURi
                     Method     = "GET"
-                    Credential = $Credential
+                    Session    = $Session
                 }
                 Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
                 $result = Invoke-JiraMethod @parameter
@@ -39,7 +38,7 @@
                     Write-Verbose "[$($MyInvocation.MyCommand.Name)] Processing [$_issueType]"
                     Write-Debug "[$($MyInvocation.MyCommand.Name)] Processing `$_issueType [$_issueType]"
 
-                    $allIssueTypes = Get-JiraIssueType -Credential $Credential
+                    $allIssueTypes = Get-JiraIssueType -Session $Session
 
                     Write-Output ($allIssueTypes | Where-Object -FilterScript {$_.Id -eq $_issueType})
                     Write-Output ($allIssueTypes | Where-Object -FilterScript {$_.Name -like $_issueType})

--- a/JiraPS/Public/Get-JiraIssueWatcher.ps1
+++ b/JiraPS/Public/Get-JiraIssueWatcher.ps1
@@ -28,10 +28,9 @@
         [Object]
         $Issue,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     begin {
@@ -43,13 +42,13 @@
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] PSBoundParameters: $($PSBoundParameters | Out-String)"
 
         # Find the proper object for the Issue
-        $issueObj = Resolve-JiraIssueObject -InputObject $Issue -Credential $Credential
+        $issueObj = Resolve-JiraIssueObject -InputObject $Issue -Session $Session
 
         foreach ($issue in $issueObj) {
             $parameter = @{
                 URI        = "{0}/watchers" -f $issue.RestURL
                 Method     = "GET"
-                Credential = $Credential
+                Session    = $Session
             }
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
             if ($result = Invoke-JiraMethod @parameter) {

--- a/JiraPS/Public/Get-JiraIssueWatcher.ps1
+++ b/JiraPS/Public/Get-JiraIssueWatcher.ps1
@@ -1,4 +1,4 @@
-﻿function Get-JiraIssueWatcher {
+function Get-JiraIssueWatcher {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding()]
     param(

--- a/JiraPS/Public/Get-JiraPriority.ps1
+++ b/JiraPS/Public/Get-JiraPriority.ps1
@@ -6,10 +6,9 @@ function Get-JiraPriority {
         [Int[]]
         $Id,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     begin {
@@ -27,7 +26,7 @@ function Get-JiraPriority {
                 $parameter = @{
                     URI        = $resourceURi -f ""
                     Method     = "GET"
-                    Credential = $Credential
+                    Session    = $Session
                 }
                 Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
                 $result = Invoke-JiraMethod @parameter
@@ -42,7 +41,7 @@ function Get-JiraPriority {
                     $parameter = @{
                         URI        = $resourceURi -f "/$_id"
                         Method     = "GET"
-                        Credential = $Credential
+                        Session    = $Session
                     }
                     Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
                     $result = Invoke-JiraMethod @parameter

--- a/JiraPS/Public/Get-JiraPriority.ps1
+++ b/JiraPS/Public/Get-JiraPriority.ps1
@@ -15,9 +15,7 @@ function Get-JiraPriority {
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/latest/priority{0}"
+        $resourceURi = "rest/api/latest/priority{0}"
     }
 
     process {

--- a/JiraPS/Public/Get-JiraProject.ps1
+++ b/JiraPS/Public/Get-JiraProject.ps1
@@ -6,10 +6,9 @@ function Get-JiraProject {
         [String[]]
         $Project,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     begin {
@@ -27,7 +26,7 @@ function Get-JiraProject {
                 $parameter = @{
                     URI        = $resourceURi -f ""
                     Method     = "GET"
-                    Credential = $Credential
+                    Session    = $Session
                 }
                 Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
                 $result = Invoke-JiraMethod @parameter
@@ -42,7 +41,7 @@ function Get-JiraProject {
                     $parameter = @{
                         URI        = $resourceURi -f "/$($_project)"
                         Method     = "GET"
-                        Credential = $Credential
+                        Session    = $Session
                     }
                     Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
                     $result = Invoke-JiraMethod @parameter

--- a/JiraPS/Public/Get-JiraProject.ps1
+++ b/JiraPS/Public/Get-JiraProject.ps1
@@ -15,9 +15,7 @@ function Get-JiraProject {
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/latest/project{0}?expand=description,lead,issueTypes,url,projectKeys"
+        $resourceURi = "rest/api/latest/project{0}?expand=description,lead,issueTypes,url,projectKeys"
     }
 
     process {

--- a/JiraPS/Public/Get-JiraRemoteLink.ps1
+++ b/JiraPS/Public/Get-JiraRemoteLink.ps1
@@ -31,10 +31,9 @@ function Get-JiraRemoteLink {
         [Int]
         $LinkId,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     begin {
@@ -50,7 +49,7 @@ function Get-JiraRemoteLink {
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Processing `$_issue [$_issue]"
 
             # Find the proper object for the Issue
-            $issueObj = Resolve-JiraIssueObject -InputObject $_issue -Credential $Credential
+            $issueObj = Resolve-JiraIssueObject -InputObject $_issue -Session $Session
 
             $urlAppendix = ""
             if ($LinkId) {
@@ -60,7 +59,7 @@ function Get-JiraRemoteLink {
             $parameter = @{
                 URI        = "{0}/remotelink{1}" -f $issueObj.RestUrl, $urlAppendix
                 Method     = "GET"
-                Credential = $Credential
+                Session    = $Session
             }
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
             $result = Invoke-JiraMethod @parameter

--- a/JiraPS/Public/Get-JiraServerInformation.ps1
+++ b/JiraPS/Public/Get-JiraServerInformation.ps1
@@ -2,10 +2,9 @@ function Get-JiraServerInformation {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding()]
     param(
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     begin {

--- a/JiraPS/Public/Get-JiraServerInformation.ps1
+++ b/JiraPS/Public/Get-JiraServerInformation.ps1
@@ -11,9 +11,7 @@ function Get-JiraServerInformation {
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/latest/serverInfo"
+        $resourceURi = "rest/api/latest/serverInfo"
     }
 
     process {

--- a/JiraPS/Public/Get-JiraServerInformation.ps1
+++ b/JiraPS/Public/Get-JiraServerInformation.ps1
@@ -21,7 +21,7 @@ function Get-JiraServerInformation {
         $parameter = @{
             URI        = $resourceURi
             Method     = "GET"
-            Credential = $Credential
+            Session    = $Session
         }
         Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
         $result = Invoke-JiraMethod @parameter

--- a/JiraPS/Public/Get-JiraUser.ps1
+++ b/JiraPS/Public/Get-JiraUser.ps1
@@ -89,7 +89,7 @@ function Get-JiraUser {
                     Write-Debug "[$($MyInvocation.MyCommand.Name)] Processing `$user [$user]"
 
                     $parameter = @{
-                        URI        = $resourceURi -f $user
+                        URI        = $resourceURi -f [System.Uri]::EscapeDataString($user)
                         Method     = "GET"
                         Session    = $Session
                     }

--- a/JiraPS/Public/Get-JiraUser.ps1
+++ b/JiraPS/Public/Get-JiraUser.ps1
@@ -37,11 +37,9 @@ function Get-JiraUser {
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $selfResourceUri = "$server/rest/api/latest/myself"
-        $searchResourceUri = "$server/rest/api/latest/user/search?username={0}"
-        $exactResourceUri = "$server/rest/api/latest/user?username={0}"
+        $selfResourceUri = "rest/api/latest/myself"
+        $searchResourceUri = "rest/api/latest/user/search?username={0}"
+        $exactResourceUri = "rest/api/latest/user?username={0}"
 
         if ($IncludeInactive) {
             $searchResourceUri += "&includeInactive=true"

--- a/JiraPS/Public/Get-JiraUser.ps1
+++ b/JiraPS/Public/Get-JiraUser.ps1
@@ -28,10 +28,9 @@ function Get-JiraUser {
         [UInt64]
         $Skip = 0,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     begin {
@@ -70,7 +69,7 @@ function Get-JiraUser {
                 $parameter = @{
                     URI        = $resourceURi
                     Method     = "GET"
-                    Credential = $Credential
+                    Session    = $Session
                 }
                 Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
                 $result = Invoke-JiraMethod @parameter
@@ -92,7 +91,7 @@ function Get-JiraUser {
                     $parameter = @{
                         URI        = $resourceURi -f $user
                         Method     = "GET"
-                        Credential = $Credential
+                        Session    = $Session
                     }
                     Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
                     if ($users = Invoke-JiraMethod @parameter) {
@@ -100,7 +99,7 @@ function Get-JiraUser {
                             $parameter = @{
                                 URI        = "{0}&expand=groups" -f $item.self
                                 Method     = "GET"
-                                Credential = $Credential
+                                Session    = $Session
                             }
                             Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
                             $result = Invoke-JiraMethod @parameter

--- a/JiraPS/Public/Get-JiraVersion.ps1
+++ b/JiraPS/Public/Get-JiraVersion.ps1
@@ -38,10 +38,9 @@
         [UInt32]
         $PageSize = $script:DefaultPageSize,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     begin {
@@ -71,7 +70,7 @@
                     $parameter = @{
                         URI        = $resourceURi -f "version/$_id"
                         Method     = "GET"
-                        Credential = $Credential
+                        Session    = $Session
                     }
                     Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
                     $result = Invoke-JiraMethod @parameter
@@ -84,7 +83,7 @@
                     Write-Verbose "[$($MyInvocation.MyCommand.Name)] Processing [$_project]"
                     Write-Debug "[$($MyInvocation.MyCommand.Name)] Processing `$_project [$_project]"
 
-                    $projectData = Get-JiraProject -Project $_project -Credential $Credential
+                    $projectData = Get-JiraProject -Project $_project -Session $Session
 
                     $parameter = @{
                         URI          = $resourceURi -f "project/$($projectData.key)/version"
@@ -95,7 +94,7 @@
                         }
                         Paging       = $true
                         OutputType   = "JiraVersion"
-                        Credential   = $Credential
+                        Session      = $Session
                     }
                     # Paging
                     ($PSCmdlet.PagingParameters | Get-Member -MemberType Property).Name | ForEach-Object {

--- a/JiraPS/Public/Get-JiraVersion.ps1
+++ b/JiraPS/Public/Get-JiraVersion.ps1
@@ -1,4 +1,4 @@
-﻿function Get-JiraVersion {
+function Get-JiraVersion {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( SupportsPaging, DefaultParameterSetName = 'byId' )]
     param(

--- a/JiraPS/Public/Get-JiraVersion.ps1
+++ b/JiraPS/Public/Get-JiraVersion.ps1
@@ -47,9 +47,7 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/latest/{0}"
+        $resourceURi = "rest/api/latest/{0}"
     }
 
     process {

--- a/JiraPS/Public/Invoke-JiraMethod.ps1
+++ b/JiraPS/Public/Invoke-JiraMethod.ps1
@@ -3,7 +3,7 @@ function Invoke-JiraMethod {
     [CmdletBinding( SupportsPaging )]
     param(
         [Parameter( Mandatory )]
-        [psobject]
+        [uri]
         $URI,
 
         [Microsoft.PowerShell.Commands.WebRequestMethod]
@@ -75,11 +75,6 @@ function Invoke-JiraMethod {
         #endregion
 
         #region Manage URI
-
-        # if provided value for URI is string - convert it to an instance of URI
-        if ($URI -is [string]) {
-            $URI = New-Object -TypeName "System.Uri" -ArgumentList @($URI, [System.UriKind]::RelativeOrAbsolute)
-        }
 
         # if instance of URI is relative path - convert it to abosolute URI using session's ServerUri as base URI
         if (-not $URI.IsAbsoluteUri) {

--- a/JiraPS/Public/Invoke-JiraMethod.ps1
+++ b/JiraPS/Public/Invoke-JiraMethod.ps1
@@ -82,8 +82,9 @@ function Invoke-JiraMethod {
         }
 
         # if instance of URI is relative path - convert it to abosolute URI using session's ServerUri as base URI
-        if ($URI.UriKind -eq [System.UriKind]::Relative) {
-            $URI = New-Object -TypeName uri -ArgumentList @($Session.ServerConfig.Server, $URI)
+        if (-not $URI.IsAbsoluteUri) {
+            $serverUri = New-Object -TypeName "System.Uri" -ArgumentList @($Session.ServerConfig.Server)
+            $URI = New-Object -TypeName "System.Uri" -ArgumentList @($serverUri, $URI)
         }
 
         # Amend query from URI with GetParameter

--- a/JiraPS/Public/Invoke-JiraMethod.ps1
+++ b/JiraPS/Public/Invoke-JiraMethod.ps1
@@ -140,7 +140,8 @@ function Invoke-JiraMethod {
             else {
                 # Encode Body to preserve special chars
                 # http://stackoverflow.com/questions/15290185/invoke-webrequest-issue-with-special-characters-in-json
-                $splatParameters["Body"] = [System.Text.Encoding]::UTF8.GetBytes($Body)
+                $bodyBytes = [System.Text.Encoding]::UTF8.GetBytes($Body)
+                $splatParameters["Body"] = $bodyBytes
             }
         }
 

--- a/JiraPS/Public/Move-JiraVersion.ps1
+++ b/JiraPS/Public/Move-JiraVersion.ps1
@@ -65,9 +65,7 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $versionResourceUri = "$server/rest/api/latest/version/{0}/move"
+        $versionResourceUri = "rest/api/latest/version/{0}/move"
     }
 
     process {

--- a/JiraPS/Public/Move-JiraVersion.ps1
+++ b/JiraPS/Public/Move-JiraVersion.ps1
@@ -56,10 +56,9 @@
         [Object]
         $After,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     begin {
@@ -80,7 +79,7 @@
             'ByAfter' {
                 $afterSelfUri = ''
                 if ($After -is [Int]) {
-                    $versionObj = Get-JiraVersion -Id $After -Credential $Credential -ErrorAction Stop
+                    $versionObj = Get-JiraVersion -Id $After -Session $Session -ErrorAction Stop
                     $afterSelfUri = $versionObj.RestUrl
                 }
                 else {
@@ -101,7 +100,7 @@
             URI        = $versionResourceUri -f $versionId
             Method     = "POST"
             Body       = ConvertTo-Json $requestBody
-            Credential = $Credential
+            Session    = $Session
         }
 
         Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"

--- a/JiraPS/Public/Move-JiraVersion.ps1
+++ b/JiraPS/Public/Move-JiraVersion.ps1
@@ -1,4 +1,4 @@
-﻿function Move-JiraVersion {
+function Move-JiraVersion {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( DefaultParameterSetName = 'ByAfter' )]
     param(

--- a/JiraPS/Public/New-JiraFilter.ps1
+++ b/JiraPS/Public/New-JiraFilter.ps1
@@ -30,9 +30,7 @@ function New-JiraFilter {
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/latest/filter"
+        $resourceURi = "rest/api/latest/filter"
     }
 
     process {

--- a/JiraPS/Public/New-JiraFilter.ps1
+++ b/JiraPS/Public/New-JiraFilter.ps1
@@ -21,10 +21,9 @@ function New-JiraFilter {
         [Switch]
         $Favorite,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     begin {
@@ -50,7 +49,7 @@ function New-JiraFilter {
             URI        = $resourceURi
             Method     = "POST"
             Body       = ConvertTo-Json -InputObject $requestBody
-            Credential = $Credential
+            Session    = $Session
         }
         Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
         if ($PSCmdlet.ShouldProcess($Name, "Creating new Filter")) {

--- a/JiraPS/Public/New-JiraGroup.ps1
+++ b/JiraPS/Public/New-JiraGroup.ps1
@@ -1,4 +1,4 @@
-﻿function New-JiraGroup {
+function New-JiraGroup {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( SupportsShouldProcess )]
     param(

--- a/JiraPS/Public/New-JiraGroup.ps1
+++ b/JiraPS/Public/New-JiraGroup.ps1
@@ -7,10 +7,9 @@
         [String[]]
         $GroupName,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     begin {
@@ -35,7 +34,7 @@
                 URI        = $resourceURi
                 Method     = "POST"
                 Body       = ConvertTo-Json -InputObject $requestBody
-                Credential = $Credential
+                Session    = $Session
             }
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
             if ($PSCmdlet.ShouldProcess($GroupName, "Creating group [$GroupName] to JIRA")) {

--- a/JiraPS/Public/New-JiraGroup.ps1
+++ b/JiraPS/Public/New-JiraGroup.ps1
@@ -16,9 +16,7 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/latest/group"
+        $resourceURi = "rest/api/latest/group"
     }
 
     process {

--- a/JiraPS/Public/New-JiraIssue.ps1
+++ b/JiraPS/Public/New-JiraIssue.ps1
@@ -56,11 +56,10 @@ function New-JiraIssue {
     }
 
     process {
-        $server = Get-JiraConfigServer -ErrorAction Stop -Debug:$false
 
         $createmeta = Get-JiraIssueCreateMetadata -Project $Project -IssueType $IssueType -Credential $Credential -ErrorAction Stop -Debug:$false
 
-        $resourceURi = "$server/rest/api/latest/issue"
+        $resourceURi = "rest/api/latest/issue"
 
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] ParameterSetName: $($PsCmdlet.ParameterSetName)"
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] PSBoundParameters: $($PSBoundParameters | Out-String)"

--- a/JiraPS/Public/New-JiraSession.ps1
+++ b/JiraPS/Public/New-JiraSession.ps1
@@ -15,7 +15,7 @@ function New-JiraSession {
         $SessionName = "Default",
 
         [string]
-        $ServerName
+        $ServerName = "Default"
     )
 
     begin {
@@ -23,7 +23,7 @@ function New-JiraSession {
 
         $serverConfig = Get-JiraConfigServer -Name $ServerName
 
-        $resourceURi = New-Object -TypeName uri -ArgumentList $serverConfig.Server,"rest/api/2/mypermissions"
+        $resourceURi = "rest/api/2/mypermissions"
     }
 
     process {

--- a/JiraPS/Public/New-JiraSession.ps1
+++ b/JiraPS/Public/New-JiraSession.ps1
@@ -30,7 +30,7 @@ function New-JiraSession {
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] ParameterSetName: $($PsCmdlet.ParameterSetName)"
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] PSBoundParameters: $($PSBoundParameters | Out-String)"
 
-        $session = ConvertTo-JiraSession -Name $SessionName -Credential $Credential -ServerConfig $serverConfig
+        $session = ConvertTo-JiraSession -Name $SessionName -Session $Session -ServerConfig $serverConfig
 
         $parameter = @{
             URI          = $resourceURi

--- a/JiraPS/Public/New-JiraSession.ps1
+++ b/JiraPS/Public/New-JiraSession.ps1
@@ -30,7 +30,7 @@ function New-JiraSession {
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] ParameterSetName: $($PsCmdlet.ParameterSetName)"
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] PSBoundParameters: $($PSBoundParameters | Out-String)"
 
-        $session = ConvertTo-JiraSession -Name $SessionName -Session $Session -ServerConfig $serverConfig
+        $session = ConvertTo-JiraSession -Name $SessionName -Credential $Credential -ServerConfig $serverConfig
 
         $parameter = @{
             URI          = $resourceURi

--- a/JiraPS/Public/New-JiraUser.ps1
+++ b/JiraPS/Public/New-JiraUser.ps1
@@ -26,9 +26,7 @@ function New-JiraUser {
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/latest/user"
+        $resourceURi = "rest/api/latest/user"
     }
 
     process {

--- a/JiraPS/Public/New-JiraUser.ps1
+++ b/JiraPS/Public/New-JiraUser.ps1
@@ -17,10 +17,9 @@ function New-JiraUser {
         [Boolean]
         $Notify = $true,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     begin {
@@ -51,7 +50,7 @@ function New-JiraUser {
             URI        = $resourceURi
             Method     = "POST"
             Body       = ConvertTo-Json -InputObject $requestBody
-            Credential = $Credential
+            Session    = $Session
         }
         Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
         if ($PSCmdlet.ShouldProcess($UserName, "Creating new User on JIRA")) {

--- a/JiraPS/Public/New-JiraVersion.ps1
+++ b/JiraPS/Public/New-JiraVersion.ps1
@@ -79,10 +79,9 @@
         [DateTime]
         $StartDate,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     begin {
@@ -138,7 +137,7 @@
                     }
                 }
                 else {
-                    $requestBody["projectId"] = (Get-JiraProject $Project -Credential $Credential).Id
+                    $requestBody["projectId"] = (Get-JiraProject $Project -Session $Session).Id
                 }
             }
         }
@@ -147,7 +146,7 @@
             URI        = $resourceURi
             Method     = "POST"
             Body       = ConvertTo-Json -InputObject $requestBody
-            Credential = $Credential
+            Session    = $Session
         }
         Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
         if ($PSCmdlet.ShouldProcess($Name, "Creating new Version on JIRA")) {

--- a/JiraPS/Public/New-JiraVersion.ps1
+++ b/JiraPS/Public/New-JiraVersion.ps1
@@ -88,9 +88,7 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/latest/version"
+        $resourceURi = "rest/api/latest/version"
     }
 
     process {

--- a/JiraPS/Public/New-JiraVersion.ps1
+++ b/JiraPS/Public/New-JiraVersion.ps1
@@ -1,4 +1,4 @@
-﻿function New-JiraVersion {
+function New-JiraVersion {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( SupportsShouldProcess, DefaultParameterSetName = 'byObject' )]
     param(

--- a/JiraPS/Public/Remove-JiraFilter.ps1
+++ b/JiraPS/Public/Remove-JiraFilter.ps1
@@ -12,10 +12,9 @@ function Remove-JiraFilter {
         [UInt32[]]
         $Id,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     begin {
@@ -36,7 +35,7 @@ function Remove-JiraFilter {
             $parameter = @{
                 URI        = $filter.RestURL
                 Method     = "DELETE"
-                Credential = $Credential
+                Session    = $Session
             }
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
             if ($PSCmdlet.ShouldProcess($filter.Name, "Deleting Filter")) {

--- a/JiraPS/Public/Remove-JiraFilterPermission.ps1
+++ b/JiraPS/Public/Remove-JiraFilterPermission.ps1
@@ -1,4 +1,4 @@
-﻿function Remove-JiraFilterPermission {
+function Remove-JiraFilterPermission {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( SupportsShouldProcess, DefaultParameterSetName = 'ByFilterId' )]
     param(

--- a/JiraPS/Public/Remove-JiraFilterPermission.ps1
+++ b/JiraPS/Public/Remove-JiraFilterPermission.ps1
@@ -44,10 +44,9 @@
         [UInt32[]]
         $PermissionId,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     begin {
@@ -71,7 +70,7 @@
             $parameter = @{
                 URI        = "{0}/permission/{1}" -f $Filter.RestURL, $_permissionId
                 Method     = "DELETE"
-                Credential = $Credential
+                Session    = $Session
             }
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
             if ($PSCmdlet.ShouldProcess($InputObject.Type, "Remove Permission")) {

--- a/JiraPS/Public/Remove-JiraGroup.ps1
+++ b/JiraPS/Public/Remove-JiraGroup.ps1
@@ -28,10 +28,9 @@
         [Object[]]
         $Group,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty,
+        [Alias("Credential")]
+        [psobject]
+        $Session,
 
         [Switch]
         $Force
@@ -57,12 +56,12 @@
             Write-Verbose "[$($MyInvocation.MyCommand.Name)] Processing [$_group]"
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Processing `$_group [$_group]"
 
-            $groupObj = Get-JiraGroup -GroupName $_group -Credential $Credential -ErrorAction Stop
+            $groupObj = Get-JiraGroup -GroupName $_group -Session $Session -ErrorAction Stop
 
             $parameter = @{
                 URI        = $resourceURi -f $groupObj.Name
                 Method     = "DELETE"
-                Credential = $Credential
+                Session    = $Session
             }
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
             if ($PSCmdlet.ShouldProcess($groupObj.Name, "Remove group")) {

--- a/JiraPS/Public/Remove-JiraGroup.ps1
+++ b/JiraPS/Public/Remove-JiraGroup.ps1
@@ -1,4 +1,4 @@
-﻿function Remove-JiraGroup {
+function Remove-JiraGroup {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( SupportsShouldProcess, ConfirmImpact = 'High' )]
     param(

--- a/JiraPS/Public/Remove-JiraGroup.ps1
+++ b/JiraPS/Public/Remove-JiraGroup.ps1
@@ -40,9 +40,7 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/latest/group?groupname={0}"
+        $resourceURi = "rest/api/latest/group?groupname={0}"
 
         if ($Force) {
             Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] -Force was passed. Backing up current ConfirmPreference [$ConfirmPreference] and setting to None"

--- a/JiraPS/Public/Remove-JiraGroupMember.ps1
+++ b/JiraPS/Public/Remove-JiraGroupMember.ps1
@@ -54,10 +54,9 @@ function Remove-JiraGroupMember {
         [Object[]]
         $User,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty,
+        [Alias("Credential")]
+        [psobject]
+        $Session,
 
         [Switch]
         $PassThru,
@@ -86,21 +85,21 @@ function Remove-JiraGroupMember {
             Write-Verbose "[$($MyInvocation.MyCommand.Name)] Processing [$_group]"
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Processing `$_group [$_group]"
 
-            $groupObj = Get-JiraGroup -GroupName $_group -Credential $Credential -ErrorAction Stop
-            # $groupMembers = (Get-JiraGroupMember -Group $_group -Credential $Credential -ErrorAction Stop).Name
+            $groupObj = Get-JiraGroup -GroupName $_group -Session $Session -ErrorAction Stop
+            # $groupMembers = (Get-JiraGroupMember -Group $_group -Session $Session -ErrorAction Stop).Name
 
             foreach ($_user in $User) {
                 Write-Verbose "[$($MyInvocation.MyCommand.Name)] Processing [$_user]"
                 Write-Debug "[$($MyInvocation.MyCommand.Name)] Processing `$_user [$_user]"
 
-                $userObj = Resolve-JiraUser -InputObject $_user -Exact -Credential $Credential -ErrorAction Stop
+                $userObj = Resolve-JiraUser -InputObject $_user -Exact -Session $Session -ErrorAction Stop
 
                 # if ($groupMembers -contains $userObj.Name) {
                 # TODO: test what jira says
                 $parameter = @{
                     URI        = $resourceURi -f $groupObj.Name, $userObj.Name
                     Method     = "DELETE"
-                    Credential = $Credential
+                    Session    = $Session
                 }
                 Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
                 if ($PSCmdlet.ShouldProcess($groupObj.Name, "Remove $($userObj.Name) from group")) {
@@ -110,7 +109,7 @@ function Remove-JiraGroupMember {
             }
 
             if ($PassThru) {
-                Write-Output (Get-JiraGroup -InputObject $groupObj -Credential $Credential)
+                Write-Output (Get-JiraGroup -InputObject $groupObj -Session $Session)
             }
         }
     }

--- a/JiraPS/Public/Remove-JiraGroupMember.ps1
+++ b/JiraPS/Public/Remove-JiraGroupMember.ps1
@@ -69,9 +69,7 @@ function Remove-JiraGroupMember {
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/latest/group/user?groupname={0}&username={1}"
+        $resourceURi = "rest/api/latest/group/user?groupname={0}&username={1}"
 
         if ($Force) {
             Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] -Force was passed. Backing up current ConfirmPreference [$ConfirmPreference] and setting to None"

--- a/JiraPS/Public/Remove-JiraIssue.ps1
+++ b/JiraPS/Public/Remove-JiraIssue.ps1
@@ -49,9 +49,7 @@ function Remove-JiraIssue {
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/latest/issue/{0}?deleteSubtasks={1}"
+        $resourceURi = "rest/api/latest/issue/{0}?deleteSubtasks={1}"
 
         if ($Force) {
             Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] -Force was passed. Backing up current ConfirmPreference [$ConfirmPreference] and setting to None"

--- a/JiraPS/Public/Remove-JiraIssue.ps1
+++ b/JiraPS/Public/Remove-JiraIssue.ps1
@@ -38,9 +38,9 @@ function Remove-JiraIssue {
         [Alias("deleteSubtasks")]
         $IncludeSubTasks,
 
-        [System.Management.Automation.CredentialAttribute()]
-        [System.Management.Automation.PSCredential]
-        $Credential = [System.Management.Automation.PSCredential]::Empty,
+        [Alias("Credential")]
+        [psobject]
+        $Session,
 
         [Switch]
         $Force

--- a/JiraPS/Public/Remove-JiraIssue.ps1
+++ b/JiraPS/Public/Remove-JiraIssue.ps1
@@ -71,7 +71,7 @@ function Remove-JiraIssue {
         foreach ($issueItem in $PrimaryIterator) {
 
             if ($PsCmdlet.ParameterSetName -eq "ByIssueId") {
-                $_issue = Get-JiraIssue -Key $issueItem -Credential $Credential -ErrorAction Stop
+                $_issue = Get-JiraIssue -Key $issueItem -Session $Session -ErrorAction Stop
             } Else {
                 $_issue = $issueItem
             }
@@ -84,7 +84,7 @@ function Remove-JiraIssue {
             $parameter = @{
                 URI        = $resourceURi -f $_issue.Key,$IncludeSubTasks
                 Method     = "DELETE"
-                Credential = $Credential
+                Session    = $Session
                 Cmdlet = $PsCmdlet
             }
 

--- a/JiraPS/Public/Remove-JiraIssueAttachment.ps1
+++ b/JiraPS/Public/Remove-JiraIssueAttachment.ps1
@@ -50,9 +50,7 @@ function Remove-JiraIssueAttachment {
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/latest/attachment/{0}"
+        $resourceURi = "rest/api/latest/attachment/{0}"
 
         if ($Force) {
             Write-DebugMessage "[Remove-JiraGroupMember] -Force was passed. Backing up current ConfirmPreference [$ConfirmPreference] and setting to None"

--- a/JiraPS/Public/Remove-JiraIssueAttachment.ps1
+++ b/JiraPS/Public/Remove-JiraIssueAttachment.ps1
@@ -38,10 +38,9 @@ function Remove-JiraIssueAttachment {
         [String[]]
         $FileName,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty,
+        [Alias("Credential")]
+        [psobject]
+        $Session,
 
         [Switch]
         $Force
@@ -72,7 +71,7 @@ function Remove-JiraIssueAttachment {
                     $parameter = @{
                         URI        = $resourceURi -f $_id
                         Method     = "DELETE"
-                        Credential = $Credential
+                        Session    = $Session
                     }
                     Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
                     if ($PSCmdlet.ShouldProcess($thisUrl, "Removing an attachment")) {
@@ -95,8 +94,8 @@ function Remove-JiraIssueAttachment {
                 }
 
                 # Find the proper object for the Issue
-                $issueObj = Resolve-JiraIssueObject -InputObject $Issue -Credential $Credential
-                $attachments = Get-JiraIssueAttachment -Issue $IssueObj -Credential $Credential -ErrorAction Stop
+                $issueObj = Resolve-JiraIssueObject -InputObject $Issue -Session $Session
+                $attachments = Get-JiraIssueAttachment -Issue $IssueObj -Session $Session -ErrorAction Stop
 
                 if ($FileName) {
                     $_attachments = @()
@@ -113,7 +112,7 @@ function Remove-JiraIssueAttachment {
                     $parameter = @{
                         URI        = $resourceURi -f $attachment.Id
                         Method     = "DELETE"
-                        Credential = $Credential
+                        Session    = $Session
                     }
                     Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
                     if ($PSCmdlet.ShouldProcess($Issue.Key, "Removing attachment '$($attachment.FileName)'")) {

--- a/JiraPS/Public/Remove-JiraIssueLink.ps1
+++ b/JiraPS/Public/Remove-JiraIssueLink.ps1
@@ -30,10 +30,9 @@ function Remove-JiraIssueLink {
         [Object[]]
         $IssueLink,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     begin {
@@ -63,7 +62,7 @@ function Remove-JiraIssueLink {
             $parameter = @{
                 URI        = $resourceURi -f $link.id
                 Method     = "DELETE"
-                Credential = $Credential
+                Session    = $Session
             }
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
             if ($PSCmdlet.ShouldProcess($link.id, "Remove IssueLink")) {

--- a/JiraPS/Public/Remove-JiraIssueLink.ps1
+++ b/JiraPS/Public/Remove-JiraIssueLink.ps1
@@ -39,9 +39,7 @@ function Remove-JiraIssueLink {
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/latest/issueLink/{0}"
+        $resourceURi = "rest/api/latest/issueLink/{0}"
     }
 
     process {

--- a/JiraPS/Public/Remove-JiraIssueWatcher.ps1
+++ b/JiraPS/Public/Remove-JiraIssueWatcher.ps1
@@ -1,4 +1,4 @@
-﻿function Remove-JiraIssueWatcher {
+function Remove-JiraIssueWatcher {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( SupportsShouldProcess )]
     param(

--- a/JiraPS/Public/Remove-JiraIssueWatcher.ps1
+++ b/JiraPS/Public/Remove-JiraIssueWatcher.ps1
@@ -32,10 +32,9 @@
         [Object]
         $Issue,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     begin {
@@ -47,7 +46,7 @@
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] PSBoundParameters: $($PSBoundParameters | Out-String)"
 
         # Find the proper object for the Issue
-        $issueObj = Resolve-JiraIssueObject -InputObject $Issue -Credential $Credential
+        $issueObj = Resolve-JiraIssueObject -InputObject $Issue -Session $Session
 
         foreach ($username in $Watcher) {
             Write-Verbose "[$($MyInvocation.MyCommand.Name)] Processing [$username]"
@@ -56,7 +55,7 @@
             $parameter = @{
                 URI        = "{0}/watchers?username={1}" -f $issueObj.RestURL, $username
                 Method     = "DELETE"
-                Credential = $Credential
+                Session    = $Session
             }
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
             if ($PSCmdlet.ShouldProcess($IssueObj.Key, "Removing watcher '$($username)'")) {

--- a/JiraPS/Public/Remove-JiraRemoteLink.ps1
+++ b/JiraPS/Public/Remove-JiraRemoteLink.ps1
@@ -44,9 +44,7 @@ function Remove-JiraRemoteLink {
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/latest/issue/{0}/remotelink/{1}"
+        $resourceURi = "rest/api/latest/issue/{0}/remotelink/{1}"
 
         if ($Force) {
             Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] -Force was passed. Backing up current ConfirmPreference [$ConfirmPreference] and setting to None"

--- a/JiraPS/Public/Remove-JiraRemoteLink.ps1
+++ b/JiraPS/Public/Remove-JiraRemoteLink.ps1
@@ -32,10 +32,9 @@ function Remove-JiraRemoteLink {
         [Int[]]
         $LinkId,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty,
+        [Alias("Credential")]
+        [psobject]
+        $Session,
 
         [Switch]
         $Force
@@ -62,7 +61,7 @@ function Remove-JiraRemoteLink {
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Processing `$Issue [$Issue]"
 
             # Find the proper object for the Issue
-            $issueObj = Resolve-JiraIssueObject -InputObject $_issue -Credential $Credential
+            $issueObj = Resolve-JiraIssueObject -InputObject $_issue -Session $Session
 
             foreach ($_link in $LinkId) {
                 Write-Verbose "[$($MyInvocation.MyCommand.Name)] Processing [$_link]"
@@ -71,7 +70,7 @@ function Remove-JiraRemoteLink {
                 $parameter = @{
                     URI        = $resourceURi -f $issueObj.Key, $_link
                     Method     = "DELETE"
-                    Credential = $Credential
+                    Session    = $Session
                 }
                 Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
                 if ($PSCmdlet.ShouldProcess($issueObj.Key, "Remove RemoteLink '$_link'")) {

--- a/JiraPS/Public/Remove-JiraSession.ps1
+++ b/JiraPS/Public/Remove-JiraSession.ps1
@@ -16,8 +16,22 @@ function Remove-JiraSession {
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] ParameterSetName: $($PsCmdlet.ParameterSetName)"
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] PSBoundParameters: $($PSBoundParameters | Out-String)"
 
-        if ($Session = Get-JiraSession) {
-            $MyInvocation.MyCommand.Module.PrivateData.Session = $null
+        $sessionName = $null
+
+        if ("JiraPS.Session" -in $Session.PSObject.TypeNames) {
+            $sessionName = $Session.Name
+        }
+
+        if ($Session -is [string]) {
+            $sessionName = $Session
+        }
+
+        if (-not $Session) {
+            $sessionName = "Default"
+        }
+
+        if ($sessionName -and $script:JiraSessions.ContainsKey($sessionName)) {
+            $script:JiraSessions.Remove($sessionName)
         }
     }
 

--- a/JiraPS/Public/Remove-JiraUser.ps1
+++ b/JiraPS/Public/Remove-JiraUser.ps1
@@ -40,9 +40,7 @@ function Remove-JiraUser {
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/latest/user?username={0}"
+        $resourceURi = "rest/api/latest/user?username={0}"
 
         if ($Force) {
             Write-DebugMessage "[Remove-JiraGroup] -Force was passed. Backing up current ConfirmPreference [$ConfirmPreference] and setting to None"

--- a/JiraPS/Public/Remove-JiraUser.ps1
+++ b/JiraPS/Public/Remove-JiraUser.ps1
@@ -28,10 +28,9 @@ function Remove-JiraUser {
         [Object[]]
         $User,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty,
+        [Alias("Credential")]
+        [psobject]
+        $Session,
 
         [Switch]
         $Force
@@ -57,12 +56,12 @@ function Remove-JiraUser {
             Write-Verbose "[$($MyInvocation.MyCommand.Name)] Processing [$_user]"
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Processing `$_user [$_user]"
 
-            $userObj = Resolve-JiraUser -InputObject $_user -Credential $Credential -ErrorAction Stop
+            $userObj = Resolve-JiraUser -InputObject $_user -Session $Session -ErrorAction Stop
 
             $parameter = @{
                 URI        = $resourceURi -f $userObj.Name
                 Method     = "DELETE"
-                Credential = $Credential
+                Session    = $Session
             }
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
             if ($PSCmdlet.ShouldProcess($userObj.Name, 'Remove user')) {

--- a/JiraPS/Public/Remove-JiraVersion.ps1
+++ b/JiraPS/Public/Remove-JiraVersion.ps1
@@ -1,4 +1,4 @@
-﻿function Remove-JiraVersion {
+function Remove-JiraVersion {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( ConfirmImpact = 'High', SupportsShouldProcess )]
     param(

--- a/JiraPS/Public/Remove-JiraVersion.ps1
+++ b/JiraPS/Public/Remove-JiraVersion.ps1
@@ -27,10 +27,9 @@
         [Object[]]
         $Version,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty,
+        [Alias("Credential")]
+        [psobject]
+        $Session,
 
         [Switch]
         $Force
@@ -58,12 +57,12 @@
                 $_version = $_version.Id
             }
 
-            $versionObj = Get-JiraVersion -Id $_version -Credential $Credential -ErrorAction Stop
+            $versionObj = Get-JiraVersion -Id $_version -Session $Session -ErrorAction Stop
 
             $parameter = @{
                 URI        = $versionObj.RestUrl
                 Method     = "DELETE"
-                Credential = $Credential
+                Session    = $Session
             }
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
             if ($PSCmdlet.ShouldProcess($versionObj.Name, "Removing Version")) {

--- a/JiraPS/Public/Set-JiraConfigServer.ps1
+++ b/JiraPS/Public/Set-JiraConfigServer.ps1
@@ -7,7 +7,11 @@ function Set-JiraConfigServer {
         [ValidateNotNullOrEmpty()]
         [Alias('Uri')]
         [Uri]
-        $Server
+        $Server,
+
+        [Parameter( Mandatory )]
+        [string]
+        $Name = "Default"
     )
 
     begin {
@@ -15,9 +19,10 @@ function Set-JiraConfigServer {
     }
 
     process {
-        $script:JiraServerUrl = $Server
 
-        Set-Content -Value $Server -Path "$script:serverConfig"
+        $script:JiraServerConfigs[$Name] = New-Object psobject -Property @{ Server = $Server }
+
+        $script:JiraServerConfigs | ConvertTo-Json | Set-Content -Path $script:serversConfig
     }
 
     end {

--- a/JiraPS/Public/Set-JiraConfigServer.ps1
+++ b/JiraPS/Public/Set-JiraConfigServer.ps1
@@ -9,7 +9,6 @@ function Set-JiraConfigServer {
         [Uri]
         $Server,
 
-        [Parameter( Mandatory )]
         [string]
         $Name = "Default"
     )
@@ -19,6 +18,10 @@ function Set-JiraConfigServer {
     }
 
     process {
+
+        if (-not $Server.AbsolutePath.EndsWith("/")) {
+            $Server = New-Object -TypeName uri -ArgumentList $Server,($Server.AbsolutePath + "/")
+        }
 
         $script:JiraServerConfigs[$Name] = New-Object psobject -Property @{ Server = $Server }
 

--- a/JiraPS/Public/Set-JiraConfigServer.ps1
+++ b/JiraPS/Public/Set-JiraConfigServer.ps1
@@ -23,7 +23,7 @@ function Set-JiraConfigServer {
             $Server = New-Object -TypeName uri -ArgumentList $Server,($Server.AbsolutePath + "/")
         }
 
-        $config = New-Object psobject -Property @{ Server = $Server }
+        $config = New-Object psobject -Property @{ Server = $Server.ToString() }
 
         $script:JiraServerConfigs | Add-Member -NotePropertyName $Name -NotePropertyValue $config -Force
         $script:JiraServerConfigs | ConvertTo-Json | Set-Content -Path $script:serversConfig

--- a/JiraPS/Public/Set-JiraConfigServer.ps1
+++ b/JiraPS/Public/Set-JiraConfigServer.ps1
@@ -23,8 +23,9 @@ function Set-JiraConfigServer {
             $Server = New-Object -TypeName uri -ArgumentList $Server,($Server.AbsolutePath + "/")
         }
 
-        $script:JiraServerConfigs[$Name] = New-Object psobject -Property @{ Server = $Server }
+        $config = New-Object psobject -Property @{ Server = $Server }
 
+        $script:JiraServerConfigs | Add-Member -NotePropertyName $Name -NotePropertyValue $config -Force
         $script:JiraServerConfigs | ConvertTo-Json | Set-Content -Path $script:serversConfig
     }
 

--- a/JiraPS/Public/Set-JiraFilter.ps1
+++ b/JiraPS/Public/Set-JiraFilter.ps1
@@ -26,10 +26,9 @@ function Set-JiraFilter {
         [Bool]
         $Favorite,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     begin {
@@ -59,7 +58,7 @@ function Set-JiraFilter {
                 URI        = $InputObject.RestURL
                 Method     = "PUT"
                 Body       = ConvertTo-Json -InputObject $requestBody
-                Credential = $Credential
+                Session    = $Session
             }
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
             if ($PSCmdlet.ShouldProcess($InputObject.Name, "Update Filter")) {

--- a/JiraPS/Public/Set-JiraIssueLabel.ps1
+++ b/JiraPS/Public/Set-JiraIssueLabel.ps1
@@ -1,4 +1,4 @@
-﻿function Set-JiraIssueLabel {
+function Set-JiraIssueLabel {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( SupportsShouldProcess, DefaultParameterSetName = 'ReplaceLabels' )]
     param(

--- a/JiraPS/Public/Set-JiraIssueLabel.ps1
+++ b/JiraPS/Public/Set-JiraIssueLabel.ps1
@@ -45,10 +45,9 @@
         [Switch]
         $Clear,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty,
+        [Alias("Credential")]
+        [psobject]
+        $Session,
 
         [Switch]
         $PassThru
@@ -67,7 +66,7 @@
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Processing `$_issue [$_issue]"
 
             # Find the proper object for the Issue
-            $issueObj = Resolve-JiraIssueObject -InputObject $_issue -Credential $Credential
+            $issueObj = Resolve-JiraIssueObject -InputObject $_issue -Session $Session
 
             $labels = [System.Collections.ArrayList]@($issueObj.labels | Where-Object {$_})
 
@@ -115,14 +114,14 @@
                 URI        = $issueObj.RestURL
                 Method     = "PUT"
                 Body       = ConvertTo-Json -InputObject $requestBody -Depth 6
-                Credential = $Credential
+                Session    = $Session
             }
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
             if ($PSCmdlet.ShouldProcess($IssueObj.Key, "Updating Issue labels")) {
                 Invoke-JiraMethod @parameter
 
                 if ($PassThru) {
-                    Get-JiraIssue -Key $issueObj.Key -Credential $Credential
+                    Get-JiraIssue -Key $issueObj.Key -Session $Session
                 }
             }
         }

--- a/JiraPS/Public/Set-JiraUser.ps1
+++ b/JiraPS/Public/Set-JiraUser.ps1
@@ -71,9 +71,7 @@ function Set-JiraUser {
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/latest/user?username={0}"
+        $resourceURi = "rest/api/latest/user?username={0}"
     }
 
     process {

--- a/JiraPS/Public/Set-JiraUser.ps1
+++ b/JiraPS/Public/Set-JiraUser.ps1
@@ -59,10 +59,9 @@ function Set-JiraUser {
         [Hashtable]
         $Property,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty,
+        [Alias("Credential")]
+        [psobject]
+        $Session,
 
         [Switch]
         $PassThru
@@ -82,7 +81,7 @@ function Set-JiraUser {
             Write-Verbose "[$($MyInvocation.MyCommand.Name)] Processing [$_user]"
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Processing `$_user [$_user]"
 
-            $userObj = Resolve-JiraUser -InputObject $_user -Exact -Credential $Credential -ErrorAction Stop
+            $userObj = Resolve-JiraUser -InputObject $_user -Exact -Session $Session -ErrorAction Stop
 
             $requestBody = @{}
 
@@ -115,7 +114,7 @@ function Set-JiraUser {
                 URI        = $resourceURi -f $userObj.Name
                 Method     = "PUT"
                 Body       = ConvertTo-Json -InputObject $requestBody -Depth 4
-                Credential = $Credential
+                Session    = $Session
             }
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
             if ($PSCmdlet.ShouldProcess($UserObj.DisplayName, "Updating user")) {

--- a/JiraPS/Public/Set-JiraVersion.ps1
+++ b/JiraPS/Public/Set-JiraVersion.ps1
@@ -1,4 +1,4 @@
-﻿function Set-JiraVersion {
+function Set-JiraVersion {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( SupportsShouldProcess )]
     param(

--- a/JiraPS/Public/Set-JiraVersion.ps1
+++ b/JiraPS/Public/Set-JiraVersion.ps1
@@ -68,10 +68,9 @@
         [Object]
         $Project,
 
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        [Alias("Credential")]
+        [psobject]
+        $Session
     )
 
     begin {
@@ -86,7 +85,7 @@
             Write-Verbose "[$($MyInvocation.MyCommand.Name)] Processing [$_version]"
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Processing `$_version [$_version]"
 
-            $versionObj = Get-JiraVersion -Id $_version.Id -Credential $Credential -ErrorAction Stop
+            $versionObj = Get-JiraVersion -Id $_version.Id -Session $Session -ErrorAction Stop
 
             $requestBody = @{}
 
@@ -103,7 +102,7 @@
                 $requestBody["released"] = $Released
             }
             if ($PSCmdlet.MyInvocation.BoundParameters.ContainsKey("Project")) {
-                $projectObj = Get-JiraProject -Project $Project -Credential $Credential -ErrorAction Stop
+                $projectObj = Get-JiraProject -Project $Project -Session $Session -ErrorAction Stop
 
                 $requestBody["projectId"] = $projectObj.Id
             }
@@ -118,7 +117,7 @@
                 URI        = $versionObj.RestUrl
                 Method     = "PUT"
                 Body       = ConvertTo-Json -InputObject $requestBody
-                Credential = $Credential
+                Session    = $Session
             }
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
             if ($PSCmdlet.ShouldProcess($Name, "Updating Version on JIRA")) {

--- a/Tests/Functions/Add-JiraFilterPermission.Unit.Tests.ps1
+++ b/Tests/Functions/Add-JiraFilterPermission.Unit.Tests.ps1
@@ -49,18 +49,18 @@ Describe 'Add-JiraFilterPermission' -Tag 'Unit' {
     "id": 10010,
     "type": "project",
     "project": {
-      "self": "$jiraServer/jira/rest/api/2/project/EX",
+      "self": "jira/rest/api/2/project/EX",
       "id": "10000",
       "key": "EX",
       "name": "Example",
       "avatarUrls": {
-        "48x48": "$jiraServer/jira/secure/projectavatar?size=large&pid=10000",
-        "24x24": "$jiraServer/jira/secure/projectavatar?size=small&pid=10000",
-        "16x16": "$jiraServer/jira/secure/projectavatar?size=xsmall&pid=10000",
-        "32x32": "$jiraServer/jira/secure/projectavatar?size=medium&pid=10000"
+        "48x48": "jira/secure/projectavatar?size=large&pid=10000",
+        "24x24": "jira/secure/projectavatar?size=small&pid=10000",
+        "16x16": "jira/secure/projectavatar?size=xsmall&pid=10000",
+        "32x32": "jira/secure/projectavatar?size=medium&pid=10000"
       },
       "projectCategory": {
-        "self": "$jiraServer/jira/rest/api/2/projectCategory/10000",
+        "self": "jira/rest/api/2/projectCategory/10000",
         "id": "10000",
         "name": "FIRST",
         "description": "First Project Category"
@@ -72,18 +72,18 @@ Describe 'Add-JiraFilterPermission' -Tag 'Unit' {
     "id": 10010,
     "type": "project",
     "project": {
-      "self": "$jiraServer/jira/rest/api/2/project/MKY",
+      "self": "jira/rest/api/2/project/MKY",
       "id": "10002",
       "key": "MKY",
       "name": "Example",
       "avatarUrls": {
-        "48x48": "$jiraServer/jira/secure/projectavatar?size=large&pid=10002",
-        "24x24": "$jiraServer/jira/secure/projectavatar?size=small&pid=10002",
-        "16x16": "$jiraServer/jira/secure/projectavatar?size=xsmall&pid=10002",
-        "32x32": "$jiraServer/jira/secure/projectavatar?size=medium&pid=10002"
+        "48x48": "jira/secure/projectavatar?size=large&pid=10002",
+        "24x24": "jira/secure/projectavatar?size=small&pid=10002",
+        "16x16": "jira/secure/projectavatar?size=xsmall&pid=10002",
+        "32x32": "jira/secure/projectavatar?size=medium&pid=10002"
       },
       "projectCategory": {
-        "self": "$jiraServer/jira/rest/api/2/projectCategory/10000",
+        "self": "jira/rest/api/2/projectCategory/10000",
         "id": "10000",
         "name": "FIRST",
         "description": "First Project Category"
@@ -91,7 +91,7 @@ Describe 'Add-JiraFilterPermission' -Tag 'Unit' {
       "simplified": false
     },
     "role": {
-      "self": "$jiraServer/jira/rest/api/2/project/MKY/role/10360",
+      "self": "jira/rest/api/2/project/MKY/role/10360",
       "name": "Developers",
       "id": 10360,
       "description": "A project role that represents developers in a project",
@@ -116,7 +116,7 @@ Describe 'Add-JiraFilterPermission' -Tag 'Unit' {
     "type": "group",
     "group": {
       "name": "jira-administrators",
-      "self": "$jiraServer/jira/rest/api/2/group?groupname=jira-administrators"
+      "self": "jira/rest/api/2/group?groupname=jira-administrators"
     }
   }
 ]
@@ -139,14 +139,14 @@ Describe 'Add-JiraFilterPermission' -Tag 'Unit' {
             foreach ($_id in $Id) {
                 $object = New-Object -TypeName PSCustomObject -Property @{
                 id = $_id
-                RestUrl = "$jiraServer/rest/api/latest/filter/$_id"
+                RestUrl = "rest/api/latest/filter/$_id"
             }
             $object.PSObject.TypeNames.Insert(0, 'JiraPS.Filter')
             $object
         }
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Post' -and $URI -like "$jiraServer/rest/api/*/filter/*/permission"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Post' -and $URI -like "rest/api/*/filter/*/permission"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri', 'Body'
             ConvertFrom-Json $permissionJSON
         }
@@ -175,7 +175,7 @@ Describe 'Add-JiraFilterPermission' -Tag 'Unit' {
 
                 Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -Scope It -ParameterFilter {
                     $Method -eq 'Post' -and
-                    $URI -like '*/rest/api/*/filter/12844/permission'
+                    $URI -like 'rest/api/*/filter/12844/permission'
                 }
 
                 Assert-MockCalled -CommandName ConvertTo-JiraFilter -ModuleName JiraPS -Exactly -Times 1 -Scope It
@@ -188,7 +188,7 @@ Describe 'Add-JiraFilterPermission' -Tag 'Unit' {
 
                 Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -Scope It -ParameterFilter {
                     $Method -eq 'Post' -and
-                    $URI -like '*/rest/api/*/filter/12844/permission'
+                    $URI -like 'rest/api/*/filter/12844/permission'
                 }
 
                 Assert-MockCalled -CommandName ConvertTo-JiraFilter -ModuleName JiraPS -Exactly -Times 1 -Scope It
@@ -260,7 +260,7 @@ Describe 'Add-JiraFilterPermission' -Tag 'Unit' {
 
                 Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -Scope It -ParameterFilter {
                     $Method -eq 'Post' -and
-                    $URI -like '*/rest/api/*/filter/12844/permission' -and
+                    $URI -like 'rest/api/*/filter/12844/permission' -and
                     $Body -match '"type":\s*"global"' -and
                     $Body -notmatch ','
                 }
@@ -271,7 +271,7 @@ Describe 'Add-JiraFilterPermission' -Tag 'Unit' {
 
                 Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -Scope It -ParameterFilter {
                     $Method -eq 'Post' -and
-                    $URI -like '*/rest/api/*/filter/12844/permission' -and
+                    $URI -like 'rest/api/*/filter/12844/permission' -and
                     $Body -match '"type":\s*"authenticated"' -and
                     $Body -notmatch ","
                 }
@@ -282,7 +282,7 @@ Describe 'Add-JiraFilterPermission' -Tag 'Unit' {
 
                 Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -Scope It -ParameterFilter {
                     $Method -eq 'Post' -and
-                    $URI -like '*/rest/api/*/filter/12844/permission' -and
+                    $URI -like 'rest/api/*/filter/12844/permission' -and
                     $Body -match '"type":\s*"group"' -and
                     $Body -match '"groupname":\s*"administrators"'
                 }
@@ -293,7 +293,7 @@ Describe 'Add-JiraFilterPermission' -Tag 'Unit' {
 
                 Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -Scope It -ParameterFilter {
                     $Method -eq 'Post' -and
-                    $URI -like '*/rest/api/*/filter/12844/permission' -and
+                    $URI -like 'rest/api/*/filter/12844/permission' -and
                     $Body -match '"type":\s*"project"' -and
                     $Body -match '"projectId":\s*"11822"'
                 }
@@ -304,7 +304,7 @@ Describe 'Add-JiraFilterPermission' -Tag 'Unit' {
 
                 Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -Scope It -ParameterFilter {
                     $Method -eq 'Post' -and
-                    $URI -like '*/rest/api/*/filter/12844/permission' -and
+                    $URI -like 'rest/api/*/filter/12844/permission' -and
                     $Body -match '"type":\s*"projectRole"' -and
                     $Body -match '"projectRoleId":\s*"11822"'
                 }

--- a/Tests/Functions/Add-JiraFilterPermission.Unit.Tests.ps1
+++ b/Tests/Functions/Add-JiraFilterPermission.Unit.Tests.ps1
@@ -38,7 +38,6 @@ Describe 'Add-JiraFilterPermission' -Tag 'Unit' {
         . "$PSScriptRoot/../Shared.ps1"
 
         #region Definitions
-        $jiraServer = "https://jira.example.com"
 
         $permissionJSON = @"
 [
@@ -124,11 +123,6 @@ Describe 'Add-JiraFilterPermission' -Tag 'Unit' {
 "@
         #endregion Definitions
 
-        #region Mocks
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            $jiraServer
-        }
-
         Mock ConvertTo-JiraFilter -ModuleName JiraPS {
             $i = New-Object -TypeName PSCustomObject
             $i.PSObject.TypeNames.Insert(0, 'JiraPS.Filter')
@@ -170,7 +164,7 @@ Describe 'Add-JiraFilterPermission' -Tag 'Unit' {
             defParam $command 'Id'
             defParam $command 'Type'
             defParam $command 'Value'
-            defParam $command 'Credential'
+            defParam $command 'Session'
         }
 
         Context "Behavior testing" {

--- a/Tests/Functions/Add-JiraGroupMember.Unit.Tests.ps1
+++ b/Tests/Functions/Add-JiraGroupMember.Unit.Tests.ps1
@@ -37,16 +37,11 @@ Describe "Add-JiraGroupMember" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
 
         # In most test cases, user 1 is a member of the group and user 2 is not
         $testGroupName = 'testGroup'
         $testUsername1 = 'testUsername1'
         $testUsername2 = 'testUsername2'
-
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            Write-Output $jiraServer
-        }
 
         Mock Get-JiraGroup -ModuleName JiraPS {
             $object = [PSCustomObject] @{

--- a/Tests/Functions/Add-JiraIssueAttachment.Unit.Tests.ps1
+++ b/Tests/Functions/Add-JiraIssueAttachment.Unit.Tests.ps1
@@ -110,7 +110,7 @@ Describe "Add-JiraIssueAttachment" -Tag 'Unit' {
 
             defParam $command 'Issue'
             defParam $command 'FilePath'
-            defParam $command 'Credential'
+            defParam $command 'Session'
             defParam $command 'PassThru'
         }
 

--- a/Tests/Functions/Add-JiraIssueAttachment.Unit.Tests.ps1
+++ b/Tests/Functions/Add-JiraIssueAttachment.Unit.Tests.ps1
@@ -42,7 +42,6 @@ Describe "Add-JiraIssueAttachment" -Tag 'Unit' {
 
         $pass = ConvertTo-SecureString -AsPlainText -Force -String "passowrd"
         $Cred = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList ("user", $pass)
-        $jiraServer = 'http://jiraserver.example.com'
         $issueKey = "FOO-1234"
         $file = New-Item -Path "TestDrive:\MyFile.txt" -ItemType File -Force
         $fileName = $file.Name
@@ -51,11 +50,11 @@ Describe "Add-JiraIssueAttachment" -Tag 'Unit' {
 
         $attachmentJson = @"
 {
-    "self": "$jiraServer/rest/api/2/attachment/$attachmentId",
+    "self": "rest/api/2/attachment/$attachmentId",
     "id": "$attachmentId",
     "filename": "$fileName",
     "author": {
-        "self": "$jiraServer/rest/api/2/user?username=admin",
+        "self": "rest/api/2/user?username=admin",
         "name": "admin",
         "key": "admin",
         "accountId": "0000:000000-0000-0000-0000-ab899c878d00",
@@ -82,7 +81,7 @@ Describe "Add-JiraIssueAttachment" -Tag 'Unit' {
         Mock Get-JiraIssue -ModuleName JiraPS {
             $Issue = [PSCustomObject]@{
                 Key     = $issueKey
-                RestURL = "$jiraServer/rest/api/latest/issue/$issueKey"
+                RestURL = "rest/api/latest/issue/$issueKey"
             }
             $Issue.PSObject.TypeNames.Insert(0, 'JiraPS.Issue')
             $Issue
@@ -92,7 +91,7 @@ Describe "Add-JiraIssueAttachment" -Tag 'Unit' {
             Get-JiraIssue -Key $Issue
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Post' -and $URI -eq "$jiraServer/rest/api/latest/issue/$issueKey/attachments" } {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Post' -and $URI -eq "rest/api/latest/issue/$issueKey/attachments" } {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             ConvertFrom-Json -InputObject $attachmentJson
         }

--- a/Tests/Functions/Add-JiraIssueComment.Unit.Tests.ps1
+++ b/Tests/Functions/Add-JiraIssueComment.Unit.Tests.ps1
@@ -37,13 +37,12 @@ Describe "Add-JiraIssueComment" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
         $issueID = 41701
         $issueKey = 'IT-3676'
 
         $restResponse = @"
 {
-    "self": "$jiraServer/rest/api/2/issue/$issueID/comment/90730",
+    "self": "rest/api/2/issue/$issueID/comment/90730",
     "id": "90730",
     "body": "Test comment",
     "created": "2015-05-01T16:24:38.000-0500",
@@ -51,15 +50,11 @@ Describe "Add-JiraIssueComment" -Tag 'Unit' {
 }
 "@
 
-        Mock Get-JiraConfigServer {
-            Write-Output $jiraServer
-        }
-
         Mock Get-JiraIssue {
             $object = [PSCustomObject] @{
                 ID      = $issueID
                 Key     = $issueKey
-                RestUrl = "$jiraServer/rest/api/latest/issue/$issueID"
+                RestUrl = "rest/api/latest/issue/$issueID"
             }
             $object.PSObject.TypeNames.Insert(0, 'JiraPS.Issue')
             return $object
@@ -69,7 +64,7 @@ Describe "Add-JiraIssueComment" -Tag 'Unit' {
             Get-JiraIssue -Key $Issue
         }
 
-        Mock Invoke-JiraMethod -ParameterFilter {$Method -eq 'POST' -and $URI -eq "$jiraServer/rest/api/latest/issue/$issueID/comment"} {
+        Mock Invoke-JiraMethod -ParameterFilter {$Method -eq 'POST' -and $URI -eq "rest/api/latest/issue/$issueID/comment"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             ConvertFrom-Json $restResponse
         }

--- a/Tests/Functions/Add-JiraIssueLink.Unit.Tests.ps1
+++ b/Tests/Functions/Add-JiraIssueLink.Unit.Tests.ps1
@@ -37,8 +37,6 @@ Describe 'Add-JiraIssueLink' -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
-
         $issueKey = "TEST-01"
         $issueLink = [PSCustomObject]@{
             outwardIssue = [PSCustomObject]@{key = "TEST-10"}
@@ -67,7 +65,7 @@ Describe 'Add-JiraIssueLink' -Tag 'Unit' {
             throw "Unidentified call to Invoke-JiraMethod"
         }
 
-        Mock Invoke-JiraMethod -ParameterFilter {$Method -eq 'POST' -and $URI -eq "$jiraServer/rest/api/latest/issueLink"} {
+        Mock Invoke-JiraMethod -ParameterFilter {$Method -eq 'POST' -and $URI -eq "rest/api/latest/issueLink"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             return $true
         }
@@ -82,7 +80,7 @@ Describe 'Add-JiraIssueLink' -Tag 'Unit' {
             defParam $command 'Issue'
             defParam $command 'IssueLink'
             defParam $command 'Comment'
-            defParam $command 'Credential'
+            defParam $command 'Session'
         }
 
         Context "Functionality" {

--- a/Tests/Functions/Add-JiraIssueLink.Unit.Tests.ps1
+++ b/Tests/Functions/Add-JiraIssueLink.Unit.Tests.ps1
@@ -43,10 +43,6 @@ Describe 'Add-JiraIssueLink' -Tag 'Unit' {
             type         = [PSCustomObject]@{name = "Composition"}
         }
 
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            Write-Output $jiraServer
-        }
-
         Mock Get-JiraIssue -ParameterFilter { $Key -eq $issueKey } {
             $object = [PSCustomObject]@{
                 Key = $issueKey

--- a/Tests/Functions/Add-JiraIssueWatcher.Unit.Tests.ps1
+++ b/Tests/Functions/Add-JiraIssueWatcher.Unit.Tests.ps1
@@ -78,7 +78,7 @@ Describe "Add-JiraIssueWatcher" -Tag 'Unit' {
 
             defParam $command 'Watcher'
             defParam $command 'Issue'
-            defParam $command 'Credential'
+            defParam $command 'Session'
         }
 
         Context "Behavior testing" {

--- a/Tests/Functions/Add-JiraIssueWatcher.Unit.Tests.ps1
+++ b/Tests/Functions/Add-JiraIssueWatcher.Unit.Tests.ps1
@@ -37,19 +37,14 @@ Describe "Add-JiraIssueWatcher" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
         $issueID = 41701
         $issueKey = 'IT-3676'
-
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            Write-Output $jiraServer
-        }
 
         Mock Get-JiraIssue -ModuleName JiraPS {
             $object = [PSCustomObject] @{
                 ID      = $issueID
                 Key     = $issueKey
-                RestUrl = "$jiraServer/rest/api/latest/issue/$issueID"
+                RestUrl = "rest/api/latest/issue/$issueID"
             }
             $object.PSObject.TypeNames.Insert(0, 'JiraPS.Issue')
             return $object
@@ -59,7 +54,7 @@ Describe "Add-JiraIssueWatcher" -Tag 'Unit' {
             Get-JiraIssue -Key $Issue
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'POST' -and $URI -eq "$jiraServer/rest/api/latest/issue/$issueID/watchers"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'POST' -and $URI -eq "rest/api/latest/issue/$issueID/watchers"} {
             ShowMockInfo 'Invoke-JiraMethod' -Params 'Uri', 'Method'
         }
 

--- a/Tests/Functions/Add-JiraIssueWorklog.Unit.Tests.ps1
+++ b/Tests/Functions/Add-JiraIssueWorklog.Unit.Tests.ps1
@@ -37,7 +37,6 @@ Describe "Add-JiraIssueWorklog" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
         $jiraUsername = 'powershell-test'
         $jiraUserDisplayName = 'PowerShell Test User'
         $jiraUserEmail = 'noreply@example.com'
@@ -48,7 +47,7 @@ Describe "Add-JiraIssueWorklog" -Tag 'Unit' {
         $restResponse = @"
 {
     "id": "$worklogitemID",
-    "self": "$jiraServer/rest/api/latest/issue/$issueID/worklog/$worklogitemID",
+    "self": "rest/api/latest/issue/$issueID/worklog/$worklogitemID",
     "comment": "Test description",
     "created": "2015-05-01T16:24:38.000-0500",
     "updated": "2015-05-01T16:24:38.000-0500",
@@ -56,7 +55,7 @@ Describe "Add-JiraIssueWorklog" -Tag 'Unit' {
     "timeSpent": "1h",
     "timeSpentSeconds": "3600",
     "author": {
-        "self": "$jiraServer/rest/api/2/user?username=powershell-test",
+        "self": "rest/api/2/user?username=powershell-test",
         "name": "$jiraUsername",
         "emailAddress": "$jiraUserEmail",
         "avatarUrls": {
@@ -69,7 +68,7 @@ Describe "Add-JiraIssueWorklog" -Tag 'Unit' {
         "active": true
     },
     "updateAuthor": {
-        "self": "$jiraServer/rest/api/2/user?username=powershell-test",
+        "self": "rest/api/2/user?username=powershell-test",
         "name": "powershell-test",
         "emailAddress": "$jiraUserEmail",
         "avatarUrls": {
@@ -84,15 +83,11 @@ Describe "Add-JiraIssueWorklog" -Tag 'Unit' {
 }
 "@
 
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            Write-Output $jiraServer
-        }
-
         Mock Get-JiraIssue -ModuleName JiraPS {
             $result = [PSCustomObject] @{
                 ID      = $issueID
                 Key     = $issueKey
-                RestUrl = "$jiraServer/rest/api/latest/issue/$issueID"
+                RestUrl = "rest/api/latest/issue/$issueID"
             }
             $result.PSObject.TypeNames.Insert(0, 'JiraPS.Issue')
             Write-Output $result
@@ -102,7 +97,7 @@ Describe "Add-JiraIssueWorklog" -Tag 'Unit' {
             Get-JiraIssue -Key $Issue
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'POST' -and $URI -eq "$jiraServer/rest/api/latest/issue/$issueID/worklog"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'POST' -and $URI -eq "rest/api/latest/issue/$issueID/worklog"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri', 'Body'
             ConvertFrom-Json $restResponse
         }

--- a/Tests/Functions/ConvertTo-JiraAttachment.Unit.Tests.ps1
+++ b/Tests/Functions/ConvertTo-JiraAttachment.Unit.Tests.ps1
@@ -37,7 +37,6 @@ Describe "ConvertTo-JiraAttachment" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
 
         $attachmentID1 = "270709"
         $attachmentName1 = "Nav2-HCF.PNG"
@@ -46,11 +45,11 @@ Describe "ConvertTo-JiraAttachment" -Tag 'Unit' {
         $sampleJson = @"
 [
     {
-        "self":  "$jiraServer/rest/api/2/attachment/$attachmentID1",
+        "self":  "rest/api/2/attachment/$attachmentID1",
         "id":  "$attachmentID1",
         "filename":  "$attachmentName1",
         "author":  {
-            "self":  "$jiraServer/rest/api/2/user?username=JonDoe",
+            "self":  "rest/api/2/user?username=JonDoe",
             "name":  "JonDoe",
             "key":  "JonDoe",
             "emailAddress":  "JonDoe@server.com",
@@ -66,11 +65,11 @@ Describe "ConvertTo-JiraAttachment" -Tag 'Unit' {
         "thumbnail":  "$jiraServer/secure/thumbnail/$attachmentID1/_thumb_$attachmentID1.png"
     },
     {
-        "self":  "$jiraServer/rest/api/2/attachment/$attachmentID2",
+        "self":  "rest/api/2/attachment/$attachmentID2",
         "id":  "$attachmentID2",
         "filename":  "Nav-HCF.PNG",
         "author":  {
-            "self":  "$jiraServer/rest/api/2/user?username=JonDoe",
+            "self":  "rest/api/2/user?username=JonDoe",
             "name":  "JonDoe",
             "key":  "JonDoe",
             "emailAddress":  "JonDoe@server.com",

--- a/Tests/Functions/ConvertTo-JiraComment.Unit.Tests.ps1
+++ b/Tests/Functions/ConvertTo-JiraComment.Unit.Tests.ps1
@@ -37,7 +37,6 @@ Describe "ConvertTo-JiraComment" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
         $jiraUsername = 'powershell-test'
         $jiraUserDisplayName = 'PowerShell Test User'
         $jiraUserEmail = 'noreply@example.com'
@@ -47,10 +46,10 @@ Describe "ConvertTo-JiraComment" -Tag 'Unit' {
 
         $sampleJson = @"
 {
-    "self": "$jiraServer/rest/api/2/issue/41701/comment/90730",
+    "self": "rest/api/2/issue/41701/comment/90730",
     "id": "$commentId",
     "author": {
-    "self": "$jiraServer/rest/api/2/user?username=powershell-test",
+    "self": "rest/api/2/user?username=powershell-test",
     "name": "$jiraUsername",
     "emailAddress": "$jiraUserEmail",
     "avatarUrls": {
@@ -64,7 +63,7 @@ Describe "ConvertTo-JiraComment" -Tag 'Unit' {
     },
     "body": "$commentBody",
     "updateAuthor": {
-    "self": "$jiraServer/rest/api/2/user?username=powershell-test",
+    "self": "rest/api/2/user?username=powershell-test",
     "name": "powershell-test",
     "emailAddress": "$jiraUserEmail",
     "avatarUrls": {
@@ -97,7 +96,7 @@ Describe "ConvertTo-JiraComment" -Tag 'Unit' {
 
         defProp $r 'Id' $commentId
         defProp $r 'Body' $commentBody
-        defProp $r 'RestUrl' "$jiraServer/rest/api/2/issue/41701/comment/$commentId"
+        defProp $r 'RestUrl' "rest/api/2/issue/41701/comment/$commentId"
         defProp $r 'Created' (Get-Date '2015-05-01T16:24:38.000-0500')
         defProp $r 'Updated' (Get-Date '2015-05-01T16:24:38.000-0500')
     }

--- a/Tests/Functions/ConvertTo-JiraComponent.Unit.Tests.ps1
+++ b/Tests/Functions/ConvertTo-JiraComponent.Unit.Tests.ps1
@@ -37,11 +37,10 @@ Describe "ConvertTo-JiraComponent" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
 
         $sampleJson = @"
 {
-    "self": "$jiraServer/rest/api/2/component/11000",
+    "self": "rest/api/2/component/11000",
     "id": "11000",
     "name": "test component"
 }
@@ -61,6 +60,6 @@ Describe "ConvertTo-JiraComponent" -Tag 'Unit' {
 
         defProp $r 'Id' '11000'
         defProp $r 'Name' 'test component'
-        defProp $r 'RestUrl' "$jiraServer/rest/api/2/component/11000"
+        defProp $r 'RestUrl' "rest/api/2/component/11000"
     }
 }

--- a/Tests/Functions/ConvertTo-JiraGroup.Unit.Tests.ps1
+++ b/Tests/Functions/ConvertTo-JiraGroup.Unit.Tests.ps1
@@ -37,12 +37,11 @@ Describe "ConvertTo-JiraGroup" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
         $groupName = 'powershell-testgroup'
 
         $sampleJson = @"
 {
-    "self": "$jiraServer/rest/api/2/group?groupname=$groupName",
+    "self": "rest/api/2/group?groupname=$groupName",
     "name": "$groupName",
     "users": {
         "size": 1,
@@ -65,7 +64,7 @@ Describe "ConvertTo-JiraGroup" -Tag 'Unit' {
         checkPsType $r 'JiraPS.Group'
 
         defProp $r 'Name' $groupName
-        defProp $r 'RestUrl' "$jiraServer/rest/api/2/group?groupname=$groupName"
+        defProp $r 'RestUrl' "rest/api/2/group?groupname=$groupName"
         defProp $r 'Size' 1
     }
 }

--- a/Tests/Functions/ConvertTo-JiraIssue.Unit.Tests.ps1
+++ b/Tests/Functions/ConvertTo-JiraIssue.Unit.Tests.ps1
@@ -37,8 +37,6 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
-
         # An example of how an issue will look when returned from JIRA's REST API.
         # You can obtain most of this with a one-liner:
         # (Invoke-WebRequest -Method Get -Uri '$jiraServer/rest/api/latest/issue/JRA-37294?expand=transitions').Content
@@ -51,7 +49,7 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
 {
     "expand": "renderedFields,names,schema,transitions,operations,editmeta,changelog,versionedRepresentations",
     "id": "320391",
-    "self": "$jiraServer/rest/api/latest/issue/320391",
+    "self": "rest/api/latest/issue/320391",
     "key": "JRA-37294",
     "fields": {
         "customfield_12130": null,
@@ -79,11 +77,11 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
         "issuelinks": [],
         "assignee": null,
         "status": {
-            "self": "$jiraServer/images/icons/statuses/open.png",
+            "self": "images/icons/statuses/open.png",
             "name": "Open",
             "id": "1",
             "statusCategory": {
-                "self": "$jiraServer/rest/api/2/statuscategory/2",
+                "self": "rest/api/2/statuscategory/2",
                 "id": 2,
                 "key": "new",
                 "colorName": "blue-gray",
@@ -93,7 +91,7 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
         "customfield_16030": null,
         "components": [
             {
-                "self": "$jiraServer/rest/api/2/component/13170",
+                "self": "rest/api/2/component/13170",
                 "id": "13170",
                 "name": "Remote API (REST)",
                 "description": "Issues affecting JIRA's REST API"
@@ -109,15 +107,15 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
         "customfield_10723": null,
         "aggregatetimeestimate": null,
         "creator": {
-            "self": "$jiraServer/rest/api/2/user?username=takindele",
+            "self": "rest/api/2/user?username=takindele",
             "name": "takindele",
             "key": "takindele",
             "emailAddress": "takindele at atlassian dot com",
             "avatarUrls": {
-                "48x48": "$jiraServer/secure/useravatar?avatarId=10612",
-                "24x24": "$jiraServer/secure/useravatar?size=small&avatarId=10612",
-                "16x16": "$jiraServer/secure/useravatar?size=xsmall&avatarId=10612",
-                "32x32": "$jiraServer/secure/useravatar?size=medium&avatarId=10612"
+                "48x48": "secure/useravatar?avatarId=10612",
+                "24x24": "secure/useravatar?size=small&avatarId=10612",
+                "16x16": "secure/useravatar?size=xsmall&avatarId=10612",
+                "32x32": "secure/useravatar?size=medium&avatarId=10612"
             },
             "displayName": "Taiwo Akindele [Atlassian]",
             "active": true,
@@ -131,15 +129,15 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
         "customfield_11130": "247167",
         "customfield_10680": null,
         "reporter": {
-            "self": "$jiraServer/rest/api/2/user?username=takindele",
+            "self": "rest/api/2/user?username=takindele",
             "name": "takindele",
             "key": "takindele",
             "emailAddress": "takindele at atlassian dot com",
             "avatarUrls": {
-                "48x48": "$jiraServer/secure/useravatar?avatarId=10612",
-                "24x24": "$jiraServer/secure/useravatar?size=small&avatarId=10612",
-                "16x16": "$jiraServer/secure/useravatar?size=xsmall&avatarId=10612",
-                "32x32": "$jiraServer/secure/useravatar?size=medium&avatarId=10612"
+                "48x48": "secure/useravatar?avatarId=10612",
+                "24x24": "secure/useravatar?size=small&avatarId=10612",
+                "16x16": "secure/useravatar?size=xsmall&avatarId=10612",
+                "32x32": "secure/useravatar?size=medium&avatarId=10612"
             },
             "displayName": "Taiwo Akindele [Atlassian]",
             "active": true,
@@ -155,7 +153,7 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
             "total": 0
         },
         "votes": {
-            "self": "$jiraServer/rest/api/2/issue/JRA-37294/votes",
+            "self": "rest/api/2/issue/JRA-37294/votes",
             "votes": 50,
             "hasVoted": false
         },
@@ -166,10 +164,10 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
             "worklogs": []
         },
         "issuetype": {
-            "self": "$jiraServer/rest/api/2/issuetype/10000",
+            "self": "rest/api/2/issuetype/10000",
             "id": "10000",
             "description": "",
-            "iconUrl": "$jiraServer/secure/viewavatar?size=xsmall&avatarId=51505&avatarType=issuetype",
+            "iconUrl": "secure/viewavatar?size=xsmall&avatarId=51505&avatarType=issuetype",
             "name": "Suggestion",
             "subtask": false,
             "avatarId": 51505
@@ -188,18 +186,18 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
             "torben.hoeft(torben.hoeft)"
         ],
         "project": {
-            "self": "$jiraServer/rest/api/2/project/10240",
+            "self": "rest/api/2/project/10240",
             "id": "10240",
             "key": "JRA",
             "name": "JIRA (including JIRA Core)",
             "avatarUrls": {
-                "48x48": "$jiraServer/secure/projectavatar?pid=10240&avatarId=17294",
-                "24x24": "$jiraServer/secure/projectavatar?size=small&pid=10240&avatarId=17294",
-                "16x16": "$jiraServer/secure/projectavatar?size=xsmall&pid=10240&avatarId=17294",
-                "32x32": "$jiraServer/secure/projectavatar?size=medium&pid=10240&avatarId=17294"
+                "48x48": "secure/projectavatar?pid=10240&avatarId=17294",
+                "24x24": "secure/projectavatar?size=small&pid=10240&avatarId=17294",
+                "16x16": "secure/projectavatar?size=xsmall&pid=10240&avatarId=17294",
+                "32x32": "secure/projectavatar?size=medium&pid=10240&avatarId=17294"
             },
             "projectCategory": {
-                "self": "$jiraServer/rest/api/2/projectCategory/10031",
+                "self": "rest/api/2/projectCategory/10031",
                 "id": "10031",
                 "description": "",
                 "name": "Atlassian Products"
@@ -210,7 +208,7 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
         "resolutiondate": null,
         "workratio": -1,
         "watches": {
-            "self": "$jiraServer/rest/api/2/issue/JRA-37294/watchers",
+            "self": "rest/api/2/issue/JRA-37294/watchers",
             "watchCount": 32,
             "isWatching": false
         },
@@ -245,11 +243,11 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
         "customfield_10401": null,
         "attachment": [
             {
-                "self": "$jiraServer/rest/api/2/attachment/270709",
+                "self": "rest/api/2/attachment/270709",
                 "id": "270709",
                 "filename": "Nav2-HCF.PNG",
                 "author": {
-                    "self": "$jiraServer/rest/api/2/user?username=JonDoe",
+                    "self": "rest/api/2/user?username=JonDoe",
                     "name": "JonDoe",
                     "key": "JonDoe",
                     "emailAddress": "user@server.com",
@@ -258,19 +256,19 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
                 "created": "2017-05-30T11:20:34.000+0000",
                 "size": 366272,
                 "mimeType": "image/png",
-                "content": "$jiraServer/secure/attachment/270709/Nav2-HCF.PNG",
-                "thumbnail": "$jiraServer/secure/thumbnail/270709/_thumb_270709.png"
+                "content": "secure/attachment/270709/Nav2-HCF.PNG",
+                "thumbnail": "secure/thumbnail/270709/_thumb_270709.png"
             },
             {
-                "self": "$jiraServer/rest/api/2/attachment/270656",
+                "self": "rest/api/2/attachment/270656",
                 "id": "270656",
                 "filename": "Nav-HCF.PNG",
                 "author": {},
                 "created": "2017-05-30T09:26:17.000+0000",
                 "size": 548806,
                 "mimeType": "image/png",
-                "content": "$jiraServer/secure/attachment/270656/Nav-HCF.PNG",
-                "thumbnail": "$jiraServer/secure/thumbnail/270656/_thumb_270656.png"
+                "content": "secure/attachment/270656/Nav-HCF.PNG",
+                "thumbnail": "secure/thumbnail/270656/_thumb_270656.png"
             }
         ],
         "summary": "Allow set active/inactive via REST API",
@@ -290,18 +288,18 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
             "total": 16,
             "comments": [
                 {
-                    "self": "$jiraServer/rest/api/2/issue/320391/comment/573751",
+                    "self": "rest/api/2/issue/320391/comment/573751",
                     "id": "573751",
                     "author": {
-                        "self": "$jiraServer/rest/api/2/user?username=fanno",
+                        "self": "rest/api/2/user?username=fanno",
                         "name": "fanno",
                         "key": "fanno",
                         "emailAddress": "fannoj at gmail dot com",
                         "avatarUrls": {
-                            "48x48": "$jiraServer/secure/useravatar?ownerId=fanno&avatarId=78570",
-                            "24x24": "$jiraServer/secure/useravatar?size=small&ownerId=fanno&avatarId=78570",
-                            "16x16": "$jiraServer/secure/useravatar?size=xsmall&ownerId=fanno&avatarId=78570",
-                            "32x32": "$jiraServer/secure/useravatar?size=medium&ownerId=fanno&avatarId=78570"
+                            "48x48": "secure/useravatar?ownerId=fanno&avatarId=78570",
+                            "24x24": "secure/useravatar?size=small&ownerId=fanno&avatarId=78570",
+                            "16x16": "secure/useravatar?size=xsmall&ownerId=fanno&avatarId=78570",
+                            "32x32": "secure/useravatar?size=medium&ownerId=fanno&avatarId=78570"
                         },
                         "displayName": "Morten Hundevad",
                         "active": true,
@@ -309,15 +307,15 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
                     },
                     "body": "i just tested with \r\n\r\ntrue/false aswell it gives same result\r\n\r\nthis to be excact\r\n{code}\r\nerror.no.value.found.to.be.changed\r\n{code}\r\n\r\n-Thanks",
                     "updateAuthor": {
-                        "self": "$jiraServer/rest/api/2/user?username=fanno",
+                        "self": "rest/api/2/user?username=fanno",
                         "name": "fanno",
                         "key": "fanno",
                         "emailAddress": "fannoj at gmail dot com",
                         "avatarUrls": {
-                            "48x48": "$jiraServer/secure/useravatar?ownerId=fanno&avatarId=78570",
-                            "24x24": "$jiraServer/secure/useravatar?size=small&ownerId=fanno&avatarId=78570",
-                            "16x16": "$jiraServer/secure/useravatar?size=xsmall&ownerId=fanno&avatarId=78570",
-                            "32x32": "$jiraServer/secure/useravatar?size=medium&ownerId=fanno&avatarId=78570"
+                            "48x48": "secure/useravatar?ownerId=fanno&avatarId=78570",
+                            "24x24": "secure/useravatar?size=small&ownerId=fanno&avatarId=78570",
+                            "16x16": "secure/useravatar?size=xsmall&ownerId=fanno&avatarId=78570",
+                            "32x32": "secure/useravatar?size=medium&ownerId=fanno&avatarId=78570"
                         },
                         "displayName": "Morten Hundevad",
                         "active": true,
@@ -327,18 +325,18 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
                     "updated": "2014-03-03T20:48:03.646+0000"
                 },
                 {
-                    "self": "$jiraServer/rest/api/2/issue/320391/comment/589184",
+                    "self": "rest/api/2/issue/320391/comment/589184",
                     "id": "589184",
                     "author": {
-                        "self": "$jiraServer/rest/api/2/user?username=intersol_OLD",
+                        "self": "rest/api/2/user?username=intersol_OLD",
                         "name": "intersol_OLD",
                         "key": "intersol_old",
                         "emailAddress": "sorin dot sbarnea at citrix dot com",
                         "avatarUrls": {
-                            "48x48": "$jiraServer/secure/useravatar?avatarId=10612",
-                            "24x24": "$jiraServer/secure/useravatar?size=small&avatarId=10612",
-                            "16x16": "$jiraServer/secure/useravatar?size=xsmall&avatarId=10612",
-                            "32x32": "$jiraServer/secure/useravatar?size=medium&avatarId=10612"
+                            "48x48": "secure/useravatar?avatarId=10612",
+                            "24x24": "secure/useravatar?size=small&avatarId=10612",
+                            "16x16": "secure/useravatar?size=xsmall&avatarId=10612",
+                            "32x32": "secure/useravatar?size=medium&avatarId=10612"
                         },
                         "displayName": "Citrix Devops",
                         "active": false,
@@ -346,15 +344,15 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
                     },
                     "body": "The same problems applies for username, which is supposed to be updated this way (6.2+)",
                     "updateAuthor": {
-                        "self": "$jiraServer/rest/api/2/user?username=intersol_OLD",
+                        "self": "rest/api/2/user?username=intersol_OLD",
                         "name": "intersol_OLD",
                         "key": "intersol_old",
                         "emailAddress": "sorin dot sbarnea at citrix dot com",
                         "avatarUrls": {
-                            "48x48": "$jiraServer/secure/useravatar?avatarId=10612",
-                            "24x24": "$jiraServer/secure/useravatar?size=small&avatarId=10612",
-                            "16x16": "$jiraServer/secure/useravatar?size=xsmall&avatarId=10612",
-                            "32x32": "$jiraServer/secure/useravatar?size=medium&avatarId=10612"
+                            "48x48": "secure/useravatar?avatarId=10612",
+                            "24x24": "secure/useravatar?size=small&avatarId=10612",
+                            "16x16": "secure/useravatar?size=xsmall&avatarId=10612",
+                            "32x32": "secure/useravatar?size=medium&avatarId=10612"
                         },
                         "displayName": "Citrix Devops",
                         "active": false,
@@ -364,18 +362,18 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
                     "updated": "2014-04-12T13:38:24.356+0000"
                 },
                 {
-                    "self": "$jiraServer/rest/api/2/issue/320391/comment/623287",
+                    "self": "rest/api/2/issue/320391/comment/623287",
                     "id": "623287",
                     "author": {
-                        "self": "$jiraServer/rest/api/2/user?username=matt.doar",
+                        "self": "rest/api/2/user?username=matt.doar",
                         "name": "matt.doar",
                         "key": "matt.doar",
                         "emailAddress": "matt dot doar at servicerocket dot com",
                         "avatarUrls": {
-                            "48x48": "$jiraServer/secure/useravatar?ownerId=matt.doar&avatarId=66289",
-                            "24x24": "$jiraServer/secure/useravatar?size=small&ownerId=matt.doar&avatarId=66289",
-                            "16x16": "$jiraServer/secure/useravatar?size=xsmall&ownerId=matt.doar&avatarId=66289",
-                            "32x32": "$jiraServer/secure/useravatar?size=medium&ownerId=matt.doar&avatarId=66289"
+                            "48x48": "secure/useravatar?ownerId=matt.doar&avatarId=66289",
+                            "24x24": "secure/useravatar?size=small&ownerId=matt.doar&avatarId=66289",
+                            "16x16": "secure/useravatar?size=xsmall&ownerId=matt.doar&avatarId=66289",
+                            "32x32": "secure/useravatar?size=medium&ownerId=matt.doar&avatarId=66289"
                         },
                         "displayName": "Matt Doar [ServiceRocket]",
                         "active": true,
@@ -383,15 +381,15 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
                     },
                     "body": "This is really painful to workaround. ",
                     "updateAuthor": {
-                        "self": "$jiraServer/rest/api/2/user?username=matt.doar",
+                        "self": "rest/api/2/user?username=matt.doar",
                         "name": "matt.doar",
                         "key": "matt.doar",
                         "emailAddress": "matt dot doar at servicerocket dot com",
                         "avatarUrls": {
-                            "48x48": "$jiraServer/secure/useravatar?ownerId=matt.doar&avatarId=66289",
-                            "24x24": "$jiraServer/secure/useravatar?size=small&ownerId=matt.doar&avatarId=66289",
-                            "16x16": "$jiraServer/secure/useravatar?size=xsmall&ownerId=matt.doar&avatarId=66289",
-                            "32x32": "$jiraServer/secure/useravatar?size=medium&ownerId=matt.doar&avatarId=66289"
+                            "48x48": "secure/useravatar?ownerId=matt.doar&avatarId=66289",
+                            "24x24": "secure/useravatar?size=small&ownerId=matt.doar&avatarId=66289",
+                            "16x16": "secure/useravatar?size=xsmall&ownerId=matt.doar&avatarId=66289",
+                            "32x32": "secure/useravatar?size=medium&ownerId=matt.doar&avatarId=66289"
                         },
                         "displayName": "Matt Doar [ServiceRocket]",
                         "active": true,
@@ -401,18 +399,18 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
                     "updated": "2014-07-21T18:01:01.560+0000"
                 },
                 {
-                    "self": "$jiraServer/rest/api/2/issue/320391/comment/623380",
+                    "self": "rest/api/2/issue/320391/comment/623380",
                     "id": "623380",
                     "author": {
-                        "self": "$jiraServer/rest/api/2/user?username=fanno",
+                        "self": "rest/api/2/user?username=fanno",
                         "name": "fanno",
                         "key": "fanno",
                         "emailAddress": "fannoj at gmail dot com",
                         "avatarUrls": {
-                            "48x48": "$jiraServer/secure/useravatar?ownerId=fanno&avatarId=78570",
-                            "24x24": "$jiraServer/secure/useravatar?size=small&ownerId=fanno&avatarId=78570",
-                            "16x16": "$jiraServer/secure/useravatar?size=xsmall&ownerId=fanno&avatarId=78570",
-                            "32x32": "$jiraServer/secure/useravatar?size=medium&ownerId=fanno&avatarId=78570"
+                            "48x48": "secure/useravatar?ownerId=fanno&avatarId=78570",
+                            "24x24": "secure/useravatar?size=small&ownerId=fanno&avatarId=78570",
+                            "16x16": "secure/useravatar?size=xsmall&ownerId=fanno&avatarId=78570",
+                            "32x32": "secure/useravatar?size=medium&ownerId=fanno&avatarId=78570"
                         },
                         "displayName": "Morten Hundevad",
                         "active": true,
@@ -420,15 +418,15 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
                     },
                     "body": "@Matt Doar\r\n\r\nIs there a workaround at all?\r\n\r\n-Thanks",
                     "updateAuthor": {
-                        "self": "$jiraServer/rest/api/2/user?username=fanno",
+                        "self": "rest/api/2/user?username=fanno",
                         "name": "fanno",
                         "key": "fanno",
                         "emailAddress": "fannoj at gmail dot com",
                         "avatarUrls": {
-                            "48x48": "$jiraServer/secure/useravatar?ownerId=fanno&avatarId=78570",
-                            "24x24": "$jiraServer/secure/useravatar?size=small&ownerId=fanno&avatarId=78570",
-                            "16x16": "$jiraServer/secure/useravatar?size=xsmall&ownerId=fanno&avatarId=78570",
-                            "32x32": "$jiraServer/secure/useravatar?size=medium&ownerId=fanno&avatarId=78570"
+                            "48x48": "secure/useravatar?ownerId=fanno&avatarId=78570",
+                            "24x24": "secure/useravatar?size=small&ownerId=fanno&avatarId=78570",
+                            "16x16": "secure/useravatar?size=xsmall&ownerId=fanno&avatarId=78570",
+                            "32x32": "secure/useravatar?size=medium&ownerId=fanno&avatarId=78570"
                         },
                         "displayName": "Morten Hundevad",
                         "active": true,
@@ -438,18 +436,18 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
                     "updated": "2014-07-21T20:22:37.867+0000"
                 },
                 {
-                    "self": "$jiraServer/rest/api/2/issue/320391/comment/623669",
+                    "self": "rest/api/2/issue/320391/comment/623669",
                     "id": "623669",
                     "author": {
-                        "self": "$jiraServer/rest/api/2/user?username=matt.doar",
+                        "self": "rest/api/2/user?username=matt.doar",
                         "name": "matt.doar",
                         "key": "matt.doar",
                         "emailAddress": "matt dot doar at servicerocket dot com",
                         "avatarUrls": {
-                            "48x48": "$jiraServer/secure/useravatar?ownerId=matt.doar&avatarId=66289",
-                            "24x24": "$jiraServer/secure/useravatar?size=small&ownerId=matt.doar&avatarId=66289",
-                            "16x16": "$jiraServer/secure/useravatar?size=xsmall&ownerId=matt.doar&avatarId=66289",
-                            "32x32": "$jiraServer/secure/useravatar?size=medium&ownerId=matt.doar&avatarId=66289"
+                            "48x48": "secure/useravatar?ownerId=matt.doar&avatarId=66289",
+                            "24x24": "secure/useravatar?size=small&ownerId=matt.doar&avatarId=66289",
+                            "16x16": "secure/useravatar?size=xsmall&ownerId=matt.doar&avatarId=66289",
+                            "32x32": "secure/useravatar?size=medium&ownerId=matt.doar&avatarId=66289"
                         },
                         "displayName": "Matt Doar [ServiceRocket]",
                         "active": true,
@@ -457,15 +455,15 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
                     },
                     "body": "Not that I know of",
                     "updateAuthor": {
-                        "self": "$jiraServer/rest/api/2/user?username=matt.doar",
+                        "self": "rest/api/2/user?username=matt.doar",
                         "name": "matt.doar",
                         "key": "matt.doar",
                         "emailAddress": "matt dot doar at servicerocket dot com",
                         "avatarUrls": {
-                            "48x48": "$jiraServer/secure/useravatar?ownerId=matt.doar&avatarId=66289",
-                            "24x24": "$jiraServer/secure/useravatar?size=small&ownerId=matt.doar&avatarId=66289",
-                            "16x16": "$jiraServer/secure/useravatar?size=xsmall&ownerId=matt.doar&avatarId=66289",
-                            "32x32": "$jiraServer/secure/useravatar?size=medium&ownerId=matt.doar&avatarId=66289"
+                            "48x48": "secure/useravatar?ownerId=matt.doar&avatarId=66289",
+                            "24x24": "secure/useravatar?size=small&ownerId=matt.doar&avatarId=66289",
+                            "16x16": "secure/useravatar?size=xsmall&ownerId=matt.doar&avatarId=66289",
+                            "32x32": "secure/useravatar?size=medium&ownerId=matt.doar&avatarId=66289"
                         },
                         "displayName": "Matt Doar [ServiceRocket]",
                         "active": true,
@@ -475,18 +473,18 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
                     "updated": "2014-07-22T15:47:34.834+0000"
                 },
                 {
-                    "self": "$jiraServer/rest/api/2/issue/320391/comment/634580",
+                    "self": "rest/api/2/issue/320391/comment/634580",
                     "id": "634580",
                     "author": {
-                        "self": "$jiraServer/rest/api/2/user?username=jhu",
+                        "self": "rest/api/2/user?username=jhu",
                         "name": "jhu",
                         "key": "jhu",
                         "emailAddress": "jhu at woodwing dot com",
                         "avatarUrls": {
-                            "48x48": "$jiraServer/secure/useravatar?avatarId=10612",
-                            "24x24": "$jiraServer/secure/useravatar?size=small&avatarId=10612",
-                            "16x16": "$jiraServer/secure/useravatar?size=xsmall&avatarId=10612",
-                            "32x32": "$jiraServer/secure/useravatar?size=medium&avatarId=10612"
+                            "48x48": "secure/useravatar?avatarId=10612",
+                            "24x24": "secure/useravatar?size=small&avatarId=10612",
+                            "16x16": "secure/useravatar?size=xsmall&avatarId=10612",
+                            "32x32": "secure/useravatar?size=medium&avatarId=10612"
                         },
                         "displayName": "Joost Huizinga",
                         "active": true,
@@ -494,15 +492,15 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
                     },
                     "body": "The absence of this field in the API makes migration from an old system to Jira a pain. Users that existed in the old system but no longer work for the company and therefore are not present in Jira need to be created in Jira for the migration purpose. This can be automated but since the field is missing, all added users need be set to inactive by hand afterwards.",
                     "updateAuthor": {
-                        "self": "$jiraServer/rest/api/2/user?username=jhu",
+                        "self": "rest/api/2/user?username=jhu",
                         "name": "jhu",
                         "key": "jhu",
                         "emailAddress": "jhu at woodwing dot com",
                         "avatarUrls": {
-                            "48x48": "$jiraServer/secure/useravatar?avatarId=10612",
-                            "24x24": "$jiraServer/secure/useravatar?size=small&avatarId=10612",
-                            "16x16": "$jiraServer/secure/useravatar?size=xsmall&avatarId=10612",
-                            "32x32": "$jiraServer/secure/useravatar?size=medium&avatarId=10612"
+                            "48x48": "secure/useravatar?avatarId=10612",
+                            "24x24": "secure/useravatar?size=small&avatarId=10612",
+                            "16x16": "secure/useravatar?size=xsmall&avatarId=10612",
+                            "32x32": "secure/useravatar?size=medium&avatarId=10612"
                         },
                         "displayName": "Joost Huizinga",
                         "active": true,
@@ -512,18 +510,18 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
                     "updated": "2014-08-22T08:53:46.719+0000"
                 },
                 {
-                    "self": "$jiraServer/rest/api/2/issue/320391/comment/684791",
+                    "self": "rest/api/2/issue/320391/comment/684791",
                     "id": "684791",
                     "author": {
-                        "self": "$jiraServer/rest/api/2/user?username=matt.doar",
+                        "self": "rest/api/2/user?username=matt.doar",
                         "name": "matt.doar",
                         "key": "matt.doar",
                         "emailAddress": "matt dot doar at servicerocket dot com",
                         "avatarUrls": {
-                            "48x48": "$jiraServer/secure/useravatar?ownerId=matt.doar&avatarId=66289",
-                            "24x24": "$jiraServer/secure/useravatar?size=small&ownerId=matt.doar&avatarId=66289",
-                            "16x16": "$jiraServer/secure/useravatar?size=xsmall&ownerId=matt.doar&avatarId=66289",
-                            "32x32": "$jiraServer/secure/useravatar?size=medium&ownerId=matt.doar&avatarId=66289"
+                            "48x48": "secure/useravatar?ownerId=matt.doar&avatarId=66289",
+                            "24x24": "secure/useravatar?size=small&ownerId=matt.doar&avatarId=66289",
+                            "16x16": "secure/useravatar?size=xsmall&ownerId=matt.doar&avatarId=66289",
+                            "32x32": "secure/useravatar?size=medium&ownerId=matt.doar&avatarId=66289"
                         },
                         "displayName": "Matt Doar [ServiceRocket]",
                         "active": true,
@@ -531,15 +529,15 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
                     },
                     "body": "I use script runner scripts to do this nowadays",
                     "updateAuthor": {
-                        "self": "$jiraServer/rest/api/2/user?username=matt.doar",
+                        "self": "rest/api/2/user?username=matt.doar",
                         "name": "matt.doar",
                         "key": "matt.doar",
                         "emailAddress": "matt dot doar at servicerocket dot com",
                         "avatarUrls": {
-                            "48x48": "$jiraServer/secure/useravatar?ownerId=matt.doar&avatarId=66289",
-                            "24x24": "$jiraServer/secure/useravatar?size=small&ownerId=matt.doar&avatarId=66289",
-                            "16x16": "$jiraServer/secure/useravatar?size=xsmall&ownerId=matt.doar&avatarId=66289",
-                            "32x32": "$jiraServer/secure/useravatar?size=medium&ownerId=matt.doar&avatarId=66289"
+                            "48x48": "secure/useravatar?ownerId=matt.doar&avatarId=66289",
+                            "24x24": "secure/useravatar?size=small&ownerId=matt.doar&avatarId=66289",
+                            "16x16": "secure/useravatar?size=xsmall&ownerId=matt.doar&avatarId=66289",
+                            "32x32": "secure/useravatar?size=medium&ownerId=matt.doar&avatarId=66289"
                         },
                         "displayName": "Matt Doar [ServiceRocket]",
                         "active": true,
@@ -549,18 +547,18 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
                     "updated": "2014-12-29T21:22:23.057+0000"
                 },
                 {
-                    "self": "$jiraServer/rest/api/2/issue/320391/comment/706972",
+                    "self": "rest/api/2/issue/320391/comment/706972",
                     "id": "706972",
                     "author": {
-                        "self": "$jiraServer/rest/api/2/user?username=markdw",
+                        "self": "rest/api/2/user?username=markdw",
                         "name": "markdw",
                         "key": "markdw",
                         "emailAddress": "mdwilliams1 at dstsystems dot com",
                         "avatarUrls": {
-                            "48x48": "$jiraServer/secure/useravatar?ownerId=markdw&avatarId=66693",
-                            "24x24": "$jiraServer/secure/useravatar?size=small&ownerId=markdw&avatarId=66693",
-                            "16x16": "$jiraServer/secure/useravatar?size=xsmall&ownerId=markdw&avatarId=66693",
-                            "32x32": "$jiraServer/secure/useravatar?size=medium&ownerId=markdw&avatarId=66693"
+                            "48x48": "secure/useravatar?ownerId=markdw&avatarId=66693",
+                            "24x24": "secure/useravatar?size=small&ownerId=markdw&avatarId=66693",
+                            "16x16": "secure/useravatar?size=xsmall&ownerId=markdw&avatarId=66693",
+                            "32x32": "secure/useravatar?size=medium&ownerId=markdw&avatarId=66693"
                         },
                         "displayName": "MarkW",
                         "active": true,
@@ -568,15 +566,15 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
                     },
                     "body": "This is much needed. We need to mark users that no longer work with the company as inactive in an automated fashion. It is a shame that it is not included in the API.",
                     "updateAuthor": {
-                        "self": "$jiraServer/rest/api/2/user?username=markdw",
+                        "self": "rest/api/2/user?username=markdw",
                         "name": "markdw",
                         "key": "markdw",
                         "emailAddress": "mdwilliams1 at dstsystems dot com",
                         "avatarUrls": {
-                            "48x48": "$jiraServer/secure/useravatar?ownerId=markdw&avatarId=66693",
-                            "24x24": "$jiraServer/secure/useravatar?size=small&ownerId=markdw&avatarId=66693",
-                            "16x16": "$jiraServer/secure/useravatar?size=xsmall&ownerId=markdw&avatarId=66693",
-                            "32x32": "$jiraServer/secure/useravatar?size=medium&ownerId=markdw&avatarId=66693"
+                            "48x48": "secure/useravatar?ownerId=markdw&avatarId=66693",
+                            "24x24": "secure/useravatar?size=small&ownerId=markdw&avatarId=66693",
+                            "16x16": "secure/useravatar?size=xsmall&ownerId=markdw&avatarId=66693",
+                            "32x32": "secure/useravatar?size=medium&ownerId=markdw&avatarId=66693"
                         },
                         "displayName": "MarkW",
                         "active": true,
@@ -586,18 +584,18 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
                     "updated": "2015-03-04T17:33:43.155+0000"
                 },
                 {
-                    "self": "$jiraServer/rest/api/2/issue/320391/comment/712103",
+                    "self": "rest/api/2/issue/320391/comment/712103",
                     "id": "712103",
                     "author": {
-                        "self": "$jiraServer/rest/api/2/user?username=sean26",
+                        "self": "rest/api/2/user?username=sean26",
                         "name": "sean26",
                         "key": "sean26",
                         "emailAddress": "sean at squareup dot com",
                         "avatarUrls": {
-                            "48x48": "$jiraServer/secure/useravatar?ownerId=sean26&avatarId=74797",
-                            "24x24": "$jiraServer/secure/useravatar?size=small&ownerId=sean26&avatarId=74797",
-                            "16x16": "$jiraServer/secure/useravatar?size=xsmall&ownerId=sean26&avatarId=74797",
-                            "32x32": "$jiraServer/secure/useravatar?size=medium&ownerId=sean26&avatarId=74797"
+                            "48x48": "secure/useravatar?ownerId=sean26&avatarId=74797",
+                            "24x24": "secure/useravatar?size=small&ownerId=sean26&avatarId=74797",
+                            "16x16": "secure/useravatar?size=xsmall&ownerId=sean26&avatarId=74797",
+                            "32x32": "secure/useravatar?size=medium&ownerId=sean26&avatarId=74797"
                         },
                         "displayName": "Sean Lazar",
                         "active": true,
@@ -605,15 +603,15 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
                     },
                     "body": "I definitely could use this.",
                     "updateAuthor": {
-                        "self": "$jiraServer/rest/api/2/user?username=sean26",
+                        "self": "rest/api/2/user?username=sean26",
                         "name": "sean26",
                         "key": "sean26",
                         "emailAddress": "sean at squareup dot com",
                         "avatarUrls": {
-                            "48x48": "$jiraServer/secure/useravatar?ownerId=sean26&avatarId=74797",
-                            "24x24": "$jiraServer/secure/useravatar?size=small&ownerId=sean26&avatarId=74797",
-                            "16x16": "$jiraServer/secure/useravatar?size=xsmall&ownerId=sean26&avatarId=74797",
-                            "32x32": "$jiraServer/secure/useravatar?size=medium&ownerId=sean26&avatarId=74797"
+                            "48x48": "secure/useravatar?ownerId=sean26&avatarId=74797",
+                            "24x24": "secure/useravatar?size=small&ownerId=sean26&avatarId=74797",
+                            "16x16": "secure/useravatar?size=xsmall&ownerId=sean26&avatarId=74797",
+                            "32x32": "secure/useravatar?size=medium&ownerId=sean26&avatarId=74797"
                         },
                         "displayName": "Sean Lazar",
                         "active": true,
@@ -623,28 +621,28 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
                     "updated": "2015-03-19T00:01:36.701+0000"
                 },
                 {
-                    "self": "$jiraServer/rest/api/2/issue/320391/comment/732650",
+                    "self": "rest/api/2/issue/320391/comment/732650",
                     "id": "732650",
                     "author": {
-                        "self": "$jiraServer/secure/useravatar?avatarId=10612",
-                        "24x24": "$jiraServer/secure/useravatar?size=small&avatarId=10612",
-                        "16x16": "$jiraServer/secure/useravatar?size=xsmall&avatarId=10612",
-                        "32x32": "$jiraServer/secure/useravatar?size=medium&avatarId=10612"
+                        "self": "secure/useravatar?avatarId=10612",
+                        "24x24": "secure/useravatar?size=small&avatarId=10612",
+                        "16x16": "secure/useravatar?size=xsmall&avatarId=10612",
+                        "32x32": "secure/useravatar?size=medium&avatarId=10612"
                     },
                     "displayName": "Torben Hoeft",
                     "active": true,
                     "timeZone": "Etc/UTC",
                     "body": "in the REST documentation is written \"Modify user. The \"value\" fields present will override the existing value. Fields skipped in request will not be changed.\"\r\nIf I do a GET on the user, I can see that the user is \"active\": true or \"active\": false. So I expect that I can update this values with a put.\r\nPlease make this available or do a better documentation. I prefer the first option ;-)",
                     "updateAuthor": {
-                        "self": "$jiraServer/rest/api/2/user?username=torben.hoeft",
+                        "self": "rest/api/2/user?username=torben.hoeft",
                         "name": "torben.hoeft",
                         "key": "torben.hoeft",
                         "emailAddress": "torben dot hoeft at swisscom dot com",
                         "avatarUrls": {
-                            "48x48": "$jiraServer/secure/useravatar?avatarId=10612",
-                            "24x24": "$jiraServer/secure/useravatar?size=small&avatarId=10612",
-                            "16x16": "$jiraServer/secure/useravatar?size=xsmall&avatarId=10612",
-                            "32x32": "$jiraServer/secure/useravatar?size=medium&avatarId=10612"
+                            "48x48": "secure/useravatar?avatarId=10612",
+                            "24x24": "secure/useravatar?size=small&avatarId=10612",
+                            "16x16": "secure/useravatar?size=xsmall&avatarId=10612",
+                            "32x32": "secure/useravatar?size=medium&avatarId=10612"
                         },
                         "displayName": "Torben Hoeft",
                         "active": true,
@@ -654,18 +652,18 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
                     "updated": "2015-05-07T13:15:57.596+0000"
                 },
                 {
-                    "self": "$jiraServer/rest/api/2/issue/320391/comment/746403",
+                    "self": "rest/api/2/issue/320391/comment/746403",
                     "id": "746403",
                     "author": {
-                        "self": "$jiraServer/rest/api/2/user?username=congnv",
+                        "self": "rest/api/2/user?username=congnv",
                         "name": "congnv",
                         "key": "congnv",
                         "emailAddress": "congnv at smartosc dot com",
                         "avatarUrls": {
-                            "48x48": "$jiraServer/secure/useravatar?avatarId=10612",
-                            "24x24": "$jiraServer/secure/useravatar?size=small&avatarId=10612",
-                            "16x16": "$jiraServer/secure/useravatar?size=xsmall&avatarId=10612",
-                            "32x32": "$jiraServer/secure/useravatar?size=medium&avatarId=10612"
+                            "48x48": "secure/useravatar?avatarId=10612",
+                            "24x24": "secure/useravatar?size=small&avatarId=10612",
+                            "16x16": "secure/useravatar?size=xsmall&avatarId=10612",
+                            "32x32": "secure/useravatar?size=medium&avatarId=10612"
                         },
                         "displayName": "Cong Nguyen Van",
                         "active": true,
@@ -673,15 +671,15 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
                     },
                     "body": "Could update any method or provide full api for us?",
                     "updateAuthor": {
-                        "self": "$jiraServer/rest/api/2/user?username=congnv",
+                        "self": "rest/api/2/user?username=congnv",
                         "name": "congnv",
                         "key": "congnv",
                         "emailAddress": "congnv at smartosc dot com",
                         "avatarUrls": {
-                            "48x48": "$jiraServer/secure/useravatar?avatarId=10612",
-                            "24x24": "$jiraServer/secure/useravatar?size=small&avatarId=10612",
-                            "16x16": "$jiraServer/secure/useravatar?size=xsmall&avatarId=10612",
-                            "32x32": "$jiraServer/secure/useravatar?size=medium&avatarId=10612"
+                            "48x48": "secure/useravatar?avatarId=10612",
+                            "24x24": "secure/useravatar?size=small&avatarId=10612",
+                            "16x16": "secure/useravatar?size=xsmall&avatarId=10612",
+                            "32x32": "secure/useravatar?size=medium&avatarId=10612"
                         },
                         "displayName": "Cong Nguyen Van",
                         "active": true,
@@ -691,18 +689,18 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
                     "updated": "2015-06-05T04:03:44.872+0000"
                 },
                 {
-                    "self": "$jiraServer/rest/api/2/issue/320391/comment/746450",
+                    "self": "rest/api/2/issue/320391/comment/746450",
                     "id": "746450",
                     "author": {
-                        "self": "$jiraServer/rest/api/2/user?username=torben.hoeft",
+                        "self": "rest/api/2/user?username=torben.hoeft",
                         "name": "torben.hoeft",
                         "key": "torben.hoeft",
                         "emailAddress": "torben dot hoeft at swisscom dot com",
                         "avatarUrls": {
-                            "48x48": "$jiraServer/secure/useravatar?avatarId=10612",
-                            "24x24": "$jiraServer/secure/useravatar?size=small&avatarId=10612",
-                            "16x16": "$jiraServer/secure/useravatar?size=xsmall&avatarId=10612",
-                            "32x32": "$jiraServer/secure/useravatar?size=medium&avatarId=10612"
+                            "48x48": "secure/useravatar?avatarId=10612",
+                            "24x24": "secure/useravatar?size=small&avatarId=10612",
+                            "16x16": "secure/useravatar?size=xsmall&avatarId=10612",
+                            "32x32": "secure/useravatar?size=medium&avatarId=10612"
                         },
                         "displayName": "Torben Hoeft",
                         "active": true,
@@ -710,15 +708,15 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
                     },
                     "body": "as a transitional solution we have written a small Plugin which offers a REST API to change the value.",
                     "updateAuthor": {
-                        "self": "$jiraServer/rest/api/2/user?username=torben.hoeft",
+                        "self": "rest/api/2/user?username=torben.hoeft",
                         "name": "torben.hoeft",
                         "key": "torben.hoeft",
                         "emailAddress": "torben dot hoeft at swisscom dot com",
                         "avatarUrls": {
-                            "48x48": "$jiraServer/secure/useravatar?avatarId=10612",
-                            "24x24": "$jiraServer/secure/useravatar?size=small&avatarId=10612",
-                            "16x16": "$jiraServer/secure/useravatar?size=xsmall&avatarId=10612",
-                            "32x32": "$jiraServer/secure/useravatar?size=medium&avatarId=10612"
+                            "48x48": "secure/useravatar?avatarId=10612",
+                            "24x24": "secure/useravatar?size=small&avatarId=10612",
+                            "16x16": "secure/useravatar?size=xsmall&avatarId=10612",
+                            "32x32": "secure/useravatar?size=medium&avatarId=10612"
                         },
                         "displayName": "Torben Hoeft",
                         "active": true,
@@ -728,18 +726,18 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
                     "updated": "2015-06-05T07:14:45.253+0000"
                 },
                 {
-                    "self": "$jiraServer/rest/api/2/issue/320391/comment/823128",
+                    "self": "rest/api/2/issue/320391/comment/823128",
                     "id": "823128",
                     "author": {
-                        "self": "$jiraServer/rest/api/2/user?username=stanislaw",
+                        "self": "rest/api/2/user?username=stanislaw",
                         "name": "stanislaw",
                         "key": "stanislaw",
                         "emailAddress": "stanislaw dot kodzis at sabre dot com",
                         "avatarUrls": {
-                            "48x48": "$jiraServer/secure/useravatar?avatarId=10612",
-                            "24x24": "$jiraServer/secure/useravatar?size=small&avatarId=10612",
-                            "16x16": "$jiraServer/secure/useravatar?size=xsmall&avatarId=10612",
-                            "32x32": "$jiraServer/secure/useravatar?size=medium&avatarId=10612"
+                            "48x48": "secure/useravatar?avatarId=10612",
+                            "24x24": "secure/useravatar?size=small&avatarId=10612",
+                            "16x16": "secure/useravatar?size=xsmall&avatarId=10612",
+                            "32x32": "secure/useravatar?size=medium&avatarId=10612"
                         },
                         "displayName": "Stanislaw Kodzis",
                         "active": true,
@@ -747,15 +745,15 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
                     },
                     "body": "+1 Very needed feature!",
                     "updateAuthor": {
-                        "self": "$jiraServer/rest/api/2/user?username=stanislaw",
+                        "self": "rest/api/2/user?username=stanislaw",
                         "name": "stanislaw",
                         "key": "stanislaw",
                         "emailAddress": "stanislaw dot kodzis at sabre dot com",
                         "avatarUrls": {
-                            "48x48": "$jiraServer/secure/useravatar?avatarId=10612",
-                            "24x24": "$jiraServer/secure/useravatar?size=small&avatarId=10612",
-                            "16x16": "$jiraServer/secure/useravatar?size=xsmall&avatarId=10612",
-                            "32x32": "$jiraServer/secure/useravatar?size=medium&avatarId=10612"
+                            "48x48": "secure/useravatar?avatarId=10612",
+                            "24x24": "secure/useravatar?size=small&avatarId=10612",
+                            "16x16": "secure/useravatar?size=xsmall&avatarId=10612",
+                            "32x32": "secure/useravatar?size=medium&avatarId=10612"
                         },
                         "displayName": "Stanislaw Kodzis",
                         "active": true,
@@ -765,18 +763,18 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
                     "updated": "2015-11-09T11:48:39.412+0000"
                 },
                 {
-                    "self": "$jiraServer/rest/api/2/issue/320391/comment/823304",
+                    "self": "rest/api/2/issue/320391/comment/823304",
                     "id": "823304",
                     "author": {
-                        "self": "$jiraServer/rest/api/2/user?username=fanno",
+                        "self": "rest/api/2/user?username=fanno",
                         "name": "fanno",
                         "key": "fanno",
                         "emailAddress": "fannoj at gmail dot com",
                         "avatarUrls": {
-                            "48x48": "$jiraServer/secure/useravatar?ownerId=fanno&avatarId=78570",
-                            "24x24": "$jiraServer/secure/useravatar?size=small&ownerId=fanno&avatarId=78570",
-                            "16x16": "$jiraServer/secure/useravatar?size=xsmall&ownerId=fanno&avatarId=78570",
-                            "32x32": "$jiraServer/secure/useravatar?size=medium&ownerId=fanno&avatarId=78570"
+                            "48x48": "secure/useravatar?ownerId=fanno&avatarId=78570",
+                            "24x24": "secure/useravatar?size=small&ownerId=fanno&avatarId=78570",
+                            "16x16": "secure/useravatar?size=xsmall&ownerId=fanno&avatarId=78570",
+                            "32x32": "secure/useravatar?size=medium&ownerId=fanno&avatarId=78570"
                         },
                         "displayName": "Morten Hundevad",
                         "active": true,
@@ -784,15 +782,15 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
                     },
                     "body": "Is anyone even looking at this? How many vote are needed? ",
                     "updateAuthor": {
-                        "self": "$jiraServer/rest/api/2/user?username=fanno",
+                        "self": "rest/api/2/user?username=fanno",
                         "name": "fanno",
                         "key": "fanno",
                         "emailAddress": "fannoj at gmail dot com",
                         "avatarUrls": {
-                            "48x48": "$jiraServer/secure/useravatar?ownerId=fanno&avatarId=78570",
-                            "24x24": "$jiraServer/secure/useravatar?size=small&ownerId=fanno&avatarId=78570",
-                            "16x16": "$jiraServer/secure/useravatar?size=xsmall&ownerId=fanno&avatarId=78570",
-                            "32x32": "$jiraServer/secure/useravatar?size=medium&ownerId=fanno&avatarId=78570"
+                            "48x48": "secure/useravatar?ownerId=fanno&avatarId=78570",
+                            "24x24": "secure/useravatar?size=small&ownerId=fanno&avatarId=78570",
+                            "16x16": "secure/useravatar?size=xsmall&ownerId=fanno&avatarId=78570",
+                            "32x32": "secure/useravatar?size=medium&ownerId=fanno&avatarId=78570"
                         },
                         "displayName": "Morten Hundevad",
                         "active": true,
@@ -802,18 +800,18 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
                     "updated": "2015-11-09T18:26:17.295+0000"
                 },
                 {
-                    "self": "$jiraServer/rest/api/2/issue/320391/comment/823427",
+                    "self": "rest/api/2/issue/320391/comment/823427",
                     "id": "823427",
                     "author": {
-                        "self": "$jiraServer/rest/api/2/user?username=torben.hoeft",
+                        "self": "rest/api/2/user?username=torben.hoeft",
                         "name": "torben.hoeft",
                         "key": "torben.hoeft",
                         "emailAddress": "torben dot hoeft at swisscom dot com",
                         "avatarUrls": {
-                            "48x48": "$jiraServer/secure/useravatar?avatarId=10612",
-                            "24x24": "$jiraServer/secure/useravatar?size=small&avatarId=10612",
-                            "16x16": "$jiraServer/secure/useravatar?size=xsmall&avatarId=10612",
-                            "32x32": "$jiraServer/secure/useravatar?size=medium&avatarId=10612"
+                            "48x48": "secure/useravatar?avatarId=10612",
+                            "24x24": "secure/useravatar?size=small&avatarId=10612",
+                            "16x16": "secure/useravatar?size=xsmall&avatarId=10612",
+                            "32x32": "secure/useravatar?size=medium&avatarId=10612"
                         },
                         "displayName": "Torben Hoeft",
                         "active": true,
@@ -821,15 +819,15 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
                     },
                     "body": "We have extended the REST API with this functionality. I'll check if we can put this for free on the marketplace or at least make it public on bitbucket.\r\n\r\nIf interested please leave a comment",
                     "updateAuthor": {
-                        "self": "$jiraServer/rest/api/2/user?username=torben.hoeft",
+                        "self": "rest/api/2/user?username=torben.hoeft",
                         "name": "torben.hoeft",
                         "key": "torben.hoeft",
                         "emailAddress": "torben dot hoeft at swisscom dot com",
                         "avatarUrls": {
-                            "48x48": "$jiraServer/secure/useravatar?avatarId=10612",
-                            "24x24": "$jiraServer/secure/useravatar?size=small&avatarId=10612",
-                            "16x16": "$jiraServer/secure/useravatar?size=xsmall&avatarId=10612",
-                            "32x32": "$jiraServer/secure/useravatar?size=medium&avatarId=10612"
+                            "48x48": "secure/useravatar?avatarId=10612",
+                            "24x24": "secure/useravatar?size=small&avatarId=10612",
+                            "16x16": "secure/useravatar?size=xsmall&avatarId=10612",
+                            "32x32": "secure/useravatar?size=medium&avatarId=10612"
                         },
                         "displayName": "Torben Hoeft",
                         "active": true,
@@ -839,18 +837,18 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
                     "updated": "2015-11-09T19:41:22.492+0000"
                 },
                 {
-                    "self": "$jiraServer/rest/api/2/issue/320391/comment/833460",
+                    "self": "rest/api/2/issue/320391/comment/833460",
                     "id": "833460",
                     "author": {
-                        "self": "$jiraServer/rest/api/2/user?username=fanno",
+                        "self": "rest/api/2/user?username=fanno",
                         "name": "fanno",
                         "key": "fanno",
                         "emailAddress": "fannoj at gmail dot com",
                         "avatarUrls": {
-                            "48x48": "$jiraServer/secure/useravatar?ownerId=fanno&avatarId=78570",
-                            "24x24": "$jiraServer/secure/useravatar?size=small&ownerId=fanno&avatarId=78570",
-                            "16x16": "$jiraServer/secure/useravatar?size=xsmall&ownerId=fanno&avatarId=78570",
-                            "32x32": "$jiraServer/secure/useravatar?size=medium&ownerId=fanno&avatarId=78570"
+                            "48x48": "secure/useravatar?ownerId=fanno&avatarId=78570",
+                            "24x24": "secure/useravatar?size=small&ownerId=fanno&avatarId=78570",
+                            "16x16": "secure/useravatar?size=xsmall&ownerId=fanno&avatarId=78570",
+                            "32x32": "secure/useravatar?size=medium&ownerId=fanno&avatarId=78570"
                         },
                         "displayName": "Morten Hundevad",
                         "active": true,
@@ -858,15 +856,15 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
                     },
                     "body": "Who is \"we\" ",
                     "updateAuthor": {
-                        "self": "$jiraServer/rest/api/2/user?username=fanno",
+                        "self": "rest/api/2/user?username=fanno",
                         "name": "fanno",
                         "key": "fanno",
                         "emailAddress": "fannoj at gmail dot com",
                         "avatarUrls": {
-                            "48x48": "$jiraServer/secure/useravatar?ownerId=fanno&avatarId=78570",
-                            "24x24": "$jiraServer/secure/useravatar?size=small&ownerId=fanno&avatarId=78570",
-                            "16x16": "$jiraServer/secure/useravatar?size=xsmall&ownerId=fanno&avatarId=78570",
-                            "32x32": "$jiraServer/secure/useravatar?size=medium&ownerId=fanno&avatarId=78570"
+                            "48x48": "secure/useravatar?ownerId=fanno&avatarId=78570",
+                            "24x24": "secure/useravatar?size=small&ownerId=fanno&avatarId=78570",
+                            "16x16": "secure/useravatar?size=xsmall&ownerId=fanno&avatarId=78570",
+                            "32x32": "secure/useravatar?size=medium&ownerId=fanno&avatarId=78570"
                         },
                         "displayName": "Morten Hundevad",
                         "active": true,
@@ -883,11 +881,11 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
             "id": "1",
             "name": "Fake Transition",
             "to": {
-                "self": "$jiraServer/images/icons/statuses/open.png",
+                "self": "images/icons/statuses/open.png",
                 "name": "Open",
                 "id": "1",
                 "statusCategory": {
-                    "self": "$jiraServer/rest/api/2/statuscategory/2",
+                    "self": "rest/api/2/statuscategory/2",
                     "id": 2,
                     "key": "new",
                     "colorName": "blue-gray",
@@ -911,8 +909,8 @@ Describe "ConvertTo-JiraIssue" -Tag 'Unit' {
 
             defProp $r 'Key' 'JRA-37294'
             defProp $r 'Id' '320391'
-            defProp $r 'RestUrl' "$jiraServer/rest/api/latest/issue/320391"
-            defProp $r 'HttpUrl' "$jiraServer/browse/JRA-37294"
+            defProp $r 'RestUrl' "rest/api/latest/issue/320391"
+            defProp $r 'HttpUrl' "browse/JRA-37294"
             defProp $r 'Summary' 'Allow set active/inactive via REST API'
             It "Defines the 'Attachment' property" {
                 $r.Attachment | Should Not BeNullOrEmpty

--- a/Tests/Functions/ConvertTo-JiraIssueLink.Unit.Tests.ps1
+++ b/Tests/Functions/ConvertTo-JiraIssueLink.Unit.Tests.ps1
@@ -37,7 +37,6 @@ Describe "ConvertTo-JiraIssueLink" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
 
         $issueLinkId = 41313
         $issueKeyInward = "TEST-01"

--- a/Tests/Functions/ConvertTo-JiraIssueLinkType.Unit.Tests.ps1
+++ b/Tests/Functions/ConvertTo-JiraIssueLinkType.Unit.Tests.ps1
@@ -37,7 +37,6 @@ Describe "ConvertTo-JiraIssueLinkType" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
 
         $sampleJson = @'
 {

--- a/Tests/Functions/ConvertTo-JiraIssueType.Unit.Tests.ps1
+++ b/Tests/Functions/ConvertTo-JiraIssueType.Unit.Tests.ps1
@@ -37,7 +37,6 @@ Describe "ConvertTo-JiraIssueType" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
 
         $issueTypeId = 2
         $issueTypeName = 'Test Issue Type'
@@ -45,7 +44,7 @@ Describe "ConvertTo-JiraIssueType" -Tag 'Unit' {
 
         $sampleJson = @"
 {
-    "self": "$jiraServer/rest/api/latest/issuetype/2",
+    "self": "rest/api/latest/issuetype/2",
     "id": "$issueTypeId",
     "description": "$issueTypeDescription",
     "iconUrl": "$jiraServer/images/icons/issuetypes/newfeature.png",
@@ -65,7 +64,7 @@ Describe "ConvertTo-JiraIssueType" -Tag 'Unit' {
         defProp $r 'Id' $issueTypeId
         defProp $r 'Name' $issueTypeName
         defProp $r 'Description' $issueTypeDescription
-        defProp $r 'RestUrl' "$jiraServer/rest/api/latest/issuetype/$issueTypeId"
+        defProp $r 'RestUrl' "rest/api/latest/issuetype/$issueTypeId"
         defProp $r 'IconUrl' "$jiraServer/images/icons/issuetypes/newfeature.png"
         defProp $r 'Subtask' $false
     }

--- a/Tests/Functions/ConvertTo-JiraLink.Unit.Tests.ps1
+++ b/Tests/Functions/ConvertTo-JiraLink.Unit.Tests.ps1
@@ -37,13 +37,12 @@ Describe "ConvertTo-JiraLink" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
         $LinkID = "10000"
 
         $sampleJson = @"
 {
     "id": 10000,
-    "self": "http://jiraserver.example.com/rest/api/issue/MKY-1/remotelink/10000",
+    "self": "rest/api/issue/MKY-1/remotelink/10000",
     "globalId": "system=http://www.mycompany.com/support&id=1",
     "application": {
         "type": "com.acme.tracker",
@@ -80,6 +79,6 @@ Describe "ConvertTo-JiraLink" -Tag 'Unit' {
         checkPsType $r 'JiraPS.Link'
 
         defProp $r 'id' $LinkId
-        defProp $r 'RestUrl' "$jiraServer/rest/api/issue/MKY-1/remotelink/10000"
+        defProp $r 'RestUrl' "rest/api/issue/MKY-1/remotelink/10000"
     }
 }

--- a/Tests/Functions/ConvertTo-JiraPriority.Unit.Tests.ps1
+++ b/Tests/Functions/ConvertTo-JiraPriority.Unit.Tests.ps1
@@ -37,7 +37,6 @@ Describe "ConvertTo-JiraPriority" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
 
         $priorityId = 1
         $priorityName = 'Critical'
@@ -45,7 +44,7 @@ Describe "ConvertTo-JiraPriority" -Tag 'Unit' {
 
         $sampleJson = @"
 {
-    "self": "$jiraServer/rest/api/2/priority/1",
+    "self": "rest/api/2/priority/1",
     "statusColor": "#cc0000",
     "description": "$priorityDescription",
     "name": "$priorityName",
@@ -64,7 +63,7 @@ Describe "ConvertTo-JiraPriority" -Tag 'Unit' {
 
         defProp $r 'Id' $priorityId
         defProp $r 'Name' $priorityName
-        defProp $r 'RestUrl' "$jiraServer/rest/api/2/priority/$priorityId"
+        defProp $r 'RestUrl' "rest/api/2/priority/$priorityId"
         defProp $r 'Description' $priorityDescription
         defProp $r 'StatusColor' '#cc0000'
     }

--- a/Tests/Functions/ConvertTo-JiraProject.Unit.Tests.ps1
+++ b/Tests/Functions/ConvertTo-JiraProject.Unit.Tests.ps1
@@ -37,7 +37,6 @@ Describe "ConvertTo-JiraProject" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
 
         $projectKey = 'IT'
         $projectId = '10003'
@@ -46,13 +45,13 @@ Describe "ConvertTo-JiraProject" -Tag 'Unit' {
         $sampleJson = @"
 {
     "expand": "description,lead,url,projectKeys",
-    "self": "$jiraServer/rest/api/2/project/$projectId",
+    "self": "rest/api/2/project/$projectId",
     "id": "$projectId",
     "key": "$projectKey",
     "name": "$projectName",
     "description": "",
     "lead": {
-        "self":  "$jiraServer/rest/api/2/user?username=admin",
+        "self":  "rest/api/2/user?username=admin",
         "key": "admin",
         "name": "admin",
         "avatarUrls": {
@@ -73,14 +72,14 @@ Describe "ConvertTo-JiraProject" -Tag 'Unit' {
     },
     "projectKeys": "HCC",
     "projectCategory": {
-        "self": "$jiraServer/rest/api/latest/projectCategory/10000",
+        "self": "rest/api/latest/projectCategory/10000",
         "id":  "10000",
         "name":  "Home Connect",
         "description":  "Home Connect Projects"
     },
     "projectTypeKey": "software",
     "components": {
-        "self": "$jiraServer/rest/api/2/component/11000",
+        "self": "rest/api/2/component/11000",
         "id": "11000",
         "description": "A test component",
         "name": "test component"
@@ -100,7 +99,7 @@ Describe "ConvertTo-JiraProject" -Tag 'Unit' {
         defProp $r 'Id' $projectId
         defProp $r 'Key' $projectKey
         defProp $r 'Name' $projectName
-        defProp $r 'RestUrl' "$jiraServer/rest/api/2/project/$projectId"
+        defProp $r 'RestUrl' "rest/api/2/project/$projectId"
 
         checkPsType $r.Lead 'JiraPS.User'
         # checkPsType $r.IssueTypes 'JiraPS.IssueType'

--- a/Tests/Functions/ConvertTo-JiraServerInfo.Unit.Tests.ps1
+++ b/Tests/Functions/ConvertTo-JiraServerInfo.Unit.Tests.ps1
@@ -37,11 +37,10 @@ Describe "ConvertTo-JiraServerInfo" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
 
         $sampleJson = @"
 {
-    "baseUrl":"$jiraServer",
+    "baseUrl":"http://test/",
     "version":"1000.1323.0",
     "versionNumbers":[1000,1323,0],
     "deploymentType":"Cloud",
@@ -63,7 +62,7 @@ Describe "ConvertTo-JiraServerInfo" -Tag 'Unit' {
         checkPsType $r 'JiraPS.ServerInfo'
 
 
-        defProp $r 'BaseURL' $jiraServer
+        defProp $r 'BaseURL' "http://test/"
         defProp $r 'Version' ([Version]"1000.1323.0")
         defProp $r 'DeploymentType' "Cloud"
         defProp $r 'BuildNumber' 100062

--- a/Tests/Functions/ConvertTo-JiraStatus.Unit.Tests.ps1
+++ b/Tests/Functions/ConvertTo-JiraStatus.Unit.Tests.ps1
@@ -37,7 +37,6 @@ Describe "ConvertTo-JiraStatus" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
 
         $statusName = 'In Progress'
         $statusId = 3
@@ -45,13 +44,13 @@ Describe "ConvertTo-JiraStatus" -Tag 'Unit' {
 
         $sampleJson = @"
 {
-    "self": "$jiraServer/rest/api/2/status/$statusId",
+    "self": "rest/api/2/status/$statusId",
     "description": "$statusDesc",
     "iconUrl": "$jiraServer/images/icons/statuses/inprogress.png",
     "name": "$statusName",
     "id": "$statusId",
     "statusCategory": {
-        "self": "$jiraServer/rest/api/2/statuscategory/4",
+        "self": "rest/api/2/statuscategory/4",
         "id": 4,
         "key": "indeterminate",
         "colorName": "yellow",
@@ -73,6 +72,6 @@ Describe "ConvertTo-JiraStatus" -Tag 'Unit' {
         defProp $r 'Name' $statusName
         defProp $r 'Description' $statusDesc
         defProp $r 'IconUrl' "$jiraServer/images/icons/statuses/inprogress.png"
-        defProp $r 'RestUrl' "$jiraServer/rest/api/2/status/$statusId"
+        defProp $r 'RestUrl' "rest/api/2/status/$statusId"
     }
 }

--- a/Tests/Functions/ConvertTo-JiraTransition.Unit.Tests.ps1
+++ b/Tests/Functions/ConvertTo-JiraTransition.Unit.Tests.ps1
@@ -37,7 +37,6 @@ Describe "ConvertTo-JiraTransition" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
 
         $tId = 11
         $tName = 'Start Progress'
@@ -52,13 +51,13 @@ Describe "ConvertTo-JiraTransition" -Tag 'Unit' {
     "id": "$tId",
     "name": "$tName",
     "to": {
-        "self": "$jiraServer/rest/api/2/status/$tRId",
+        "self": "rest/api/2/status/$tRId",
         "description": "$tRDesc",
         "iconUrl": "$jiraServer/images/icons/statuses/inprogress.png",
         "name": "$tRName",
         "id": "$tRId",
         "statusCategory": {
-            "self": "$jiraServer/rest/api/2/statuscategory/4",
+            "self": "rest/api/2/statuscategory/4",
             "id": 4,
             "key": "indeterminate",
             "colorName": "yellow",

--- a/Tests/Functions/ConvertTo-JiraUser.Unit.Tests.ps1
+++ b/Tests/Functions/ConvertTo-JiraUser.Unit.Tests.ps1
@@ -37,14 +37,13 @@ Describe "ConvertTo-JiraUser" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
         $username = 'powershell-test'
         $displayName = 'PowerShell Test User'
         $email = 'noreply@example.com'
 
         $sampleJson = @"
 {
-    "self":"$jiraServer/rest/api/2/user?username=$username",
+    "self":"rest/api/2/user?username=$username",
     "key":"$username",
     "accountId":"500058:1500a9f1-0000-42b3-0000-ab8900008d00",
     "name":"$username",
@@ -64,19 +63,19 @@ Describe "ConvertTo-JiraUser" -Tag 'Unit' {
         "items":[
             {
                 "name":"administrators",
-                "self":"$jiraServer/rest/api/2/group?groupname=administrators"
+                "self":"rest/api/2/group?groupname=administrators"
             },
             {
                 "name":"balsamiq-mockups-editors",
-                "self":"$jiraServer/rest/api/2/group?groupname=balsamiq-mockups-editors"
+                "self":"rest/api/2/group?groupname=balsamiq-mockups-editors"
             },
             {
                 "name":"jira-administrators",
-                "self":"$jiraServer/rest/api/2/group?groupname=jira-administrators"
+                "self":"rest/api/2/group?groupname=jira-administrators"
             },
             {
                 "name":"site-admins",
-                "self":"$jiraServer/rest/api/2/group?groupname=site-admins"
+                "self":"rest/api/2/group?groupname=site-admins"
             }
         ]
     },
@@ -103,7 +102,7 @@ Describe "ConvertTo-JiraUser" -Tag 'Unit' {
         defProp $r 'DisplayName' $displayName
         defProp $r 'EmailAddress' $email
         defProp $r 'Active' $true
-        defProp $r 'RestUrl' "$jiraServer/rest/api/2/user?username=$username"
+        defProp $r 'RestUrl' "rest/api/2/user?username=$username"
         hasProp $r 'AvatarUrl'
         defProp $r 'TimeZone' "Europe/Berlin"
         defProp $r 'Locale' "en_Us"

--- a/Tests/Functions/ConvertTo-JiraVersion.Unit.Tests.ps1
+++ b/Tests/Functions/ConvertTo-JiraVersion.Unit.Tests.ps1
@@ -37,7 +37,6 @@ Describe "ConvertTo-JiraVersion" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
 
         $versionId = '10000'
         $versionName = 'New Version 1'
@@ -46,7 +45,7 @@ Describe "ConvertTo-JiraVersion" -Tag 'Unit' {
 
         $sampleJson = @"
 {
-    "self": "$jiraServer/rest/api/2/version/$versionId",
+    "self": "rest/api/2/version/$versionId",
     "id": "$versionId",
     "description": "$versionDescription",
     "name": "$versionName",
@@ -85,6 +84,6 @@ Describe "ConvertTo-JiraVersion" -Tag 'Unit' {
         hasProp $r 'Archived'
         hasProp $r 'Released'
         hasProp $r 'Overdue'
-        defProp $r 'RestUrl' "$jiraServer/rest/api/2/version/$versionId"
+        defProp $r 'RestUrl' "rest/api/2/version/$versionId"
     }
 }

--- a/Tests/Functions/ConvertTo-JiraWorklogitem.Unit.Tests.ps1
+++ b/Tests/Functions/ConvertTo-JiraWorklogitem.Unit.Tests.ps1
@@ -37,7 +37,6 @@ Describe "ConvertTo-JiraWorklogitem" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
         $jiraUsername = 'powershell-test'
         $jiraUserDisplayName = 'PowerShell Test User'
         $jiraUserEmail = 'noreply@example.com'
@@ -51,7 +50,7 @@ Describe "ConvertTo-JiraWorklogitem" -Tag 'Unit' {
         $sampleJson = @"
 {
     "id": "$worklogitemID",
-    "self": "$jiraServer/rest/api/2/issue/$issueID/worklog/$worklogitemID",
+    "self": "rest/api/2/issue/$issueID/worklog/$worklogitemID",
     "comment": "Test description",
     "created": "2015-05-01T16:24:38.000-0500",
     "updated": "2015-05-01T16:24:38.000-0500",
@@ -59,7 +58,7 @@ Describe "ConvertTo-JiraWorklogitem" -Tag 'Unit' {
     "timeSpent": "1h",
     "timeSpentSeconds": "3600",
     "author": {
-        "self": "$jiraServer/rest/api/2/user?username=powershell-test",
+        "self": "rest/api/2/user?username=powershell-test",
         "name": "$jiraUsername",
         "emailAddress": "$jiraUserEmail",
         "avatarUrls": {
@@ -72,7 +71,7 @@ Describe "ConvertTo-JiraWorklogitem" -Tag 'Unit' {
         "active": true
     },
     "updateAuthor": {
-        "self": "$jiraServer/rest/api/2/user?username=powershell-test",
+        "self": "rest/api/2/user?username=powershell-test",
         "name": "powershell-test",
         "emailAddress": "$jiraUserEmail",
         "avatarUrls": {
@@ -102,7 +101,7 @@ Describe "ConvertTo-JiraWorklogitem" -Tag 'Unit' {
 
         defProp $r 'Id' $worklogitemID
         defProp $r 'Comment' $commentBody
-        defProp $r 'RestUrl' "$jiraServer/rest/api/2/issue/41701/worklog/$worklogitemID"
+        defProp $r 'RestUrl' "rest/api/2/issue/41701/worklog/$worklogitemID"
         defProp $r 'Created' (Get-Date '2015-05-01T16:24:38.000-0500')
         defProp $r 'Updated' (Get-Date '2015-05-01T16:24:38.000-0500')
         defProp $r 'Started' (Get-Date '2017-02-23T22:21:00.000-0500')

--- a/Tests/Functions/Find-JiraFilter.Unit.Tests.ps1
+++ b/Tests/Functions/Find-JiraFilter.Unit.Tests.ps1
@@ -37,8 +37,6 @@ Describe 'Find-JiraFilter' -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'https://jira.example.com'
-
         $mockOwner = [PSCustomObject]@{
             AccountId = 'c62dde3418235be1c8424950'
             Name = 'TUser1'
@@ -79,9 +77,6 @@ Describe 'Find-JiraFilter' -Tag 'Unit' {
 '@
 
         #region Mocks
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            $jiraServer
-        }
 
         Mock Get-JiraProject -ModuleName JiraPS {
             ShowMockInfo 'Get-JiraProject' 'Project'
@@ -98,7 +93,7 @@ Describe 'Find-JiraFilter' -Tag 'Unit' {
 
         Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {
             $Method -eq 'Get' -and
-            $URI -like "$jiraServer/rest/api/*/filter/search*"
+            $URI -like "rest/api/*/filter/search*"
         } {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             ConvertFrom-Json $response
@@ -120,7 +115,7 @@ Describe 'Find-JiraFilter' -Tag 'Unit' {
             defParam $command 'Project'
             defParam $command 'Fields'
             defParam $command 'Sort'
-            defParam $command 'Credential'
+            defParam $command 'Session'
         }
 
         Context 'Behavior testing' {
@@ -133,7 +128,7 @@ Describe 'Find-JiraFilter' -Tag 'Unit' {
                     ModuleName      = 'JiraPS'
                     ParameterFilter = {
                         $Method -eq 'Get' -and
-                        $URI -like '*/rest/api/*/filter/search*'
+                        $URI -like 'rest/api/*/filter/search*'
                     }
                     Scope           = 'It'
                     Exactly         = $true
@@ -150,7 +145,7 @@ Describe 'Find-JiraFilter' -Tag 'Unit' {
                     ModuleName      = 'JiraPS'
                     ParameterFilter = {
                         $Method -eq 'Get' -and
-                        $URI -like '*/rest/api/*/filter/search*' -and
+                        $URI -like 'rest/api/*/filter/search*' -and
                         $GetParameter['accountId'] -eq $mockOwner.AccountId
                     }
                     Scope           = 'It'
@@ -168,7 +163,7 @@ Describe 'Find-JiraFilter' -Tag 'Unit' {
                     ModuleName      = 'JiraPS'
                     ParameterFilter = {
                         $Method -eq 'Get' -and
-                        $URI -like '*/rest/api/*/filter/search*' -and
+                        $URI -like 'rest/api/*/filter/search*' -and
                         $GetParameter['groupName'] -eq $groupEscaped
                     }
                     Scope           = 'It'
@@ -186,7 +181,7 @@ Describe 'Find-JiraFilter' -Tag 'Unit' {
                     ModuleName      = 'JiraPS'
                     ParameterFilter = {
                         $Method -eq 'Get' -and
-                        $URI -like '*/rest/api/*/filter/search*' -and
+                        $URI -like 'rest/api/*/filter/search*' -and
                         $GetParameter['projectId'] -eq '1'
                     }
                     Scope           = 'It'
@@ -204,7 +199,7 @@ Describe 'Find-JiraFilter' -Tag 'Unit' {
                     ModuleName      = 'JiraPS'
                     ParameterFilter = {
                         $Method -eq 'Get' -and
-                        $URI -like '*/rest/api/*/filter/search*' -and
+                        $URI -like 'rest/api/*/filter/search*' -and
                         $GetParameter['orderBy'] -eq 'name'
                     }
                     Scope           = 'It'
@@ -223,7 +218,7 @@ Describe 'Find-JiraFilter' -Tag 'Unit' {
                     ModuleName      = 'JiraPS'
                     ParameterFilter = {
                         $Method -eq 'Get' -and
-                        $URI -like '*/rest/api/*/filter/search*' -and
+                        $URI -like 'rest/api/*/filter/search*' -and
                         $GetParameter['expand'] -eq 'description,favourite,favouritedCount,jql,owner,searchUrl,sharePermissions,subscriptions,viewUrl'
                     }
                     Scope           = 'It'
@@ -237,7 +232,7 @@ Describe 'Find-JiraFilter' -Tag 'Unit' {
                     ModuleName      = 'JiraPS'
                     ParameterFilter = {
                         $Method -eq 'Get' -and
-                        $URI -like '*/rest/api/*/filter/search*' -and
+                        $URI -like 'rest/api/*/filter/search*' -and
                         $GetParameter['expand'] -eq 'description'
                     }
                     Scope           = 'It'
@@ -257,7 +252,7 @@ Describe 'Find-JiraFilter' -Tag 'Unit' {
                     ModuleName      = 'JiraPS'
                     ParameterFilter = {
                         $Method -eq 'Get' -and
-                        $URI -like '*/rest/api/*/filter/search*' -and
+                        $URI -like 'rest/api/*/filter/search*' -and
                         $GetParameter['projectId'] -eq '1'
                     }
                     Scope           = 'It'
@@ -282,7 +277,7 @@ Describe 'Find-JiraFilter' -Tag 'Unit' {
                     ModuleName      = 'JiraPS'
                     ParameterFilter = {
                         $Method -eq 'Get' -and
-                        $URI -like '*/rest/api/*/filter/search*' -and
+                        $URI -like 'rest/api/*/filter/search*' -and
                         $GetParameter['accountId'] -eq $mockowner.AccountId -and
                         $GetParameter['groupName'] -eq $groupEscaped -and
                         $GetParameter['projectId'] -eq '1'
@@ -302,7 +297,7 @@ Describe 'Find-JiraFilter' -Tag 'Unit' {
                     ModuleName      = 'JiraPS'
                     ParameterFilter = {
                         $Method -eq 'Get' -and
-                        $URI -like '*/rest/api/*/filter/search*' #-and
+                        $URI -like 'rest/api/*/filter/search*' #-and
                         $GetParameter['AccountId'] -eq $mockOwner.AccountId
                     }
                     Scope           = 'It'

--- a/Tests/Functions/Get-JiraComponent.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraComponent.Unit.Tests.ps1
@@ -37,7 +37,6 @@ Describe "Get-JiraComponent" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
 
         $projectKey = 'TEST'
         $projectId = '10004'
@@ -51,14 +50,14 @@ Describe "Get-JiraComponent" -Tag 'Unit' {
         $restResultAll = @"
 [
     {
-        "self": "$jiraServer/rest/api/2/component/$componentId",
+        "self": "rest/api/2/component/$componentId",
         "id": "$componentId",
         "name": "$componentName",
         "project": "$projectKey",
         "projectId": "$projectId"
     },
     {
-        "self": "$jiraServer/rest/api/2/component/$componentId2",
+        "self": "rest/api/2/component/$componentId2",
         "id": "$componentId2",
         "name": "$componentName2",
         "project": "$projectKey",
@@ -70,7 +69,7 @@ Describe "Get-JiraComponent" -Tag 'Unit' {
         $restResultOne = @"
 [
     {
-        "self": "$jiraServer/rest/api/2/component/$componentId",
+        "self": "rest/api/2/component/$componentId",
         "id": "$componentId",
         "name": "$componentName",
         "project": "$projectKey",
@@ -78,10 +77,6 @@ Describe "Get-JiraComponent" -Tag 'Unit' {
     }
 ]
 "@
-
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            Write-Output $jiraServer
-        }
 
         Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -eq "rest/api/latest/component/$componentId"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'

--- a/Tests/Functions/Get-JiraComponent.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraComponent.Unit.Tests.ps1
@@ -83,7 +83,7 @@ Describe "Get-JiraComponent" -Tag 'Unit' {
             Write-Output $jiraServer
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -eq "$jiraServer/rest/api/latest/component/$componentId"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -eq "rest/api/latest/component/$componentId"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             ConvertFrom-Json $restResultOne
         }

--- a/Tests/Functions/Get-JiraConfigServer.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraConfigServer.Unit.Tests.ps1
@@ -37,12 +37,22 @@ Describe "Get-JiraConfigServer" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
+        $sampleServerConfig = New-Object -TypeName psobject
 
         It "returns the server stored in the module's session" {
-            $script:JiraServerUrl = $jiraServer
+            $script:JiraServerConfigs["Default"] = $sampleServerConfig
 
-            Get-JiraConfigServer | Should -Be $jiraServer
+            Get-JiraConfigServer | Should -BeExactly $sampleServerConfig
+        }
+
+        It "return the named server stored in the module's session" {
+            $script:JiraServerConfigs["Test"] = $sampleServerConfig
+
+            Get-JiraConfigServer -Name "Test" | Should -BeExactly $sampleServerConfig
+        }
+
+        It "throws an error when desired config does not exist" {
+            { Get-JiraConfigServer -Name "TestB" } | Should -Throw
         }
     }
 }

--- a/Tests/Functions/Get-JiraConfigServer.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraConfigServer.Unit.Tests.ps1
@@ -40,13 +40,17 @@ Describe "Get-JiraConfigServer" -Tag 'Unit' {
         $sampleServerConfig = New-Object -TypeName psobject
 
         It "returns the server stored in the module's session" {
-            $script:JiraServerConfigs["Default"] = $sampleServerConfig
+            $script:JiraServerConfigs =
+                New-Object -TypeName psobject |
+                Add-Member -NotePropertyName "Default" -NotePropertyValue $sampleServerConfig -PassThru
 
             Get-JiraConfigServer | Should -BeExactly $sampleServerConfig
         }
 
         It "return the named server stored in the module's session" {
-            $script:JiraServerConfigs["Test"] = $sampleServerConfig
+            $script:JiraServerConfigs =
+                New-Object -TypeName psobject |
+                Add-Member -NotePropertyName "Test" -NotePropertyValue $sampleServerConfig -PassThru
 
             Get-JiraConfigServer -Name "Test" | Should -BeExactly $sampleServerConfig
         }

--- a/Tests/Functions/Get-JiraConfigServer.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraConfigServer.Unit.Tests.ps1
@@ -39,6 +39,8 @@ Describe "Get-JiraConfigServer" -Tag 'Unit' {
 
         $sampleServerConfig = New-Object -TypeName psobject
 
+        $script:JiraServerConfigs = @{}
+
         It "returns the server stored in the module's session" {
             $script:JiraServerConfigs =
                 New-Object -TypeName psobject |

--- a/Tests/Functions/Get-JiraField.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraField.Unit.Tests.ps1
@@ -164,10 +164,6 @@ Describe "Get-JiraField" -Tag 'Unit' {
 ]
 "@
 
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            Write-Output $jiraServer
-        }
-
         Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $Uri -eq "rest/api/latest/field"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             ConvertFrom-Json $restResult

--- a/Tests/Functions/Get-JiraField.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraField.Unit.Tests.ps1
@@ -37,8 +37,6 @@ Describe "Get-JiraField" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
-
         # In my Jira instance, this returns 34 objects. I've stripped it down quite a bit for testing.
         $restResult = @"
 [
@@ -170,7 +168,7 @@ Describe "Get-JiraField" -Tag 'Unit' {
             Write-Output $jiraServer
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $Uri -eq "$jiraServer/rest/api/latest/field"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $Uri -eq "rest/api/latest/field"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             ConvertFrom-Json $restResult
         }

--- a/Tests/Functions/Get-JiraFilter.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraFilter.Unit.Tests.ps1
@@ -38,7 +38,6 @@ Describe 'Get-JiraFilter' -Tag 'Unit' {
         . "$PSScriptRoot/../Shared.ps1"
 
         #region Definitions
-        $jiraServer = "https://jira.example.com"
 
         $responseFilter = @"
 {
@@ -113,9 +112,6 @@ Describe 'Get-JiraFilter' -Tag 'Unit' {
         #endregion Definitions
 
         #region Mocks
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            $jiraServer
-        }
 
         Mock ConvertTo-JiraFilter -ModuleName JiraPS {
             foreach ($i in $InputObject) {
@@ -124,22 +120,22 @@ Describe 'Get-JiraFilter' -Tag 'Unit' {
             }
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/*/filter/12345"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -like "rest/api/*/filter/12345"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             ConvertFrom-Json $responseFilter
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/*/filter/67890"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -like "rest/api/*/filter/67890"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             ConvertFrom-Json $responseFilter
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/*/filter/favourite"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -like "rest/api/*/filter/favourite"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             ConvertFrom-Json $responseFilterCollection
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/*/filter/*"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -like "rest/api/*/filter/*"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             ConvertFrom-Json $responseFilter
         }
@@ -156,7 +152,7 @@ Describe 'Get-JiraFilter' -Tag 'Unit' {
             defParam $command 'Id'
             defParam $command 'InputObject'
             defParam $command 'Favorite'
-            defParam $command 'Credential'
+            defParam $command 'Session'
 
             defAlias $command 'Favourite' 'Favorite'
         }
@@ -164,7 +160,7 @@ Describe 'Get-JiraFilter' -Tag 'Unit' {
         Context "Behavior testing" {
             It "Queries JIRA for a filter with a given ID" {
                 { Get-JiraFilter -Id 12345 } | Should Not Throw
-                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -Scope It -ParameterFilter {$Method -eq 'Get' -and $URI -like '*/rest/api/*/filter/12345'}
+                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -Scope It -ParameterFilter {$Method -eq 'Get' -and $URI -like 'rest/api/*/filter/12345'}
             }
 
             It "Uses ConvertTo-JiraFilter to output a Filter object if JIRA returns data" {
@@ -177,7 +173,7 @@ Describe 'Get-JiraFilter' -Tag 'Unit' {
             It "Finds all favorite filters of the user" {
                 { Get-JiraFilter -Favorite } | Should Not Throw
 
-                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -Scope It -ParameterFilter {$Method -eq 'Get' -and $URI -like '*/rest/api/*/filter/favourite'}
+                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -Scope It -ParameterFilter {$Method -eq 'Get' -and $URI -like 'rest/api/*/filter/favourite'}
             }
         }
 
@@ -199,20 +195,20 @@ Describe 'Get-JiraFilter' -Tag 'Unit' {
             It "Accepts multiple filter IDs to the -Filter parameter" {
                 { Get-JiraFilter -Id '12345', '67890' } | Should Not Throw
 
-                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -Scope It -ParameterFilter {$Method -eq 'Get' -and $URI -like '*/rest/api/*/filter/12345'}
-                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -Scope It -ParameterFilter {$Method -eq 'Get' -and $URI -like '*/rest/api/*/filter/67890'}
+                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -Scope It -ParameterFilter {$Method -eq 'Get' -and $URI -like 'rest/api/*/filter/12345'}
+                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -Scope It -ParameterFilter {$Method -eq 'Get' -and $URI -like 'rest/api/*/filter/67890'}
             }
 
             It "Accepts a JiraPS.Filter object to the InputObject parameter" {
                 { Get-JiraFilter -InputObject $sampleFilter } | Should Not Throw
 
-                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -Scope It -ParameterFilter {$Method -eq 'Get' -and $URI -like '*rest/api/*/filter/12844'}
+                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -Scope It -ParameterFilter {$Method -eq 'Get' -and $URI -like 'rest/api/*/filter/12844'}
             }
 
             It "Accepts a JiraPS.Filter object via pipeline" {
                 { $sampleFilter | Get-JiraFilter } | Should Not Throw
 
-                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -Scope It -ParameterFilter {$Method -eq 'Get' -and $URI -like '*rest/api/*/filter/12844'}
+                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -Scope It -ParameterFilter {$Method -eq 'Get' -and $URI -like 'rest/api/*/filter/12844'}
             }
         }
     }

--- a/Tests/Functions/Get-JiraFilter.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraFilter.Unit.Tests.ps1
@@ -41,11 +41,11 @@ Describe 'Get-JiraFilter' -Tag 'Unit' {
 
         $responseFilter = @"
 {
-    "self": "$jiraServer/rest/api/latest/filter/12844",
+    "self": "rest/api/latest/filter/12844",
     "id": "12844",
     "name": "All JIRA Bugs",
     "owner": {
-        "self": "$jiraServer/rest/api/2/user?username=scott@atlassian.com",
+        "self": "rest/api/2/user?username=scott@atlassian.com",
         "key": "scott@atlassian.com",
         "name": "scott@atlassian.com",
         "avatarUrls": {
@@ -59,7 +59,7 @@ Describe 'Get-JiraFilter' -Tag 'Unit' {
     },
     "jql": "project = 10240 AND issuetype = 1 ORDER BY key DESC",
     "viewUrl": "$jiraServer/secure/IssueNavigator.jspa?mode=hide&requestId=12844",
-    "searchUrl": "$jiraServer/rest/api/latest/search?jql=project+%3D+10240+AND+issuetype+%3D+1+ORDER+BY+key+DESC",
+    "searchUrl": "rest/api/latest/search?jql=project+%3D+10240+AND+issuetype+%3D+1+ORDER+BY+key+DESC",
     "favourite": false,
     "sharePermissions": [
         {
@@ -87,21 +87,21 @@ Describe 'Get-JiraFilter' -Tag 'Unit' {
         $responseFilterCollection = @"
 [
     {
-        "self": "$jiraServer/rest/api/latest/filter/13844",
+        "self": "rest/api/latest/filter/13844",
         "id": "13844",
         "name": "Filter 1",
         "jql": "project = 10240 AND issuetype = 1 ORDER BY key DESC",
         "favourite": true
     },
     {
-        "self": "$jiraServer/rest/api/latest/filter/14844",
+        "self": "rest/api/latest/filter/14844",
         "id": "14844",
         "name": "Filter 2",
         "jql": "project = 10240 AND issuetype = 1 ORDER BY key DESC",
         "favourite": true
     },
     {
-        "self": "$jiraServer/rest/api/latest/filter/15844",
+        "self": "rest/api/latest/filter/15844",
         "id": "15844",
         "name": "Filter 3",
         "jql": "project = 10240 AND issuetype = 1 ORDER BY key DESC",

--- a/Tests/Functions/Get-JiraFilterPermission.unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraFilterPermission.unit.Tests.ps1
@@ -38,7 +38,6 @@ BeforeAll {
         . "$PSScriptRoot/../Shared.ps1"
 
         #region Definitions
-        $jiraServer = "https://jira.example.com"
 
         $sampleResponse = @"
 {
@@ -49,9 +48,6 @@ BeforeAll {
         #endregion Definitions
 
         #region Mocks
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            $jiraServer
-        }
 
         Mock ConvertTo-JiraFilter -ModuleName JiraPS { }
 
@@ -82,7 +78,7 @@ BeforeAll {
 
             defParam $command 'Filter'
             defParam $command 'Id'
-            defParam $command 'Credential'
+            defParam $command 'Session'
         }
 
         Context "Behavior testing" {

--- a/Tests/Functions/Get-JiraFilterPermission.unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraFilterPermission.unit.Tests.ps1
@@ -55,14 +55,14 @@ BeforeAll {
             foreach ($_id in $Id) {
             $basicFilter = New-Object -TypeName PSCustomObject -Property @{
                 Id = $Id
-                RestUrl = "$jiraServer/rest/api/2/filter/$Id"
+                RestUrl = "rest/api/2/filter/$Id"
             }
             $basicFilter.PSObject.TypeNames.Insert(0, 'JiraPS.Filter')
             $basicFilter
         }
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/*/filter/*/permission"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -like "rest/api/*/filter/*/permission"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             ConvertFrom-Json $sampleResponse
         }
@@ -87,7 +87,7 @@ BeforeAll {
 
                 Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -Scope It -ParameterFilter {
                     $Method -eq 'Get' -and
-                    $URI -like '*/rest/api/*/filter/23456/permission'
+                    $URI -like 'rest/api/*/filter/23456/permission'
                 }
             }
 
@@ -96,7 +96,7 @@ BeforeAll {
 
                 Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -Scope It -ParameterFilter {
                     $Method -eq 'Get' -and
-                    $URI -like '*/rest/api/*/filter/23456/permission'
+                    $URI -like 'rest/api/*/filter/23456/permission'
                 }
             }
         }

--- a/Tests/Functions/Get-JiraGroup.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraGroup.Unit.Tests.ps1
@@ -37,8 +37,6 @@ Describe "Get-JiraGroup" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
-
         $testGroupName = 'Test Group'
         $testGroupNameEscaped = ConvertTo-URLEncoded $testGroupName
         $testGroupSize = 1
@@ -46,7 +44,7 @@ Describe "Get-JiraGroup" -Tag 'Unit' {
         $restResult = @"
 {
     "name": "$testGroupName",
-    "self": "$jiraServer/rest/api/2/group?groupname=$testGroupName",
+    "self": "rest/api/2/group?groupname=$testGroupName",
     "users": {
         "size": "$testGroupSize",
         "items": [],
@@ -58,12 +56,8 @@ Describe "Get-JiraGroup" -Tag 'Unit' {
 }
 "@
 
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            Write-Output $jiraServer
-        }
-
         # Searching for a group.
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -eq "$jiraServer/rest/api/latest/group?groupname=$testGroupNameEscaped"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -eq "rest/api/latest/group?groupname=$testGroupNameEscaped"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             ConvertFrom-Json -InputObject $restResult
         }

--- a/Tests/Functions/Get-JiraGroupMember.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraGroupMember.Unit.Tests.ps1
@@ -86,7 +86,7 @@ Describe "Get-JiraGroupMember" -Tag 'Unit' {
             defParam $command 'IncludeInactive'
             defParam $command 'StartIndex'
             defParam $command 'MaxResults'
-            defParam $command 'Credential'
+            defParam $command 'Session'
         }
 
         Context "Behavior testing" {

--- a/Tests/Functions/Get-JiraGroupMember.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraGroupMember.Unit.Tests.ps1
@@ -38,9 +38,6 @@ Describe "Get-JiraGroupMember" -Tag 'Unit' {
         . "$PSScriptRoot/../Shared.ps1"
 
         #region Mocks
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            'https://jira.example.com'
-        }
 
         Mock Get-JiraUser -ModuleName JiraPS {
             $object = [PSCustomObject] @{
@@ -60,7 +57,7 @@ Describe "Get-JiraGroupMember" -Tag 'Unit' {
             Write-Output $obj
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like '*/rest/api/*/group/member' -and $GetParameter["groupname"] -eq "testgroup" } {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like 'rest/api/*/group/member' -and $GetParameter["groupname"] -eq "testgroup" } {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             ConvertFrom-Json @'
 {
@@ -99,7 +96,7 @@ Describe "Get-JiraGroupMember" -Tag 'Unit' {
                     ModuleName      = 'JiraPS'
                     ParameterFilter = {
                         $Method -eq 'Get' -and
-                        $URI -like '*/rest/api/*/group/member'
+                        $URI -like 'rest/api/*/group/member'
                     }
                     Scope           = 'It'
                     Exactly         = $true
@@ -116,7 +113,7 @@ Describe "Get-JiraGroupMember" -Tag 'Unit' {
                     ModuleName      = 'JiraPS'
                     ParameterFilter = {
                         $Method -eq 'Get' -and
-                        $URI -like '*/rest/api/*/group/member' -and
+                        $URI -like 'rest/api/*/group/member' -and
                         $PSCmdlet.PagingParameters.Skip -eq 10
                     }
                     Scope           = 'It'
@@ -134,7 +131,7 @@ Describe "Get-JiraGroupMember" -Tag 'Unit' {
                     ModuleName      = 'JiraPS'
                     ParameterFilter = {
                         $Method -eq 'Get' -and
-                        $URI -like '*/rest/api/*/group/member' -and
+                        $URI -like 'rest/api/*/group/member' -and
                         $PSCmdlet.PagingParameters.First -eq 50
                     }
                     Scope           = 'It'
@@ -154,7 +151,7 @@ Describe "Get-JiraGroupMember" -Tag 'Unit' {
                     ModuleName      = 'JiraPS'
                     ParameterFilter = {
                         $Method -eq 'Get' -and
-                        $URI -like '*/rest/api/*/group/member' -and
+                        $URI -like 'rest/api/*/group/member' -and
                         $GetParameter["groupname"] -eq "testgroup"
                     }
                     Scope           = 'It'
@@ -174,7 +171,7 @@ Describe "Get-JiraGroupMember" -Tag 'Unit' {
                     ModuleName      = 'JiraPS'
                     ParameterFilter = {
                         $Method -eq 'Get' -and
-                        $URI -like '*/rest/api/*/group/member' -and
+                        $URI -like 'rest/api/*/group/member' -and
                         $GetParameter["groupname"] -eq "testgroup"
                     }
                     Scope           = 'It'

--- a/Tests/Functions/Get-JiraIssue.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraIssue.Unit.Tests.ps1
@@ -71,13 +71,13 @@ Describe "Get-JiraGroupMember" -Tag 'Unit' {
             [PSCustomObject]@{
                 PSTypeName = "JiraPS.Filter"
                 Id         = 12345
-                SearchUrl  = "https://jira.example.com/rest/api/latest/filter/12345"
+                SearchUrl  = "rest/api/latest/filter/12345"
             }
         }
 
         Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {
             $Method -eq 'Get' -and
-            $URI -like "$jiraServer/rest/api/*/issue/TEST-001*"
+            $URI -like "rest/api/*/issue/TEST-001*"
         } {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             ConvertFrom-Json $response
@@ -85,7 +85,7 @@ Describe "Get-JiraGroupMember" -Tag 'Unit' {
 
         Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {
             $Method -eq 'Get' -and
-            $URI -like "$jiraServer/rest/api/*/search" -and
+            $URI -like "rest/api/*/search" -and
             $GetParameter["jql"] -eq $jqlEscaped
         } {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
@@ -94,7 +94,7 @@ Describe "Get-JiraGroupMember" -Tag 'Unit' {
 
         Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {
             $Method -eq 'Get' -and
-            $URI -like "$jiraServer/rest/api/*/filter/*"
+            $URI -like "rest/api/*/filter/*"
         } {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             ConvertFrom-Json $response
@@ -130,7 +130,7 @@ Describe "Get-JiraGroupMember" -Tag 'Unit' {
                     ModuleName      = 'JiraPS'
                     ParameterFilter = {
                         $Method -eq 'Get' -and
-                        $URI -like '*/rest/api/*/issue/TEST-001*'
+                        $URI -like 'rest/api/*/issue/TEST-001*'
                     }
                     Scope           = 'It'
                     Exactly         = $true
@@ -147,7 +147,7 @@ Describe "Get-JiraGroupMember" -Tag 'Unit' {
                     ModuleName      = 'JiraPS'
                     ParameterFilter = {
                         $Method -eq 'Get' -and
-                        $URI -like "*/rest/api/*/search" -and
+                        $URI -like "rest/api/*/search" -and
                         $GetParameter["jql"] -eq $jqlEscaped
                     }
                     Scope           = 'It'
@@ -165,7 +165,7 @@ Describe "Get-JiraGroupMember" -Tag 'Unit' {
                     ModuleName      = 'JiraPS'
                     ParameterFilter = {
                         $Method -eq 'Get' -and
-                        $URI -like "*/rest/api/*/search" -and
+                        $URI -like "rest/api/*/search" -and
                         $GetParameter["jql"] -eq $jqlEscaped -and
                         $PSCmdlet.PagingParameters.Skip -eq 10
                         $PSCmdlet.PagingParameters.First -eq 50
@@ -185,7 +185,7 @@ Describe "Get-JiraGroupMember" -Tag 'Unit' {
                     ModuleName      = 'JiraPS'
                     ParameterFilter = {
                         $Method -eq 'Get' -and
-                        $URI -like "*/rest/api/*/search" -and
+                        $URI -like "rest/api/*/search" -and
                         $GetParameter["jql"] -eq $jqlEscaped -and
                         $GetParameter["maxResults"] -eq 25
                     }
@@ -273,7 +273,7 @@ Describe "Get-JiraGroupMember" -Tag 'Unit' {
                     ModuleName      = 'JiraPS'
                     ParameterFilter = {
                         $Method -eq 'Get' -and
-                        $URI -like "*/rest/api/*/issue/TEST-001*"
+                        $URI -like "rest/api/*/issue/TEST-001*"
                     }
                     Scope           = 'It'
                     Exactly         = $true
@@ -297,7 +297,7 @@ Describe "Get-JiraGroupMember" -Tag 'Unit' {
                     ModuleName      = 'JiraPS'
                     ParameterFilter = {
                         $Method -eq 'Get' -and
-                        $URI -like "*/rest/api/*/issue/TEST-001*"
+                        $URI -like "rest/api/*/issue/TEST-001*"
                     }
                     Scope           = 'It'
                     Exactly         = $true

--- a/Tests/Functions/Get-JiraIssue.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraIssue.Unit.Tests.ps1
@@ -37,7 +37,6 @@ Describe "Get-JiraGroupMember" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = "https://jira.example.com"
 
         $jql = 'reporter in (testuser)'
         $jqlEscaped = ConvertTo-URLEncoded $jql
@@ -59,9 +58,6 @@ Describe "Get-JiraGroupMember" -Tag 'Unit' {
 '@
 
         #region Mocks
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            $jiraServer
-        }
 
         Mock Get-JiraUser -ModuleName JiraPS {
             $object = [PSCustomObject] @{
@@ -121,7 +117,7 @@ Describe "Get-JiraGroupMember" -Tag 'Unit' {
             defParam $command 'StartIndex'
             defParam $command 'MaxResults'
             defParam $command 'PageSize'
-            defParam $command 'Credential'
+            defParam $command 'Session'
         }
 
         Context "Behavior testing" {

--- a/Tests/Functions/Get-JiraIssueAttachment.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraIssueAttachment.Unit.Tests.ps1
@@ -37,18 +37,17 @@ Describe "Get-JiraIssueAttachment" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
         $issueID = 41701
         $issueKey = 'IT-3676'
 
         $attachments = @"
 [
     {
-        "self": "$jiraServer/rest/api/2/attachment/10013",
+        "self": "rest/api/2/attachment/10013",
         "id": "10013",
         "filename": "foo.pdf",
         "author": {
-            "self": "$jiraServer/rest/api/2/user?username=admin",
+            "self": "rest/api/2/user?username=admin",
             "name": "admin",
             "key": "admin",
             "accountId": "000000:000000-0000-0000-0000-ab899c878d00",
@@ -64,11 +63,11 @@ Describe "Get-JiraIssueAttachment" -Tag 'Unit' {
         "content": "$jiraServer/secure/attachment/10013/foo.pdf"
     },
     {
-        "self": "$jiraServer/rest/api/2/attachment/10010",
+        "self": "rest/api/2/attachment/10010",
         "id": "10010",
         "filename": "bar.pdf",
         "author": {
-            "self": "$jiraServer/rest/api/2/user?username=admin",
+            "self": "rest/api/2/user?username=admin",
             "name": "admin",
             "key": "admin",
             "accountId": "000000:000000-0000-0000-0000-ab899c878d00",
@@ -90,7 +89,7 @@ Describe "Get-JiraIssueAttachment" -Tag 'Unit' {
             $IssueObj = [PSCustomObject]@{
                 ID         = $issueID
                 Key        = $issueKey
-                RestUrl    = "$jiraServer/rest/api/latest/issue/$issueID"
+                RestUrl    = "rest/api/latest/issue/$issueID"
                 attachment = (ConvertFrom-Json -InputObject $attachments)
             }
             $IssueObj.PSObject.TypeNames.Insert(0, 'JiraPS.Issue')

--- a/Tests/Functions/Get-JiraIssueAttachmentFile.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraIssueAttachmentFile.Unit.Tests.ps1
@@ -37,18 +37,17 @@ Describe "Get-JiraIssueAttachmentFile" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
         $issueID = 41701
         $issueKey = 'IT-3676'
 
         $attachments = @"
 [
     {
-        "self": "$jiraServer/rest/api/2/attachment/10013",
+        "self": "rest/api/2/attachment/10013",
         "id": "10013",
         "filename": "foo.pdf",
         "author": {
-            "self": "$jiraServer/rest/api/2/user?username=admin",
+            "self": "rest/api/2/user?username=admin",
             "name": "admin",
             "key": "admin",
             "accountId": "000000:000000-0000-0000-0000-ab899c878d00",
@@ -64,11 +63,11 @@ Describe "Get-JiraIssueAttachmentFile" -Tag 'Unit' {
         "content": "$jiraServer/secure/attachment/10013/foo.pdf"
     },
     {
-        "self": "$jiraServer/rest/api/2/attachment/10010",
+        "self": "rest/api/2/attachment/10010",
         "id": "10010",
         "filename": "bar.pdf",
         "author": {
-            "self": "$jiraServer/rest/api/2/user?username=admin",
+            "self": "rest/api/2/user?username=admin",
             "name": "admin",
             "key": "admin",
             "accountId": "000000:000000-0000-0000-0000-ab899c878d00",

--- a/Tests/Functions/Get-JiraIssueComment.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraIssueComment.Unit.Tests.ps1
@@ -38,7 +38,6 @@ Describe "Get-JiraIssueComment" -Tag 'Unit' {
         . "$PSScriptRoot/../Shared.ps1"
 
 
-        $jiraServer = 'http://jiraserver.example.com'
         $issueID = 41701
         $issueKey = 'IT-3676'
 
@@ -49,7 +48,7 @@ Describe "Get-JiraIssueComment" -Tag 'Unit' {
     "total": 1,
     "comments": [
         {
-            "self": "$jiraServer/rest/api/2/issue/$issueID/comment/90730",
+            "self": "rest/api/2/issue/$issueID/comment/90730",
             "id": "90730",
             "body": "Test comment",
             "created": "2015-05-01T16:24:38.000-0500",
@@ -64,15 +63,12 @@ Describe "Get-JiraIssueComment" -Tag 'Unit' {
 "@
 
         #region Mocks
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            Write-Output $jiraServer
-        }
 
         Mock Get-JiraIssue -ModuleName JiraPS {
             $object = [PSCustomObject] @{
                 ID      = $issueID
                 Key     = $issueKey
-                RestUrl = "$jiraServer/rest/api/latest/issue/$issueID"
+                RestUrl = "rest/api/latest/issue/$issueID"
             }
             $object.PSObject.TypeNames.Insert(0, 'JiraPS.Issue')
             return $object
@@ -83,7 +79,7 @@ Describe "Get-JiraIssueComment" -Tag 'Unit' {
         }
 
         # Obtaining comments from an issue...this is IT-3676 in the test environment
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -eq "$jiraServer/rest/api/latest/issue/$issueID/comment"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -eq "rest/api/latest/issue/$issueID/comment"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             (ConvertFrom-Json -InputObject $restResult).comments
         }

--- a/Tests/Functions/Get-JiraIssueCreateMetadata.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraIssueCreateMetadata.Unit.Tests.ps1
@@ -251,7 +251,7 @@ Describe "Get-JiraIssueCreateMetadata" -Tag 'Unit' {
 
             defParam $command 'Project'
             defParam $command 'IssueType'
-            defParam $command 'Credential'
+            defParam $command 'Session'
         }
 
         Context "Behavior testing" {

--- a/Tests/Functions/Get-JiraIssueCreateMetadata.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraIssueCreateMetadata.Unit.Tests.ps1
@@ -37,8 +37,6 @@ Describe "Get-JiraIssueCreateMetadata" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'https://jira.example.com'
-
         $restResult = @"
 {
     "expand": "projects",
@@ -213,10 +211,6 @@ Describe "Get-JiraIssueCreateMetadata" -Tag 'Unit' {
 }
 "@
 
-        Mock Get-JiraConfigServer {
-            $jiraserver
-        }
-
         Mock Get-JiraProject -ModuleName JiraPS {
             $issueObject = [PSCustomObject] @{
                 ID   = 2
@@ -236,7 +230,7 @@ Describe "Get-JiraIssueCreateMetadata" -Tag 'Unit' {
             $InputObject
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -like "$jiraserver/rest/api/*/issue/createmeta?*"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -like "rest/api/*/issue/createmeta?*"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             return $restResult
         }

--- a/Tests/Functions/Get-JiraIssueEditMetadata.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraIssueEditMetadata.Unit.Tests.ps1
@@ -65,7 +65,7 @@ Describe "Get-JiraIssueEditMetadata" -Tag 'Unit' {
             "hasDefaultValue": false,
             "operations": [],
             "allowedValues": [{
-                "self": "$jiraServer/rest/api/2/issuetype/2",
+                "self": "rest/api/2/issuetype/2",
                 "id": "2",
                 "description": "This is a test issue type",
                 "iconUrl": "$jiraServer/images/icons/issuetypes/newfeature.png",
@@ -97,12 +97,12 @@ Describe "Get-JiraIssueEditMetadata" -Tag 'Unit' {
                 "set"
             ],
             "allowedValues": [{
-                "self": "$jiraServer/rest/api/2/project/10003",
+                "self": "rest/api/2/project/10003",
                 "id": "10003",
                 "key": "TEST",
                 "name": "Test Project",
                 "projectCategory": {
-                    "self": "$jiraServer/rest/api/2/projectCategory/10000",
+                    "self": "rest/api/2/projectCategory/10000",
                     "id": "10000",
                     "description": "All Project Catagories",
                     "name": "All Project"
@@ -116,7 +116,7 @@ Describe "Get-JiraIssueEditMetadata" -Tag 'Unit' {
                 "system": "reporter"
             },
             "name": "Reporter",
-            "autoCompleteUrl": "$jiraServer/rest/api/latest/user/search?username=",
+            "autoCompleteUrl": "rest/api/latest/user/search?username=",
             "hasDefaultValue": false,
             "operations": [
                 "set"
@@ -129,7 +129,7 @@ Describe "Get-JiraIssueEditMetadata" -Tag 'Unit' {
                 "system": "assignee"
             },
             "name": "Assignee",
-            "autoCompleteUrl": "$jiraServer/rest/api/latest/user/assignable/search?issueKey=null&username=",
+            "autoCompleteUrl": "rest/api/latest/user/assignable/search?issueKey=null&username=",
             "hasDefaultValue": false,
             "operations": [
                 "set"
@@ -147,31 +147,31 @@ Describe "Get-JiraIssueEditMetadata" -Tag 'Unit' {
                 "set"
             ],
             "allowedValues": [{
-                    "self": "$jiraServer/rest/api/2/priority/1",
+                    "self": "rest/api/2/priority/1",
                     "iconUrl": "$jiraServer/images/icons/priorities/blocker.png",
                     "name": "Blocker",
                     "id": "1"
                 },
                 {
-                    "self": "$jiraServer/rest/api/2/priority/2",
+                    "self": "rest/api/2/priority/2",
                     "iconUrl": "$jiraServer/images/icons/priorities/critical.png",
                     "name": "Critical",
                     "id": "2"
                 },
                 {
-                    "self": "$jiraServer/rest/api/2/priority/3",
+                    "self": "rest/api/2/priority/3",
                     "iconUrl": "$jiraServer/images/icons/priorities/major.png",
                     "name": "Major",
                     "id": "3"
                 },
                 {
-                    "self": "$jiraServer/rest/api/2/priority/4",
+                    "self": "rest/api/2/priority/4",
                     "iconUrl": "$jiraServer/images/icons/priorities/minor.png",
                     "name": "Minor",
                     "id": "4"
                 },
                 {
-                    "self": "$jiraServer/rest/api/2/priority/5",
+                    "self": "rest/api/2/priority/5",
                     "iconUrl": "$jiraServer/images/icons/priorities/trivial.png",
                     "name": "Trivial",
                     "id": "5"
@@ -186,7 +186,7 @@ Describe "Get-JiraIssueEditMetadata" -Tag 'Unit' {
                 "system": "labels"
             },
             "name": "Labels",
-            "autoCompleteUrl": "$jiraServer/rest/api/1.0/labels/suggest?query=",
+            "autoCompleteUrl": "rest/api/1.0/labels/suggest?query=",
             "hasDefaultValue": false,
             "operations": [
                 "add",
@@ -198,15 +198,11 @@ Describe "Get-JiraIssueEditMetadata" -Tag 'Unit' {
 }
 "@
 
-        Mock Get-JiraConfigServer {
-            $jiraServer
-        }
-
         Mock Get-JiraIssue -ModuleName JiraPS {
             [PSCustomObject] @{
                 ID      = $issueID
                 Key     = $issueKey
-                RestUrl = "$jiraServer/rest/api/latest/issue/$issueID"
+                RestUrl = "rest/api/latest/issue/$issueID"
             }
         }
 
@@ -214,7 +210,7 @@ Describe "Get-JiraIssueEditMetadata" -Tag 'Unit' {
             $InputObject
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -like "*/rest/api/*/issue/$issueID/editmeta"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -like "rest/api/*/issue/$issueID/editmeta"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             ConvertFrom-Json $restResult
         }

--- a/Tests/Functions/Get-JiraIssueEditMetadata.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraIssueEditMetadata.Unit.Tests.ps1
@@ -37,7 +37,6 @@ Describe "Get-JiraIssueEditMetadata" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = "https://jira.example.com"
         $issueID = 41701
         $issueKey = 'IT-3676'
 
@@ -229,7 +228,7 @@ Describe "Get-JiraIssueEditMetadata" -Tag 'Unit' {
             $command = Get-Command -Name Get-JiraIssueEditMetadata
 
             defParam $command 'Issue'
-            defParam $command 'Credential'
+            defParam $command 'Session'
         }
 
         Context "Behavior testing" {

--- a/Tests/Functions/Get-JiraIssueLink.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraIssueLink.Unit.Tests.ps1
@@ -37,8 +37,6 @@ Describe "Get-JiraIssueLink" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
-
         $issueLinkId = 1234
 
         # We don't care about anything except for the id
@@ -52,17 +50,13 @@ Describe "Get-JiraIssueLink" -Tag 'Unit' {
 }
 "@
 
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            Write-Output $jiraServer
-        }
-
         # Generic catch-all. This will throw an exception if we forgot to mock something.
         Mock Invoke-JiraMethod -ModuleName JiraPS {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             throw "Unidentified call to Invoke-JiraMethod"
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -eq "$jiraServer/rest/api/2/issueLink/1234"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -eq "rest/api/2/issueLink/1234"} {
             ConvertFrom-Json $resultsJson
         }
 

--- a/Tests/Functions/Get-JiraIssueLinkType.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraIssueLinkType.Unit.Tests.ps1
@@ -48,7 +48,7 @@ Describe 'Get-JiraIssueLinkType' -Tag 'Unit' {
             $command = Get-Command -Name Get-JiraIssueLinkType
 
             defParam $command 'LinkType'
-            defParam $command 'Credential'
+            defParam $command 'Session'
         }
 
         $filterAll = {$Method -eq 'Get' -and $Uri -ceq "$jiraServer/rest/api/latest/issueLinkType"}

--- a/Tests/Functions/Get-JiraIssueLinkType.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraIssueLinkType.Unit.Tests.ps1
@@ -37,13 +37,6 @@ Describe 'Get-JiraIssueLinkType' -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
-
-
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            Write-Output $jiraServer
-        }
-
         Context "Sanity checking" {
             $command = Get-Command -Name Get-JiraIssueLinkType
 
@@ -51,8 +44,8 @@ Describe 'Get-JiraIssueLinkType' -Tag 'Unit' {
             defParam $command 'Session'
         }
 
-        $filterAll = {$Method -eq 'Get' -and $Uri -ceq "$jiraServer/rest/api/latest/issueLinkType"}
-        $filterOne = {$Method -eq 'Get' -and $Uri -ceq "$jiraServer/rest/api/latest/issueLinkType/10000"}
+        $filterAll = {$Method -eq 'Get' -and $Uri -ceq "rest/api/latest/issueLinkType"}
+        $filterOne = {$Method -eq 'Get' -and $Uri -ceq "rest/api/latest/issueLinkType/10000"}
 
         Mock ConvertTo-JiraIssueLinkType {
             ShowMockInfo 'ConvertTo-JiraIssueLinkType'

--- a/Tests/Functions/Get-JiraIssueType.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraIssueType.Unit.Tests.ps1
@@ -37,15 +37,13 @@ Describe "Get-JiraIssueType" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
-
         $issueTypeId = 2
         $issueTypeName = 'Desktop Support'
 
         $restResult = @"
 [
     {
-        "self": "$jiraServer/rest/api/latest/issuetype/12",
+        "self": "rest/api/latest/issuetype/12",
         "id": "12",
         "description": "This issue type is no longer used.",
         "iconUrl": "$jiraServer/images/icons/issuetypes/delete.png",
@@ -53,7 +51,7 @@ Describe "Get-JiraIssueType" -Tag 'Unit' {
         "subtask": false
     },
     {
-        "self": "$jiraServer/rest/api/latest/issuetype/11",
+        "self": "rest/api/latest/issuetype/11",
         "id": "11",
         "description": "An issue related to classroom technology, moodle, library services",
         "iconUrl": "$jiraServer/images/icons/issuetypes/documentation.png",
@@ -61,7 +59,7 @@ Describe "Get-JiraIssueType" -Tag 'Unit' {
         "subtask": false
     },
     {
-        "self": "$jiraServer/rest/api/latest/issuetype/4",
+        "self": "rest/api/latest/issuetype/4",
         "id": "4",
         "description": "An issue related to network connectivity or infrastructure including Access Control.",
         "iconUrl": "$jiraServer/images/icons/issuetypes/improvement.png",
@@ -69,7 +67,7 @@ Describe "Get-JiraIssueType" -Tag 'Unit' {
         "subtask": false
     },
     {
-        "self": "$jiraServer/rest/api/latest/issuetype/6",
+        "self": "rest/api/latest/issuetype/6",
         "id": "6",
         "description": "An issue related to telephone services",
         "iconUrl": "$jiraServer/images/icons/issuetypes/genericissue.png",
@@ -77,7 +75,7 @@ Describe "Get-JiraIssueType" -Tag 'Unit' {
         "subtask": false
     },
     {
-        "self": "$jiraServer/rest/api/latest/issuetype/8",
+        "self": "rest/api/latest/issuetype/8",
         "id": "8",
         "description": "An issue related to A/V and media services including teacher stations",
         "iconUrl": "$jiraServer/images/icons/issuetypes/genericissue.png",
@@ -85,7 +83,7 @@ Describe "Get-JiraIssueType" -Tag 'Unit' {
         "subtask": false
     },
     {
-        "self": "$jiraServer/rest/api/latest/issuetype/1",
+        "self": "rest/api/latest/issuetype/1",
         "id": "1",
         "description": "An issue related to Banner, MU Online, Oracle Reports, MU Account Suite, Hobsons, or CS Gold",
         "iconUrl": "$jiraServer/images/icons/issuetypes/bug.png",
@@ -93,7 +91,7 @@ Describe "Get-JiraIssueType" -Tag 'Unit' {
         "subtask": false
     },
     {
-        "self": "$jiraServer/rest/api/latest/issuetype/10",
+        "self": "rest/api/latest/issuetype/10",
         "id": "10",
         "description": "The sub-task of the issue",
         "iconUrl": "$jiraServer/images/icons/issuetypes/subtask_alternate.png",
@@ -101,7 +99,7 @@ Describe "Get-JiraIssueType" -Tag 'Unit' {
         "subtask": true
     },
     {
-        "self": "$jiraServer/rest/api/latest/issuetype/2",
+        "self": "rest/api/latest/issuetype/2",
         "id": "2",
         "description": "An issue related to end-user workstations.",
         "iconUrl": "$jiraServer/images/icons/issuetypes/newfeature.png",
@@ -111,15 +109,11 @@ Describe "Get-JiraIssueType" -Tag 'Unit' {
 ]
 "@
 
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            Write-Output $jiraServer
-        }
-
         Mock ConvertTo-JiraIssueType {
             $inputObject
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $Uri -eq "$jiraServer/rest/api/latest/issuetype"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $Uri -eq "rest/api/latest/issuetype"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             ConvertFrom-Json $restResult
         }

--- a/Tests/Functions/Get-JiraIssueWatcher.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraIssueWatcher.Unit.Tests.ps1
@@ -97,7 +97,7 @@ Describe "Get-JiraIssueWatcher" -Tag 'Unit' {
             $command = Get-Command -Name Get-JiraIssueWatcher
 
             defParam $command 'Issue'
-            defParam $command 'Credential'
+            defParam $command 'Session'
         }
 
         Context "Behavior testing" {

--- a/Tests/Functions/Get-JiraIssueWatcher.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraIssueWatcher.Unit.Tests.ps1
@@ -59,15 +59,12 @@ Describe "Get-JiraIssueWatcher" -Tag 'Unit' {
     ]
 }
 "@
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            Write-Output $jiraServer
-        }
 
         Mock Get-JiraIssue -ModuleName JiraPS {
             $object = [PSCustomObject] @{
                 ID      = $issueID
                 Key     = $issueKey
-                RestUrl = "$jiraServer/rest/api/latest/issue/$issueID"
+                RestUrl = "rest/api/latest/issue/$issueID"
             }
             $object.PSObject.TypeNames.Insert(0, 'JiraPS.Issue')
             return $object
@@ -78,7 +75,7 @@ Describe "Get-JiraIssueWatcher" -Tag 'Unit' {
         }
 
         # Obtaining watchers from an issue...this is IT-3676 in the test environment
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -eq "$jiraServer/rest/api/latest/issue/$issueID/watchers"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -eq "rest/api/latest/issue/$issueID/watchers"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             ConvertFrom-Json -InputObject $restResult
         }

--- a/Tests/Functions/Get-JiraPriority.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraPriority.Unit.Tests.ps1
@@ -37,40 +37,38 @@ Describe "Get-JiraPriority" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
-
         $restResultAll = @"
 [
     {
-        "self": "$jiraServer/rest/api/2/priority/1",
+        "self": "rest/api/2/priority/1",
         "statusColor": "#cc0000",
         "description": "Cannot continue work. Affects teaching and learning",
         "name": "Critical",
         "id": "1"
     },
     {
-        "self": "$jiraServer/rest/api/2/priority/2",
+        "self": "rest/api/2/priority/2",
         "statusColor": "#ff0000",
         "description": "High priority, attention needed immediately",
         "name": "High",
         "id": "2"
     },
     {
-        "self": "$jiraServer/rest/api/2/priority/3",
+        "self": "rest/api/2/priority/3",
         "statusColor": "#ffff66",
         "description": "Typical request for information or service",
         "name": "Normal",
         "id": "3"
     },
     {
-        "self": "$jiraServer/rest/api/2/priority/4",
+        "self": "rest/api/2/priority/4",
         "statusColor": "#006600",
         "description": "Upcoming project, planned request",
         "name": "Project",
         "id": "4"
     },
     {
-        "self": "$jiraServer/rest/api/2/priority/5",
+        "self": "rest/api/2/priority/5",
         "statusColor": "#0000ff",
         "description": "General questions, request for enhancement, wish list",
         "name": "Low",
@@ -81,7 +79,7 @@ Describe "Get-JiraPriority" -Tag 'Unit' {
 
         $restResultOne = @"
 {
-    "self": "$jiraServer/rest/api/2/priority/1",
+    "self": "rest/api/2/priority/1",
     "statusColor": "#cc0000",
     "description": "Cannot continue work. Affects teaching and learning",
     "name": "Critical",
@@ -89,19 +87,15 @@ Describe "Get-JiraPriority" -Tag 'Unit' {
 }
 "@
 
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            Write-Output $jiraServer
-        }
-
         Mock ConvertTo-JiraPriority -ModuleName JiraPS {
             $InputObject
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -eq "$jiraServer/rest/api/latest/priority"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -eq "rest/api/latest/priority"} {
             ConvertFrom-Json $restResultAll
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -eq "$jiraServer/rest/api/latest/priority/1"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -eq "rest/api/latest/priority/1"} {
             ConvertFrom-Json $restResultOne
         }
 

--- a/Tests/Functions/Get-JiraProject.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraProject.Unit.Tests.ps1
@@ -37,8 +37,6 @@ Describe "Get-JiraProject" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
-
         $projectKey = 'IT'
         $projectId = '10003'
         $projectName = 'Information Technology'
@@ -50,24 +48,24 @@ Describe "Get-JiraProject" -Tag 'Unit' {
         $restResultAll = @"
 [
     {
-        "self": "$jiraServer/rest/api/2/project/10003",
+        "self": "rest/api/2/project/10003",
         "id": "$projectId",
         "key": "$projectKey",
         "name": "$projectName",
         "projectCategory": {
-            "self": "$jiraServer/rest/api/2/projectCategory/10000",
+            "self": "rest/api/2/projectCategory/10000",
             "id": "10000",
             "description": "All Project Catagories",
             "name": "All Project"
         }
     },
     {
-        "self": "$jiraServer/rest/api/2/project/10121",
+        "self": "rest/api/2/project/10121",
         "id": "$projectId2",
         "key": "$projectKey2",
         "name": "$projectName2",
         "projectCategory": {
-            "self": "$jiraServer/rest/api/2/projectCategory/10000",
+            "self": "rest/api/2/projectCategory/10000",
             "id": "10000",
             "description": "All Project Catagories",
             "name": "All Project"
@@ -79,12 +77,12 @@ Describe "Get-JiraProject" -Tag 'Unit' {
         $restResultOne = @"
 [
     {
-        "self": "$jiraServer/rest/api/2/project/10003",
+        "self": "rest/api/2/project/10003",
         "id": "$projectId",
         "key": "$projectKey",
         "name": "$projectName",
         "projectCategory": {
-            "self": "$jiraServer/rest/api/2/projectCategory/10000",
+            "self": "rest/api/2/projectCategory/10000",
             "id": "10000",
             "description": "All Project Catagories",
             "name": "All Project"
@@ -92,16 +90,13 @@ Describe "Get-JiraProject" -Tag 'Unit' {
     }
 ]
 "@
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            Write-Output $jiraServer
-        }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/*/project*"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -like "rest/api/*/project*"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             ConvertFrom-Json $restResultAll
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/*/project/$projectKey?*"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -like "rest/api/*/project/$projectKey?*"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             ConvertFrom-Json $restResultOne
         }

--- a/Tests/Functions/Get-JiraRemoteLink.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraRemoteLink.Unit.Tests.ps1
@@ -44,7 +44,7 @@ Describe "Get-JiraRemoteLink" -Tag 'Unit' {
         $restResult = @"
 {
     "id": 10000,
-    "self": "$jiraServer/rest/api/latest/issue/MKY-1/remotelink/10000",
+    "self": "rest/api/latest/issue/MKY-1/remotelink/10000",
     "globalId": "system=http://www.mycompany.com/support&id=1",
     "application": {
         "type": "com.acme.tracker",
@@ -63,13 +63,9 @@ Describe "Get-JiraRemoteLink" -Tag 'Unit' {
 }
 "@
 
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            Write-Output $jiraServer
-        }
-
         Mock Get-JiraIssue {
             $object = [PSCustomObject] @{
-                'RestURL' = "$jiraServer/rest/api/latest/issue/12345"
+                'RestURL' = "rest/api/latest/issue/12345"
                 'Key'     = $issueKey
             }
             $object.PSObject.TypeNames.Insert(0, 'JiraPS.Issue')
@@ -109,7 +105,7 @@ Describe "Get-JiraRemoteLink" -Tag 'Unit' {
                 ModuleName = 'JiraPS'
                 ParameterFilter = {
                     $Method -eq "Get" -and
-                    $Uri -like "$jiraServer/rest/api/*/issue/12345/remotelink"
+                    $Uri -like "rest/api/*/issue/12345/remotelink"
                 }
                 Exactly = $true
                 Times = 1
@@ -136,7 +132,7 @@ Describe "Get-JiraRemoteLink" -Tag 'Unit' {
                 ModuleName = 'JiraPS'
                 ParameterFilter = {
                     $Method -eq "Get" -and
-                    $Uri -like "$jiraServer/rest/api/*/issue/12345/remotelink/10000"
+                    $Uri -like "rest/api/*/issue/12345/remotelink/10000"
                 }
                 Exactly = $true
                 Times = 1

--- a/Tests/Functions/Get-JiraServerInformation.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraServerInformation.Unit.Tests.ps1
@@ -37,8 +37,6 @@ Describe "Get-JiraServerInformation" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
-
         $restResult = @"
 {
     "baseUrl":"$jiraServer",
@@ -52,11 +50,8 @@ Describe "Get-JiraServerInformation" -Tag 'Unit' {
     "serverTitle":"JIRA"
 }
 "@
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            Write-Output $jiraServer
-        }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -eq "$jiraServer/rest/api/latest/serverInfo"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -eq "rest/api/latest/serverInfo"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             ConvertFrom-Json $restResult
         }

--- a/Tests/Functions/Get-JiraUser.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraUser.Unit.Tests.ps1
@@ -37,8 +37,6 @@ Describe "Get-JiraUser" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
-
         $testUsername = 'powershell-test'
         $testEmail = "$testUsername@example.com"
 
@@ -48,7 +46,7 @@ Describe "Get-JiraUser" -Tag 'Unit' {
         $restResult = @"
 [
     {
-        "self": "$jiraServer/rest/api/2/user?username=$testUsername",
+        "self": "rest/api/2/user?username=$testUsername",
         "key": "$testUsername",
         "name": "$testUsername",
         "emailAddress": "$testEmail",
@@ -61,7 +59,7 @@ Describe "Get-JiraUser" -Tag 'Unit' {
         # Removed from JSON: avatarUrls, timeZone
         $restResult2 = @"
 {
-    "self": "$jiraServer/rest/api/2/user?username=$testUsername",
+    "self": "rest/api/2/user?username=$testUsername",
     "key": "$testUsername",
     "name": "$testUsername",
     "emailAddress": "$testEmail",
@@ -72,11 +70,11 @@ Describe "Get-JiraUser" -Tag 'Unit' {
         "items": [
             {
                 "name": "$testGroup1",
-                "self": "$jiraServer/rest/api/2/group?groupname=$testGroup1"
+                "self": "rest/api/2/group?groupname=$testGroup1"
             },
             {
                 "name": "$testGroup2",
-                "self": "$jiraServer/rest/api/2/group?groupname=$testGroup2"
+                "self": "rest/api/2/group?groupname=$testGroup2"
             }
         ]
     },
@@ -84,38 +82,34 @@ Describe "Get-JiraUser" -Tag 'Unit' {
 }
 "@
 
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            Write-Output $jiraServer
-        }
-
         Mock ConvertTo-JiraUser -ModuleName JiraPS {
             $InputObject
         }
 
         # Return information of the current user
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/*/myself"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -like "rest/api/*/myself"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             ConvertFrom-Json -InputObject $restResult
         }
 
         # Searching for a user.
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/*/user/search?*username=$testUsername*"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -like "rest/api/*/user/search?*username=$testUsername*"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             ConvertFrom-Json -InputObject $restResult
         }
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/*/user/search?*username=%25*"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -like "rest/api/*/user/search?*username=%25*"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             ConvertFrom-Json -InputObject $restResult
         }
 
         # Get exact user
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/*/user?username=$testUsername"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -like "rest/api/*/user?username=$testUsername"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             ConvertFrom-Json -InputObject $restResult
         }
 
         # Viewing a specific user. The main difference here is that this includes groups, and the first does not.
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/*/user?username=$testUsername&expand=groups"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Get' -and $URI -like "rest/api/*/user?username=$testUsername&expand=groups"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             ConvertFrom-Json -InputObject $restResult2
         }
@@ -135,8 +129,8 @@ Describe "Get-JiraUser" -Tag 'Unit' {
 
             $getResult | Should Not BeNullOrEmpty
 
-            Assert-MockCalled -CommandName Invoke-JiraMethod -Exactly 1 -Scope It -ParameterFilter {$URI -like "$jiraServer/rest/api/*/myself"}
-            Assert-MockCalled -CommandName Invoke-JiraMethod -Exactly 1 -Scope It -ParameterFilter {$URI -like "$jiraServer/rest/api/*/user?username=$testUsername&expand=groups"}
+            Assert-MockCalled -CommandName Invoke-JiraMethod -Exactly 1 -Scope It -ParameterFilter {$URI -like "rest/api/*/myself"}
+            Assert-MockCalled -CommandName Invoke-JiraMethod -Exactly 1 -Scope It -ParameterFilter {$URI -like "rest/api/*/user?username=$testUsername&expand=groups"}
         }
 
         It "Gets information about a provided Jira user" {
@@ -144,8 +138,8 @@ Describe "Get-JiraUser" -Tag 'Unit' {
 
             $getResult | Should Not BeNullOrEmpty
 
-            Assert-MockCalled -CommandName Invoke-JiraMethod -Exactly 1 -Scope It -ParameterFilter {$URI -like "$jiraServer/rest/api/*/user/search?*username=$testUsername*"}
-            Assert-MockCalled -CommandName Invoke-JiraMethod -Exactly 1 -Scope It -ParameterFilter {$URI -like "$jiraServer/rest/api/*/user?username=$testUsername&expand=groups"}
+            Assert-MockCalled -CommandName Invoke-JiraMethod -Exactly 1 -Scope It -ParameterFilter {$URI -like "rest/api/*/user/search?*username=$testUsername*"}
+            Assert-MockCalled -CommandName Invoke-JiraMethod -Exactly 1 -Scope It -ParameterFilter {$URI -like "rest/api/*/user?username=$testUsername&expand=groups"}
         }
 
         It "Gets information about a provided Jira exact user" {
@@ -153,8 +147,8 @@ Describe "Get-JiraUser" -Tag 'Unit' {
 
             $getResult | Should Not BeNullOrEmpty
 
-            Assert-MockCalled -CommandName Invoke-JiraMethod -Exactly 1 -Scope It -ParameterFilter {$Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/*/user?username=$testUsername"}
-            Assert-MockCalled -CommandName Invoke-JiraMethod -Exactly 1 -Scope It -ParameterFilter {$URI -like "$jiraServer/rest/api/*/user?username=$testUsername&expand=groups"}
+            Assert-MockCalled -CommandName Invoke-JiraMethod -Exactly 1 -Scope It -ParameterFilter {$Method -eq 'Get' -and $URI -like "rest/api/*/user?username=$testUsername"}
+            Assert-MockCalled -CommandName Invoke-JiraMethod -Exactly 1 -Scope It -ParameterFilter {$URI -like "rest/api/*/user?username=$testUsername&expand=groups"}
         }
 
         It "Returns all available properties about the returned user object" {
@@ -167,7 +161,7 @@ Describe "Get-JiraUser" -Tag 'Unit' {
             $getResult.DisplayName | Should Be $restObj.displayName
             $getResult.Active | Should Be $restObj.active
 
-            Assert-MockCalled -CommandName Invoke-JiraMethod -Exactly 1 -Scope It -ParameterFilter {$URI -like "$jiraServer/rest/api/*/user?username=$testUsername&expand=groups"}
+            Assert-MockCalled -CommandName Invoke-JiraMethod -Exactly 1 -Scope It -ParameterFilter {$URI -like "rest/api/*/user?username=$testUsername&expand=groups"}
         }
 
         It "Gets information for a provided Jira user if a JiraPS.User object is provided to the InputObject parameter" {
@@ -177,14 +171,14 @@ Describe "Get-JiraUser" -Tag 'Unit' {
             $result2 | Should Not BeNullOrEmpty
             $result2.Name | Should Be $testUsername
 
-            Assert-MockCalled -CommandName Invoke-JiraMethod -Exactly 2 -Scope It -ParameterFilter {$URI -like "$jiraServer/rest/api/*/user?username=$testUsername&expand=groups"}
+            Assert-MockCalled -CommandName Invoke-JiraMethod -Exactly 2 -Scope It -ParameterFilter {$URI -like "rest/api/*/user?username=$testUsername&expand=groups"}
         }
 
         It "Allow it search for multiple users" {
             Get-JiraUser -UserName "%"
 
             Assert-MockCalled -CommandName Invoke-JiraMethod -Exactly 1 -Scope It -ParameterFilter {
-                $URI -like "$jiraServer/rest/api/*/user/search?*username=%25*"
+                $URI -like "rest/api/*/user/search?*username=%25*"
             }
         }
 
@@ -192,7 +186,7 @@ Describe "Get-JiraUser" -Tag 'Unit' {
             Get-JiraUser -UserName "%" -MaxResults 100
 
             Assert-MockCalled -CommandName Invoke-JiraMethod -Exactly 1 -Scope It -ParameterFilter {
-                $URI -like "$jiraServer/rest/api/*/user/search?*maxResults=100*"
+                $URI -like "rest/api/*/user/search?*maxResults=100*"
             }
         }
 
@@ -200,7 +194,7 @@ Describe "Get-JiraUser" -Tag 'Unit' {
             Get-JiraUser -UserName "%" -Skip 10
 
             Assert-MockCalled -CommandName Invoke-JiraMethod -Exactly 1 -Scope It -ParameterFilter {
-                $URI -like "$jiraServer/rest/api/*/user/search?*startAt=10*"
+                $URI -like "rest/api/*/user/search?*startAt=10*"
             }
         }
 

--- a/Tests/Functions/Get-JiraVersion.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraVersion.Unit.Tests.ps1
@@ -38,7 +38,6 @@ Describe "Get-JiraVersion" -Tag 'Unit' {
         . "$PSScriptRoot/../Shared.ps1"
 
         #region Definitions
-        $jiraServer = 'http://jiraserver.example.com'
         $versionName1 = 'v1.0'
         $versionName2 = 'v2.0'
         $versionName3 = 'v3.0'
@@ -62,7 +61,7 @@ Describe "Get-JiraVersion" -Tag 'Unit' {
 "@
         $testJson1 = @"
 {
-    "self" : "$jiraServer/rest/api/latest/version/$versionID1",
+    "self" : "rest/api/latest/version/$versionID1",
     "id" : $versionID1,
     "description" : "$versionName1",
     "name" : "$versionName1",
@@ -73,7 +72,7 @@ Describe "Get-JiraVersion" -Tag 'Unit' {
 "@
         $testJson2 = @"
 {
-    "self" : "$jiraServer/rest/api/latest/version/$versionID2",
+    "self" : "rest/api/latest/version/$versionID2",
     "id" : $versionID2,
     "description" : "$versionName2",
     "name" : "$versionName2",
@@ -85,7 +84,7 @@ Describe "Get-JiraVersion" -Tag 'Unit' {
         $testJsonAll = @"
 [
     {
-        "self" : "$jiraServer/rest/api/latest/version/$versionID1",
+        "self" : "rest/api/latest/version/$versionID1",
         "id" : $versionID1,
         "description" : "$versionName1",
         "name" : "$versionName1",
@@ -94,7 +93,7 @@ Describe "Get-JiraVersion" -Tag 'Unit' {
         "projectId" : "$projectId"
     },
     {
-        "self" : "$jiraServer/rest/api/latest/version/$versionID2",
+        "self" : "rest/api/latest/version/$versionID2",
         "id" : $versionID2,
         "description" : "$versionName2",
         "name" : "$versionName2",
@@ -103,7 +102,7 @@ Describe "Get-JiraVersion" -Tag 'Unit' {
         "projectId" : "$projectId"
     },
     {
-        "self" : "$jiraServer/rest/api/latest/version/$versionID3",
+        "self" : "rest/api/latest/version/$versionID3",
         "id" : $versionID3,
         "description" : "$versionName3",
         "name" : "$versionName3",
@@ -116,9 +115,6 @@ Describe "Get-JiraVersion" -Tag 'Unit' {
         #endregion Definitions
 
         #region Mocks
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            Write-Output $jiraServer
-        }
 
         Mock Get-JiraProject -ModuleName JiraPS {
             $json = ConvertFrom-Json $JiraProjectData
@@ -137,22 +133,22 @@ Describe "Get-JiraVersion" -Tag 'Unit' {
             $result
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/latest/version/$versionId1" } {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "rest/api/latest/version/$versionId1" } {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             ConvertFrom-Json $testJson1
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/*/version/$versionId2" } {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "rest/api/*/version/$versionId2" } {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             ConvertFrom-Json $testJson2
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/*/version" } {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "rest/api/*/version" } {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             ConvertFrom-Json $testJsonAll
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/*/project/*/version" } {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "rest/api/*/project/*/version" } {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             ConvertFrom-Json $testJsonAll
         }
@@ -185,7 +181,7 @@ Describe "Get-JiraVersion" -Tag 'Unit' {
                     ModuleName      = 'JiraPS'
                     ParameterFilter = {
                         $Method -eq 'Get' -and
-                        $URI -like "*/rest/api/*/version/$versionID1"
+                        $URI -like "rest/api/*/version/$versionID1"
                     }
                     Scope           = 'It'
                     Exactly         = $true
@@ -213,7 +209,7 @@ Describe "Get-JiraVersion" -Tag 'Unit' {
                     ModuleName      = 'JiraPS'
                     ParameterFilter = {
                         $Method -eq 'Get' -and
-                        $URI -like "*/rest/api/*/version/$versionID1"
+                        $URI -like "rest/api/*/version/$versionID1"
                     }
                     Scope           = 'It'
                     Exactly         = $true
@@ -226,7 +222,7 @@ Describe "Get-JiraVersion" -Tag 'Unit' {
                     ModuleName      = 'JiraPS'
                     ParameterFilter = {
                         $Method -eq 'Get' -and
-                        $URI -like "*/rest/api/*/version/$versionID2"
+                        $URI -like "rest/api/*/version/$versionID2"
                     }
                     Scope           = 'It'
                     Exactly         = $true
@@ -258,7 +254,7 @@ Describe "Get-JiraVersion" -Tag 'Unit' {
                     ModuleName      = 'JiraPS'
                     ParameterFilter = {
                         $Method -eq 'Get' -and
-                        $URI -like "*/rest/api/*/version/$versionID2"
+                        $URI -like "rest/api/*/version/$versionID2"
                     }
                     Scope           = 'It'
                     Exactly         = $true
@@ -286,7 +282,7 @@ Describe "Get-JiraVersion" -Tag 'Unit' {
                     ModuleName      = 'JiraPS'
                     ParameterFilter = {
                         $Method -eq 'Get' -and
-                        $URI -like "*/rest/api/*/project/$projectKey/version" -and
+                        $URI -like "rest/api/*/project/$projectKey/version" -and
                         $Paging -eq $true
                     }
                     Scope           = 'It'
@@ -324,7 +320,7 @@ Describe "Get-JiraVersion" -Tag 'Unit' {
                     ModuleName      = 'JiraPS'
                     ParameterFilter = {
                         $Method -eq 'Get' -and
-                        $URI -like "*/rest/api/*/project/$projectKey/version" -and
+                        $URI -like "rest/api/*/project/$projectKey/version" -and
                         $Paging -eq $true
                     }
                     Scope           = 'It'
@@ -364,7 +360,7 @@ Describe "Get-JiraVersion" -Tag 'Unit' {
                     ModuleName      = 'JiraPS'
                     ParameterFilter = {
                         $Method -eq 'Get' -and
-                        $URI -like "*/rest/api/*/project/*/version" -and
+                        $URI -like "rest/api/*/project/*/version" -and
                         $Paging -eq $true
                     }
                     Scope           = 'It'
@@ -402,7 +398,7 @@ Describe "Get-JiraVersion" -Tag 'Unit' {
                     ModuleName      = 'JiraPS'
                     ParameterFilter = {
                         $Method -eq 'Get' -and
-                        $URI -like "*/rest/api/*/project/*/version" -and
+                        $URI -like "rest/api/*/project/*/version" -and
                         $Paging -eq $true
                     }
                     Scope           = 'It'
@@ -440,7 +436,7 @@ Describe "Get-JiraVersion" -Tag 'Unit' {
                     ModuleName      = 'JiraPS'
                     ParameterFilter = {
                         $Method -eq 'Get' -and
-                        $URI -like "*/rest/api/*/project/*/version" -and
+                        $URI -like "rest/api/*/project/*/version" -and
                         $Paging -eq $true
                     }
                     Scope           = 'It'
@@ -476,7 +472,7 @@ Describe "Get-JiraVersion" -Tag 'Unit' {
                     ModuleName      = 'JiraPS'
                     ParameterFilter = {
                         $Method -eq 'Get' -and
-                        $URI -like '*/rest/api/*/project/*/version' -and
+                        $URI -like 'rest/api/*/project/*/version' -and
                         $Paging -eq $true -and
                         $PSCmdlet.PagingParameters.Skip -eq 10
                     }
@@ -495,7 +491,7 @@ Describe "Get-JiraVersion" -Tag 'Unit' {
                     ModuleName      = 'JiraPS'
                     ParameterFilter = {
                         $Method -eq 'Get' -and
-                        $URI -like '*/rest/api/*/project/*/version' -and
+                        $URI -like 'rest/api/*/project/*/version' -and
                         $Paging -eq $true -and
                         $PSCmdlet.PagingParameters.First -eq 50
                     }

--- a/Tests/Functions/Get-JiraVersion.Unit.Tests.ps1
+++ b/Tests/Functions/Get-JiraVersion.Unit.Tests.ps1
@@ -170,7 +170,7 @@ Describe "Get-JiraVersion" -Tag 'Unit' {
             defParam $command 'Project'
             defParam $command 'Name'
             defParam $command 'ID'
-            defParam $command 'Credential'
+            defParam $command 'Session'
         }
 
         Context "Behavior checking" {

--- a/Tests/Functions/Invoke-JiraIssueTransition.Unit.Tests.ps1
+++ b/Tests/Functions/Invoke-JiraIssueTransition.Unit.Tests.ps1
@@ -37,14 +37,9 @@ Describe "Invoke-JiraIssueTransition" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
         $issueID = 41701
         $issueKey = 'IT-3676'
 
-
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            Write-Output $jiraServer
-        }
 
         Mock Get-JiraField {
             $object = [PSCustomObject] @{
@@ -70,7 +65,7 @@ Describe "Invoke-JiraIssueTransition" -Tag 'Unit' {
             $object = [PSCustomObject] @{
                 ID         = $issueID
                 Key        = $issueKey
-                RestUrl    = "$jiraServer/rest/api/latest/issue/$issueID"
+                RestUrl    = "rest/api/latest/issue/$issueID"
                 Transition = @($t1, $t2)
             }
             $object.PSObject.TypeNames.Insert(0, 'JiraPS.Issue')
@@ -81,7 +76,7 @@ Describe "Invoke-JiraIssueTransition" -Tag 'Unit' {
             Get-JiraIssue -Key $Issue
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Post' -and $URI -eq "$jiraServer/rest/api/latest/issue/$issueID/transitions"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Post' -and $URI -eq "rest/api/latest/issue/$issueID/transitions"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             # This should return a 204 status code, so no data should actually be returned
         }
@@ -135,32 +130,32 @@ Describe "Invoke-JiraIssueTransition" -Tag 'Unit' {
                 Invoke-JiraIssueTransition @parameter
             } | Should Not Throw
 
-            Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Post' -and $URI -like "*/rest/api/latest/issue/$issueID/transitions" -and $Body -like '*customfield_12345*set*foo*' }
-            Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Post' -and $URI -like "*/rest/api/latest/issue/$issueID/transitions" -and $Body -like '*customfield_67890*set*bar*' }
+            Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Post' -and $URI -like "rest/api/latest/issue/$issueID/transitions" -and $Body -like '*customfield_12345*set*foo*' }
+            Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Post' -and $URI -like "rest/api/latest/issue/$issueID/transitions" -and $Body -like '*customfield_67890*set*bar*' }
         }
 
         It "Updates assignee name if provided to the -Assignee parameter" {
             Mock Get-JiraUser {
                 [PSCustomObject] @{
                     'Name'    = 'powershell-user'
-                    'RestUrl' = "$jiraServer/rest/api/2/user?username=powershell-user"
+                    'RestUrl' = "rest/api/2/user?username=powershell-user"
                 }
             }
             { Invoke-JiraIssueTransition -Issue $issueKey -Transition 11 -Assignee 'powershell-user'} | Should Not Throw
 
-            Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Post' -and $URI -like "*/rest/api/latest/issue/$issueID/transitions" -and $Body -like '*name*powershell-user*' }
+            Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Post' -and $URI -like "rest/api/latest/issue/$issueID/transitions" -and $Body -like '*name*powershell-user*' }
         }
 
         It "Unassigns an issue if 'Unassigned' is passed to the -Assignee parameter" {
             { Invoke-JiraIssueTransition -Issue $issueKey -Transition 11 -Assignee 'Unassigned'} | Should Not Throw
 
-            Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Post' -and $URI -like "*/rest/api/latest/issue/$issueID/transitions" -and $Body -like '*name*""*' }
+            Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Post' -and $URI -like "rest/api/latest/issue/$issueID/transitions" -and $Body -like '*name*""*' }
         }
 
         It "Adds a comment if provide to the -Comment parameter" {
             { Invoke-JiraIssueTransition -Issue $issueKey -Transition 11 -Comment 'test comment'} | Should Not Throw
 
-            Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Post' -and $URI -like "*/rest/api/latest/issue/$issueID/transitions" -and $Body -like '*body*test comment*' }
+            Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Post' -and $URI -like "rest/api/latest/issue/$issueID/transitions" -and $Body -like '*body*test comment*' }
         }
 
         It "Returns the Issue object when -Passthru is provided" {

--- a/Tests/Functions/Move-JiraVersion.Unit.Tests.ps1
+++ b/Tests/Functions/Move-JiraVersion.Unit.Tests.ps1
@@ -104,7 +104,7 @@ Describe "Move-JiraVersion" -Tag 'Unit' {
             defParam $command 'Version'
             defParam $command 'Position'
             defParam $command 'After'
-            defParam $command 'Credential'
+            defParam $command 'Session'
         }
 
         Context "ByPosition behavior checking" {

--- a/Tests/Functions/Move-JiraVersion.Unit.Tests.ps1
+++ b/Tests/Functions/Move-JiraVersion.Unit.Tests.ps1
@@ -37,7 +37,6 @@ Describe "Move-JiraVersion" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
         $versionID1 = 16840
         $versionID2 = 16940
         $projectKey = 'LDD'
@@ -57,9 +56,6 @@ Describe "Move-JiraVersion" -Tag 'Unit' {
 "@
 
         #region Mock
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            Write-Output $jiraServer
-        }
 
         Mock Get-JiraProject -ModuleName JiraPS {
             $Projects = ConvertFrom-Json $JiraProjectData
@@ -76,18 +72,18 @@ Describe "Move-JiraVersion" -Tag 'Unit' {
                     Project     = (Get-JiraProject -Project $projectKey)
                     ReleaseDate = (Get-Date "2017-12-01")
                     StartDate   = (Get-Date "2017-01-01")
-                    RestUrl     = "$jiraServer/rest/api/latest/version/$_Id"
+                    RestUrl     = "rest/api/latest/version/$_Id"
                 }
                 $Version.PSObject.TypeNames.Insert(0, 'JiraPS.Version')
                 $Version
             }
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'POST' -and $URI -like "$jiraServer/rest/api/*/version/$versionID1/move" } {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'POST' -and $URI -like "rest/api/*/version/$versionID1/move" } {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'POST' -and $URI -like "$jiraServer/rest/api/*/version/$versionID2/move" } {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'POST' -and $URI -like "rest/api/*/version/$versionID2/move" } {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
         }
 
@@ -111,20 +107,18 @@ Describe "Move-JiraVersion" -Tag 'Unit' {
             It 'moves a Version using its ID and Last Position' {
                 { Move-JiraVersion -Version $versionID1 -Position Last -ErrorAction Stop } | Should Not Throw
                 Assert-MockCalled 'Get-JiraVersion' -Times 0 -Scope It -ModuleName JiraPS -Exactly
-                Assert-MockCalled 'Get-JiraConfigServer' -Times 1 -Scope It -ModuleName JiraPS -Exactly
                 Assert-MockCalled 'Invoke-JiraMethod' -Times 1 -Scope It -ModuleName JiraPS -Exactly -ParameterFilter {
                     $Method -eq 'POST' -and
-                    $URI -like "$jiraServer/rest/api/latest/version/$versionID1/move" -and
+                    $URI -like "rest/api/latest/version/$versionID1/move" -and
                     $Body -match '"position":\s*"Last"'
                 }
             }
             It 'moves a Version using its ID and Earlier Position' {
                 { Move-JiraVersion -Version $versionID1 -Position Earlier -ErrorAction Stop } | Should Not Throw
                 Assert-MockCalled 'Get-JiraVersion' -Times 0 -Scope It -ModuleName JiraPS -Exactly
-                Assert-MockCalled 'Get-JiraConfigServer' -Times 1 -Scope It -ModuleName JiraPS -Exactly
                 Assert-MockCalled 'Invoke-JiraMethod' -Times 1 -Scope It -ModuleName JiraPS -Exactly -ParameterFilter {
                     $Method -eq 'POST' -and
-                    $URI -like "$jiraServer/rest/api/latest/version/$versionID1/move" -and
+                    $URI -like "rest/api/latest/version/$versionID1/move" -and
                     $Body -match '"position":\s*"Earlier"'
                 }
             }
@@ -134,10 +128,9 @@ Describe "Move-JiraVersion" -Tag 'Unit' {
                     Move-JiraVersion -Version $version -Position Later -ErrorAction Stop
                 } | Should Not Throw
                 Assert-MockCalled 'Get-JiraVersion' -Times 1 -Scope It -ModuleName JiraPS -Exactly
-                Assert-MockCalled 'Get-JiraConfigServer' -Times 1 -Scope It -ModuleName JiraPS -Exactly
                 Assert-MockCalled 'Invoke-JiraMethod' -Times 1 -Scope It -ModuleName JiraPS -Exactly -ParameterFilter {
                     $Method -eq 'POST' -and
-                    $URI -like "$jiraServer/rest/api/latest/version/$versionID2/move" -and
+                    $URI -like "rest/api/latest/version/$versionID2/move" -and
                     $Body -match '"position":\s*"Later"'
                 }
             }
@@ -147,10 +140,9 @@ Describe "Move-JiraVersion" -Tag 'Unit' {
                     Move-JiraVersion -Version $version -Position First -ErrorAction Stop
                 } | Should Not Throw
                 Assert-MockCalled 'Get-JiraVersion' -Times 1 -Scope It -ModuleName JiraPS -Exactly
-                Assert-MockCalled 'Get-JiraConfigServer' -Times 1 -Scope It -ModuleName JiraPS -Exactly
                 Assert-MockCalled 'Invoke-JiraMethod' -Times 1 -Scope It -ModuleName JiraPS -Exactly -ParameterFilter {
                     $Method -eq 'POST' -and
-                    $URI -like "$jiraServer/rest/api/latest/version/$versionID2/move" -and
+                    $URI -like "rest/api/latest/version/$versionID2/move" -and
                     $Body -match '"position":\s*"First"'
                 }
             }
@@ -160,10 +152,9 @@ Describe "Move-JiraVersion" -Tag 'Unit' {
                     $version | Move-JiraVersion -Position First -ErrorAction Stop
                 } | Should Not Throw
                 Assert-MockCalled 'Get-JiraVersion' -Times 1 -Scope It -ModuleName JiraPS -Exactly
-                Assert-MockCalled 'Get-JiraConfigServer' -Times 1 -Scope It -ModuleName JiraPS -Exactly
                 Assert-MockCalled 'Invoke-JiraMethod' -Times 1 -Scope It -ModuleName JiraPS -Exactly -ParameterFilter {
                     $Method -eq 'POST' -and
-                    $URI -like "$jiraServer/rest/api/latest/version/$versionID2/move" -and
+                    $URI -like "rest/api/latest/version/$versionID2/move" -and
                     $Body -match '"position":\s*"First"'
                 }
             }
@@ -172,10 +163,9 @@ Describe "Move-JiraVersion" -Tag 'Unit' {
                     $versionID1 | Move-JiraVersion -Position First -ErrorAction Stop
                 } | Should Not Throw
                 Assert-MockCalled 'Get-JiraVersion' -Times 0 -Scope It -ModuleName JiraPS -Exactly
-                Assert-MockCalled 'Get-JiraConfigServer' -Times 1 -Scope It -ModuleName JiraPS -Exactly
                 Assert-MockCalled 'Invoke-JiraMethod' -Times 1 -Scope It -ModuleName JiraPS -Exactly -ParameterFilter {
                     $Method -eq 'POST' -and
-                    $URI -like "$jiraServer/rest/api/latest/version/$versionID1/move" -and
+                    $URI -like "rest/api/latest/version/$versionID1/move" -and
                     $Body -match '"position":\s*"First"'
                 }
             }
@@ -185,10 +175,9 @@ Describe "Move-JiraVersion" -Tag 'Unit' {
                 $restUrl = (Get-JiraVersion -Id $versionID2).RestUrl
                 { Move-JiraVersion -Version $versionID1 -After $versionID2 -ErrorAction Stop } | Should Not Throw
                 Assert-MockCalled 'Get-JiraVersion' -Times 2 -Scope It -ModuleName JiraPS -Exactly
-                Assert-MockCalled 'Get-JiraConfigServer' -Times 1 -Scope It -ModuleName JiraPS -Exactly
                 Assert-MockCalled 'Invoke-JiraMethod' -Times 1 -Scope It -ModuleName JiraPS -Exactly -ParameterFilter {
                     $Method -eq 'POST' -and
-                    $URI -like "$jiraServer/rest/api/latest/version/$versionID1/move" -and
+                    $URI -like "rest/api/latest/version/$versionID1/move" -and
                     $Body -match """after"":\s*""$restUrl"""
                 }
             }
@@ -197,10 +186,9 @@ Describe "Move-JiraVersion" -Tag 'Unit' {
                 $version1 = Get-JiraVersion -ID $versionID1
                 { Move-JiraVersion -Version $version1 -After $versionID2 -ErrorAction Stop } | Should Not Throw
                 Assert-MockCalled 'Get-JiraVersion' -Times 3 -Scope It -ModuleName JiraPS -Exactly
-                Assert-MockCalled 'Get-JiraConfigServer' -Times 1 -Scope It -ModuleName JiraPS -Exactly
                 Assert-MockCalled 'Invoke-JiraMethod' -Times 1 -Scope It -ModuleName JiraPS -Exactly -ParameterFilter {
                     $Method -eq 'POST' -and
-                    $URI -like "$jiraServer/rest/api/latest/version/$versionID1/move" -and
+                    $URI -like "rest/api/latest/version/$versionID1/move" -and
                     $Body -match """after"":\s*""$restUrl"""
                 }
             }
@@ -208,10 +196,9 @@ Describe "Move-JiraVersion" -Tag 'Unit' {
                 $version2 = Get-JiraVersion -ID $versionID2
                 { Move-JiraVersion -Version $versionID1 -After $version2 -ErrorAction Stop } | Should Not Throw
                 Assert-MockCalled 'Get-JiraVersion' -Times 1 -Scope It -ModuleName JiraPS -Exactly
-                Assert-MockCalled 'Get-JiraConfigServer' -Times 1 -Scope It -ModuleName JiraPS -Exactly
                 Assert-MockCalled 'Invoke-JiraMethod' -Times 1 -Scope It -ModuleName JiraPS -Exactly -ParameterFilter {
                     $Method -eq 'POST' -and
-                    $URI -like "$jiraServer/rest/api/latest/version/$versionID1/move" -and
+                    $URI -like "rest/api/latest/version/$versionID1/move" -and
                     $Body -match """after"":\s*""$($version2.RestUrl)"""
                 }
             }
@@ -219,10 +206,9 @@ Describe "Move-JiraVersion" -Tag 'Unit' {
                 $version2 = Get-JiraVersion -ID $versionID2
                 { $versionID1 | Move-JiraVersion -After $version2 -ErrorAction Stop } | Should Not Throw
                 Assert-MockCalled 'Get-JiraVersion' -Times 1 -Scope It -ModuleName JiraPS -Exactly
-                Assert-MockCalled 'Get-JiraConfigServer' -Times 1 -Scope It -ModuleName JiraPS -Exactly
                 Assert-MockCalled 'Invoke-JiraMethod' -Times 1 -Scope It -ModuleName JiraPS -Exactly -ParameterFilter {
                     $Method -eq 'POST' -and
-                    $URI -like "$jiraServer/rest/api/latest/version/$versionID1/move" -and
+                    $URI -like "rest/api/latest/version/$versionID1/move" -and
                     $Body -match """after"":\s*""$($version2.RestUrl)"""
                 }
             }
@@ -231,10 +217,9 @@ Describe "Move-JiraVersion" -Tag 'Unit' {
                 $version2 = Get-JiraVersion -ID $versionID2
                 { $version1 | Move-JiraVersion -After $version2 -ErrorAction Stop } | Should Not Throw
                 Assert-MockCalled 'Get-JiraVersion' -Times 2 -Scope It -ModuleName JiraPS -Exactly
-                Assert-MockCalled 'Get-JiraConfigServer' -Times 1 -Scope It -ModuleName JiraPS -Exactly
                 Assert-MockCalled 'Invoke-JiraMethod' -Times 1 -Scope It -ModuleName JiraPS -Exactly -ParameterFilter {
                     $Method -eq 'POST' -and
-                    $URI -like "$jiraServer/rest/api/latest/version/$versionID1/move" -and
+                    $URI -like "rest/api/latest/version/$versionID1/move" -and
                     $Body -match """after"":\s*""$($version2.RestUrl)"""
                 }
             }

--- a/Tests/Functions/New-JiraFilter.Unit.Tests.ps1
+++ b/Tests/Functions/New-JiraFilter.Unit.Tests.ps1
@@ -41,7 +41,7 @@ Describe 'New-JiraFilter' -Tag 'Unit' {
 
         $responseFilter = @"
 {
-    "self": "$jiraServer/rest/api/latest/filter/12844",
+    "self": "rest/api/latest/filter/12844",
     "id": "12844",
     "name": "{0}",
     "jql": "{1}",
@@ -63,7 +63,7 @@ Describe 'New-JiraFilter' -Tag 'Unit' {
             ConvertTo-JiraFilter
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Post' -and $URI -like "$jiraServer/rest/api/*/filter"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Post' -and $URI -like "rest/api/*/filter"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri', 'Body'
             ConvertFrom-Json $responseFilter
         }
@@ -100,7 +100,7 @@ Describe 'New-JiraFilter' -Tag 'Unit' {
 
                 Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -Scope It -ParameterFilter {
                     $Method -eq 'Post' -and
-                    $URI -like '*/rest/api/*/filter' -and
+                    $URI -like 'rest/api/*/filter' -and
                     $Body -match "`"name`":\s*`"myName`"" -and
                     $Body -match "`"description`":\s*`"myDescription`"" -and
                     $Body -match "`"jql`":\s*`"myJQL`"" -and

--- a/Tests/Functions/New-JiraFilter.Unit.Tests.ps1
+++ b/Tests/Functions/New-JiraFilter.Unit.Tests.ps1
@@ -38,7 +38,6 @@ Describe 'New-JiraFilter' -Tag 'Unit' {
         . "$PSScriptRoot/../Shared.ps1"
 
         #region Definitions
-        $jiraServer = "https://jira.example.com"
 
         $responseFilter = @"
 {
@@ -52,9 +51,6 @@ Describe 'New-JiraFilter' -Tag 'Unit' {
         #endregion Definitions
 
         #region Mocks
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            $jiraServer
-        }
 
         Mock ConvertTo-JiraFilter -ModuleName JiraPS {
             $i = (ConvertFrom-Json $responseFilter)
@@ -85,7 +81,7 @@ Describe 'New-JiraFilter' -Tag 'Unit' {
             defParam $command 'Description'
             defParam $command 'JQL'
             defParam $command 'Favorite'
-            defParam $command 'Credential'
+            defParam $command 'Session'
 
             defAlias $command 'Favourite' 'Favorite'
         }

--- a/Tests/Functions/New-JiraGroup.Unit.Tests.ps1
+++ b/Tests/Functions/New-JiraGroup.Unit.Tests.ps1
@@ -37,14 +37,13 @@ Describe "New-JiraGroup" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
 
         $testGroupName = 'testGroup'
 
         $testJson = @"
 {
     "name": "$testGroupName",
-    "self": "$jiraServer/rest/api/2/group?groupname=$testGroupName",
+    "self": "rest/api/2/group?groupname=$testGroupName",
     "users": {
         "size": 0,
         "items": [],
@@ -56,11 +55,7 @@ Describe "New-JiraGroup" -Tag 'Unit' {
 }
 "@
 
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            Write-Output $jiraServer
-        }
-
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'POST' -and $URI -eq "$jiraServer/rest/api/latest/group"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'POST' -and $URI -eq "rest/api/latest/group"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             ConvertFrom-Json $testJson
         }
@@ -90,7 +85,7 @@ Describe "New-JiraGroup" -Tag 'Unit' {
         #     $newResult = New-JiraGroup -GroupName $testGroupName
         #     (Get-Member -InputObject $newResult).TypeName | Should Be 'JiraPS.Group'
         #     $newResult.Name | Should Be $testGroupName
-        #     $newResult.RestUrl | Should Be "$jiraServer/rest/api/2/group?groupname=$testGroupName"
+        #     $newResult.RestUrl | Should Be "rest/api/2/group?groupname=$testGroupName"
         # }
     }
 }

--- a/Tests/Functions/New-JiraIssue.Unit.Tests.ps1
+++ b/Tests/Functions/New-JiraIssue.Unit.Tests.ps1
@@ -123,7 +123,7 @@ Describe "New-JiraIssue" -Tag 'Unit' {
             defParam $command 'Reporter'
             defParam $command 'Labels'
             defParam $command 'Fields'
-            defParam $command 'Credential'
+            defParam $command 'Session'
         }
 
         Context "Behavior testing" {

--- a/Tests/Functions/New-JiraIssue.Unit.Tests.ps1
+++ b/Tests/Functions/New-JiraIssue.Unit.Tests.ps1
@@ -41,10 +41,6 @@ Describe "New-JiraIssue" -Tag 'Unit' {
         $jiraServer = 'https://jira.example.com'
         $issueTypeTest = 1
 
-        Mock Get-JiraConfigServer {
-            $jiraServer
-        }
-
         # If we don't override this in a context or test, we don't want it to
         # actually try to query a JIRA instance
         Mock Invoke-JiraMethod {
@@ -132,14 +128,14 @@ Describe "New-JiraIssue" -Tag 'Unit' {
                 # The String in the ParameterFilter is made from the keywords
                 # we should expect to see in the JSON that should be sent,
                 # including the summary provided in the test call above.
-                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Post' -and $URI -like "$jiraServer/rest/api/*/issue" }
+                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Post' -and $URI -like "rest/api/*/issue" }
             }
             It "Creates an issue in JIRA from pipeline" {
                 { $pipelineParams | New-JiraIssue } | Should Not Throw
                 # The String in the ParameterFilter is made from the keywords
                 # we should expect to see in the JSON that should be sent,
                 # including the summary provided in the test call above.
-                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Post' -and $URI -like "$jiraServer/rest/api/*/issue" }
+                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Post' -and $URI -like "rest/api/*/issue" }
             }
         }
 

--- a/Tests/Functions/New-JiraSession.Unit.Tests.ps1
+++ b/Tests/Functions/New-JiraSession.Unit.Tests.ps1
@@ -75,7 +75,7 @@ Describe "New-JiraSession" -Tag 'Unit' {
         Context "Sanity checking" {
             $command = Get-Command -Name New-JiraSession
 
-            defParam $command 'Session'
+            defParam $command 'Credential'
             defParam $command 'Headers'
             defParam $command 'SessionName'
             defParam $command 'ServerName'

--- a/Tests/Functions/New-JiraSession.Unit.Tests.ps1
+++ b/Tests/Functions/New-JiraSession.Unit.Tests.ps1
@@ -75,7 +75,7 @@ Describe "New-JiraSession" -Tag 'Unit' {
         Context "Sanity checking" {
             $command = Get-Command -Name New-JiraSession
 
-            defParam $command 'Credential'
+            defParam $command 'Session'
             defParam $command 'Headers'
             defParam $command 'SessionName'
             defParam $command 'ServerName'

--- a/Tests/Functions/New-JiraUser.Unit.Tests.ps1
+++ b/Tests/Functions/New-JiraUser.Unit.Tests.ps1
@@ -37,7 +37,6 @@ Describe "New-JiraUser" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
 
         $testUsername = 'powershell-test'
         $testEmail = "$testUsername@example.com"
@@ -46,7 +45,7 @@ Describe "New-JiraUser" -Tag 'Unit' {
         # Trimmed from this example JSON: expand, groups, avatarURL
         $testJson = @"
 {
-    "self": "$jiraServer/rest/api/2/user?username=testUser",
+    "self": "rest/api/2/user?username=testUser",
     "key": "$testUsername",
     "name": "$testUsername",
     "emailAddress": "$testEmail",
@@ -55,11 +54,7 @@ Describe "New-JiraUser" -Tag 'Unit' {
 }
 "@
 
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            Write-Output $jiraServer
-        }
-
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'POST' -and $URI -eq "$jiraServer/rest/api/latest/user"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'POST' -and $URI -eq "rest/api/latest/user"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             ConvertFrom-Json $testJson
         }

--- a/Tests/Functions/New-JiraVersion.Unit.Tests.ps1
+++ b/Tests/Functions/New-JiraVersion.Unit.Tests.ps1
@@ -37,7 +37,6 @@ Describe "New-JiraVersion" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
         $versionName = '1.0.0.0'
         $versionID = '16840'
         $projectKey = 'LDD'
@@ -57,7 +56,7 @@ Describe "New-JiraVersion" -Tag 'Unit' {
 "@
         $testJsonOne = @"
 {
-    "self" : "$jiraServer/rest/api/2/version/$versionID",
+    "self" : "rest/api/2/version/$versionID",
     "id" : $versionID,
     "description" : "$versionName",
     "name" : "$versionName",
@@ -68,9 +67,6 @@ Describe "New-JiraVersion" -Tag 'Unit' {
 "@
 
         #region Mock
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            Write-Output $jiraServer
-        }
 
         Mock Get-JiraProject -ModuleName JiraPS {
             $Projects = ConvertFrom-Json $JiraProjectData
@@ -85,7 +81,7 @@ Describe "New-JiraVersion" -Tag 'Unit' {
                 Project     = (Get-JiraProject -Project $projectKey)
                 ReleaseDate = (Get-Date "2017-12-01")
                 StartDate   = (Get-Date "2017-01-01")
-                RestUrl     = "$jiraServer/rest/api/2/version/$versionID"
+                RestUrl     = "rest/api/2/version/$versionID"
             }
             $Version.PSObject.TypeNames.Insert(0, 'JiraPS.Version')
             $Version
@@ -96,13 +92,13 @@ Describe "New-JiraVersion" -Tag 'Unit' {
                 Id      = $InputObject.Id
                 Name    = $InputObject.name
                 Project = $InputObject.projectId
-                self    = "$jiraServer/rest/api/2/version/$($InputObject.self)"
+                self    = "rest/api/2/version/$($InputObject.self)"
             }
             $result.PSObject.TypeNames.Insert(0, 'JiraPS.Version')
             $result
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Post' -and $URI -like "$jiraServer/rest/api/*/version" } {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Post' -and $URI -like "rest/api/*/version" } {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             ConvertFrom-Json $testJsonOne
         }
@@ -134,14 +130,14 @@ Describe "New-JiraVersion" -Tag 'Unit' {
                 $results = $version | New-JiraVersion -ErrorAction Stop
                 $results | Should Not BeNullOrEmpty
                 checkType $results "JiraPS.Version"
-                Assert-MockCalled 'Invoke-JiraMethod' -Times 1 -Scope It -ModuleName JiraPS -Exactly -ParameterFilter { $Method -eq 'Post' -and $URI -like "$jiraServer/rest/api/latest/version" }
+                Assert-MockCalled 'Invoke-JiraMethod' -Times 1 -Scope It -ModuleName JiraPS -Exactly -ParameterFilter { $Method -eq 'Post' -and $URI -like "rest/api/latest/version" }
                 Assert-MockCalled 'ConvertTo-JiraVersion' -Times 1 -Scope It -ModuleName JiraPS -Exactly
             }
             It "creates a Version using parameters" {
                 $results = New-JiraVersion -Name $versionName -Project $projectKey -ErrorAction Stop
                 $results | Should Not BeNullOrEmpty
                 checkType $results "JiraPS.Version"
-                Assert-MockCalled 'Invoke-JiraMethod' -Times 1 -Scope It -ModuleName JiraPS -Exactly -ParameterFilter { $Method -eq 'Post' -and $URI -like "$jiraServer/rest/api/latest/version" }
+                Assert-MockCalled 'Invoke-JiraMethod' -Times 1 -Scope It -ModuleName JiraPS -Exactly -ParameterFilter { $Method -eq 'Post' -and $URI -like "rest/api/latest/version" }
                 Assert-MockCalled 'ConvertTo-JiraVersion' -Times 1 -Scope It -ModuleName JiraPS -Exactly
             }
             It "creates a Version using splatting" {
@@ -160,7 +156,7 @@ Describe "New-JiraVersion" -Tag 'Unit' {
                 $results = New-JiraVersion @splat -ErrorAction Stop
                 $results | Should Not BeNullOrEmpty
                 checkType $results "JiraPS.Version"
-                Assert-MockCalled 'Invoke-JiraMethod' -Times 1 -Scope It -ModuleName JiraPS -Exactly -ParameterFilter { $Method -eq 'Post' -and $URI -like "$jiraServer/rest/api/latest/version" }
+                Assert-MockCalled 'Invoke-JiraMethod' -Times 1 -Scope It -ModuleName JiraPS -Exactly -ParameterFilter { $Method -eq 'Post' -and $URI -like "rest/api/latest/version" }
                 Assert-MockCalled 'ConvertTo-JiraVersion' -Times 1 -Scope It -ModuleName JiraPS -Exactly
             }
 

--- a/Tests/Functions/New-JiraVersion.Unit.Tests.ps1
+++ b/Tests/Functions/New-JiraVersion.Unit.Tests.ps1
@@ -125,7 +125,7 @@ Describe "New-JiraVersion" -Tag 'Unit' {
             defParam $command 'ReleaseDate'
             defParam $command 'StartDate'
             defParam $command 'Project'
-            defParam $command 'Credential'
+            defParam $command 'Session'
         }
 
         Context "Behavior checking" {

--- a/Tests/Functions/Remove-JiraFilter.Unit.Tests.ps1
+++ b/Tests/Functions/Remove-JiraFilter.Unit.Tests.ps1
@@ -41,11 +41,11 @@ Describe 'Remove-JiraFilter' -Tag 'Unit' {
 
         $responseFilter = @"
 {
-    "self": "$jiraServer/rest/api/latest/filter/12844",
+    "self": "rest/api/latest/filter/12844",
     "id": "12844",
     "name": "All JIRA Bugs",
     "owner": {
-        "self": "$jiraServer/rest/api/2/user?username=scott@atlassian.com",
+        "self": "rest/api/2/user?username=scott@atlassian.com",
         "key": "scott@atlassian.com",
         "name": "scott@atlassian.com",
         "avatarUrls": {
@@ -59,7 +59,7 @@ Describe 'Remove-JiraFilter' -Tag 'Unit' {
     },
     "jql": "project = 10240 AND issuetype = 1 ORDER BY key DESC",
     "viewUrl": "$jiraServer/secure/IssueNavigator.jspa?mode=hide&requestId=12844",
-    "searchUrl": "$jiraServer/rest/api/latest/search?jql=project+%3D+10240+AND+issuetype+%3D+1+ORDER+BY+key+DESC",
+    "searchUrl": "rest/api/latest/search?jql=project+%3D+10240+AND+issuetype+%3D+1+ORDER+BY+key+DESC",
     "favourite": false,
     "sharePermissions": [
         {
@@ -101,7 +101,7 @@ Describe 'Remove-JiraFilter' -Tag 'Unit' {
             }
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Delete' -and $URI -like "$jiraServer/rest/api/*/filter/*"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Delete' -and $URI -like "rest/api/*/filter/*"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             ConvertFrom-Json $responseFilter
         }
@@ -124,14 +124,14 @@ Describe 'Remove-JiraFilter' -Tag 'Unit' {
             It "deletes a filter based on one or more InputObjects" {
                 { Get-JiraFilter -Id 12844 | Remove-JiraFilter } | Should Not Throw
 
-                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -Scope It -ParameterFilter {$Method -eq 'Delete' -and $URI -like '*/rest/api/*/filter/12844'}
+                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -Scope It -ParameterFilter {$Method -eq 'Delete' -and $URI -like 'rest/api/*/filter/12844'}
             }
 
             It "deletes a filter based on one ore more filter ids" {
                 { Remove-JiraFilter -Id 12844 } | Should Not Throw
 
                 Assert-MockCalled -CommandName Get-JiraFilter -ModuleName JiraPS -Exactly -Times 1 -Scope It
-                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -Scope It -ParameterFilter {$Method -eq 'Delete' -and $URI -like '*/rest/api/*/filter/12844'}
+                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -Scope It -ParameterFilter {$Method -eq 'Delete' -and $URI -like 'rest/api/*/filter/12844'}
             }
         }
 

--- a/Tests/Functions/Remove-JiraFilter.Unit.Tests.ps1
+++ b/Tests/Functions/Remove-JiraFilter.Unit.Tests.ps1
@@ -38,7 +38,6 @@ Describe 'Remove-JiraFilter' -Tag 'Unit' {
         . "$PSScriptRoot/../Shared.ps1"
 
         #region Definitions
-        $jiraServer = "https://jira.example.com"
 
         $responseFilter = @"
 {
@@ -87,9 +86,6 @@ Describe 'Remove-JiraFilter' -Tag 'Unit' {
         #endregion Definitions
 
         #region Mocks
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            $jiraServer
-        }
 
         Mock ConvertTo-JiraFilter -ModuleName JiraPS {
             foreach ($i in $InputObject) {
@@ -120,7 +116,7 @@ Describe 'Remove-JiraFilter' -Tag 'Unit' {
             $command = Get-Command -Name Remove-JiraFilter
 
             defParam $command 'InputObject'
-            defParam $command 'Credential'
+            defParam $command 'Session'
         }
 
         Context "Behavior testing" {

--- a/Tests/Functions/Remove-JiraFilterPermission.Unit.Tests.ps1
+++ b/Tests/Functions/Remove-JiraFilterPermission.Unit.Tests.ps1
@@ -45,7 +45,7 @@ BeforeAll {
         $filterPermission2.Id = 2222
         $fullFilter = New-Object -TypeName PSCustomObject -Property @{
             Id = 12345
-            RestUrl = "$jiraServer/rest/api/2/filter/12345"
+            RestUrl = "rest/api/2/filter/12345"
             FilterPermissions = @(
                 $filterPermission1
                 $filterPermission2
@@ -54,7 +54,7 @@ BeforeAll {
         $fullFilter.PSObject.TypeNames.Insert(0, 'JiraPS.Filter')
         $basicFilter = New-Object -TypeName PSCustomObject -Property @{
             Id = 23456
-            RestUrl = "$jiraServer/rest/api/2/filter/23456"
+            RestUrl = "rest/api/2/filter/23456"
         }
         $basicFilter.PSObject.TypeNames.Insert(0, 'JiraPS.Filter')
 
@@ -70,7 +70,7 @@ BeforeAll {
             $fullFilter
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Delete' -and $URI -like "$jiraServer/rest/api/*/filter/*/permission*"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Delete' -and $URI -like "rest/api/*/filter/*/permission*"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
         }
 
@@ -97,11 +97,11 @@ BeforeAll {
 
                 Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -Scope It -ParameterFilter {
                     $Method -eq 'Delete' -and
-                    $URI -like '*/rest/api/*/filter/12345/permission/1111'
+                    $URI -like 'rest/api/*/filter/12345/permission/1111'
                 }
                 Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -Scope It -ParameterFilter {
                     $Method -eq 'Delete' -and
-                    $URI -like '*/rest/api/*/filter/12345/permission/2222'
+                    $URI -like 'rest/api/*/filter/12345/permission/2222'
                 }
             }
 
@@ -112,11 +112,11 @@ BeforeAll {
 
                 Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -Scope It -ParameterFilter {
                     $Method -eq 'Delete' -and
-                    $URI -like '*/rest/api/*/filter/23456/permission/3333'
+                    $URI -like 'rest/api/*/filter/23456/permission/3333'
                 }
                 Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -Scope It -ParameterFilter {
                     $Method -eq 'Delete' -and
-                    $URI -like '*/rest/api/*/filter/23456/permission/4444'
+                    $URI -like 'rest/api/*/filter/23456/permission/4444'
                 }
             }
         }

--- a/Tests/Functions/Remove-JiraFilterPermission.Unit.Tests.ps1
+++ b/Tests/Functions/Remove-JiraFilterPermission.Unit.Tests.ps1
@@ -38,7 +38,6 @@ BeforeAll {
         . "$PSScriptRoot/../Shared.ps1"
 
         #region Definitions
-        $jiraServer = "https://jira.example.com"
 
         $filterPermission1 = New-Object -TypeName PSCustomObject -Property @{ Id = 1111 }
         $filterPermission1.PSObject.TypeNames.Insert(0, 'JiraPS.FilterPermission')
@@ -62,9 +61,6 @@ BeforeAll {
         #endregion Definitions
 
         #region Mocks
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            $jiraServer
-        }
 
         Mock Get-JiraFilter -ModuleName JiraPS {
             $basicFilter
@@ -90,7 +86,7 @@ BeforeAll {
             defParam $command 'Filter'
             defParam $command 'FilterId'
             defParam $command 'PermissionId'
-            defParam $command 'Credential'
+            defParam $command 'Session'
         }
 
         Context "Behavior testing" {

--- a/Tests/Functions/Remove-JiraGroup.Unit.Tests.ps1
+++ b/Tests/Functions/Remove-JiraGroup.Unit.Tests.ps1
@@ -37,14 +37,13 @@ Describe "Remove-JiraGroup" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
 
         $testGroupName = 'testGroup'
 
         $testJson = @"
 {
     "name": "$testGroupName",
-    "self": "$jiraServer/rest/api/2/group?groupname=$testGroupName",
+    "self": "rest/api/2/group?groupname=$testGroupName",
     "users": {
         "size": 0,
         "items": [],
@@ -56,17 +55,13 @@ Describe "Remove-JiraGroup" -Tag 'Unit' {
 }
 "@
 
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            Write-Output $jiraServer
-        }
-
         Mock Get-JiraGroup -ModuleName JiraPS {
             $object = ConvertFrom-Json $testJson
             $object.PSObject.TypeNames.Insert(0, 'JiraPS.Group')
             return $object
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'DELETE' -and $URI -like "$jiraServer/rest/api/*/group?groupname=$testGroupName"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'DELETE' -and $URI -like "rest/api/*/group?groupname=$testGroupName"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             # This REST method should produce no output
         }

--- a/Tests/Functions/Remove-JiraGroupMember.Unit.Tests.ps1
+++ b/Tests/Functions/Remove-JiraGroupMember.Unit.Tests.ps1
@@ -38,7 +38,6 @@ BeforeAll {
         . "$PSScriptRoot/../Shared.ps1"
 
         #region Definitions
-        $jiraServer = 'http://jiraserver.example.com'
 
         $testGroupName = 'testGroup'
         $testUsername1 = 'testUsername1'
@@ -46,9 +45,6 @@ BeforeAll {
         #endregion Definitions
 
         #region Mocks
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            Write-Output $jiraServer
-        }
 
         Mock Get-JiraGroup -ModuleName JiraPS {
             [PSCustomObject]@{
@@ -117,7 +113,7 @@ BeforeAll {
                     ModuleName      = "JiraPS"
                     ParameterFilter = {
                         $Method -eq 'Delete' -and
-                        $URI -like "$jiraServer/rest/api/*/group/user?groupname=$testGroupName&username=$testUsername1"
+                        $URI -like "rest/api/*/group/user?groupname=$testGroupName&username=$testUsername1"
                     }
                     Exactly         = $true
                     Times           = 1
@@ -147,7 +143,7 @@ BeforeAll {
                     ModuleName      = "JiraPS"
                     ParameterFilter = {
                         $Method -eq 'Delete' -and
-                        $URI -like "$jiraServer/rest/api/*/group/user?groupname=$testGroupName&username=*"
+                        $URI -like "rest/api/*/group/user?groupname=$testGroupName&username=*"
                     }
                     Exactly         = $true
                     Times           = 2
@@ -166,7 +162,7 @@ BeforeAll {
                     ModuleName      = "JiraPS"
                     ParameterFilter = {
                         $Method -eq "Delete" -and
-                        $URI -like "*/rest/api/*/group/user*" -and
+                        $URI -like "rest/api/*/group/user*" -and
                         $URI -match "groupname=$testGroupName" -and
                         $URI -match "username=$testUsername1"
                     }
@@ -188,7 +184,7 @@ BeforeAll {
                     ModuleName      = "JiraPS"
                     ParameterFilter = {
                         $Method -eq "Delete" -and
-                        $URI -like "*/rest/api/*/group/user*" -and
+                        $URI -like "rest/api/*/group/user*" -and
                         $URI -match "groupname=$testGroupName" -and
                         $URI -match "username=$testUsername1"
                     }
@@ -207,7 +203,7 @@ BeforeAll {
                     ModuleName      = "JiraPS"
                     ParameterFilter = {
                         $Method -eq "Delete" -and
-                        $URI -like "*/rest/api/*/group/user*" -and
+                        $URI -like "rest/api/*/group/user*" -and
                         $URI -match "groupname=$testGroupName" -and
                         $URI -match "username=$testUsername1"
                     }
@@ -229,7 +225,7 @@ BeforeAll {
                     ModuleName      = "JiraPS"
                     ParameterFilter = {
                         $Method -eq "Delete" -and
-                        $URI -like "*/rest/api/*/group/user*" -and
+                        $URI -like "rest/api/*/group/user*" -and
                         $URI -match "groupname=$testGroupName" -and
                         $URI -match "username=$testUsername1"
                     }

--- a/Tests/Functions/Remove-JiraGroupMember.Unit.Tests.ps1
+++ b/Tests/Functions/Remove-JiraGroupMember.Unit.Tests.ps1
@@ -97,7 +97,7 @@ BeforeAll {
 
             defParam $command 'Group'
             defParam $command 'User'
-            defParam $command 'Credential'
+            defParam $command 'Session'
             defParam $command 'PassThru'
             defParam $command 'Force'
         }

--- a/Tests/Functions/Remove-JiraIssue.Unit.Tests.ps1
+++ b/Tests/Functions/Remove-JiraIssue.Unit.Tests.ps1
@@ -37,7 +37,6 @@ Describe "Remove-JiraIssue" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
 
         $TestIssueJSONs = @{
 
@@ -218,10 +217,6 @@ Describe "Remove-JiraIssue" -Tag 'Unit' {
 
         }
 
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            Write-Output $jiraServer
-        }
-
         Mock Get-JiraIssue {
             $obj = $TestIssueJSONs[$Key] | ConvertFrom-Json
 
@@ -231,11 +226,11 @@ Describe "Remove-JiraIssue" -Tag 'Unit' {
             return $obj
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$URI -like "$jiraServer/rest/api/*/issue/TEST-1?*" -and $Method -eq "Delete"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$URI -like "rest/api/*/issue/TEST-1?*" -and $Method -eq "Delete"} {
             return $null
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$URI -like "$jiraServer/rest/api/*/issue/TEST-2?deleteSubTasks=False" -and $Method -eq "Delete"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$URI -like "rest/api/*/issue/TEST-2?deleteSubTasks=False" -and $Method -eq "Delete"} {
 
           Write-Error -Exception  -ErrorId
             $MockedResponse = @"
@@ -259,7 +254,7 @@ Describe "Remove-JiraIssue" -Tag 'Unit' {
             $PSCmdlet.WriteError($errorItem)
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$URI -like "$jiraServer/rest/api/*/issue/TEST-2?deleteSubTasks=True" -and $Method -eq "Delete"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$URI -like "rest/api/*/issue/TEST-2?deleteSubTasks=True" -and $Method -eq "Delete"} {
             return $null
         }
 

--- a/Tests/Functions/Remove-JiraIssue.Unit.Tests.ps1
+++ b/Tests/Functions/Remove-JiraIssue.Unit.Tests.ps1
@@ -279,7 +279,7 @@ Describe "Remove-JiraIssue" -Tag 'Unit' {
             defParam $command 'IssueId'
             defParam $command 'InputObject'
             defParam $command 'IncludeSubTasks'
-            defParam $command 'Credential'
+            defParam $command 'Session'
         }
 
         Context "Functionality" {

--- a/Tests/Functions/Remove-JiraIssueAttachment.Unit.Tests.ps1
+++ b/Tests/Functions/Remove-JiraIssueAttachment.Unit.Tests.ps1
@@ -108,7 +108,7 @@ Describe "Remove-JiraIssueAttachment" -Tag 'Unit' {
             defParam $command 'AttachmentId'
             defParam $command 'Issue'
             defParam $command 'FileName'
-            defParam $command 'Credential'
+            defParam $command 'Session'
             defParam $command 'Force'
         }
 

--- a/Tests/Functions/Remove-JiraIssueAttachment.Unit.Tests.ps1
+++ b/Tests/Functions/Remove-JiraIssueAttachment.Unit.Tests.ps1
@@ -37,7 +37,6 @@ Describe "Remove-JiraIssueAttachment" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
         $issueKey = "FOO-123"
         $attachmentId1 = 1010
         $attachmentId2 = 1011
@@ -46,9 +45,6 @@ Describe "Remove-JiraIssueAttachment" -Tag 'Unit' {
 
 
         #region Mock
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            Write-Output $jiraServer
-        }
 
         Mock Get-JiraIssueAttachment -ModuleName JiraPS {
             $all = @()
@@ -87,10 +83,10 @@ Describe "Remove-JiraIssueAttachment" -Tag 'Unit' {
             Get-JiraIssue -Key $Issue
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Delete' -and $URI -eq "$jiraServer/rest/api/latest/attachment/$attachmentId1" } {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Delete' -and $URI -eq "rest/api/latest/attachment/$attachmentId1" } {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
         }
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Delete' -and $URI -eq "$jiraServer/rest/api/latest/attachment/$attachmentId2" } {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Delete' -and $URI -eq "rest/api/latest/attachment/$attachmentId2" } {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
         }
 
@@ -149,8 +145,8 @@ Describe "Remove-JiraIssueAttachment" -Tag 'Unit' {
                 Assert-MockCalled 'Invoke-JiraMethod' -ModuleName JiraPS -ParameterFilter { $Method -eq 'Post' } -Exactly -Times 0 -Scope It
                 Assert-MockCalled 'Invoke-JiraMethod' -ModuleName JiraPS -ParameterFilter { $Method -eq 'Put' } -Exactly -Times 0 -Scope It
                 Assert-MockCalled 'Invoke-JiraMethod' -ModuleName JiraPS -ParameterFilter { $Method -eq 'Delete' } -Exactly -Times 8 -Scope It
-                Assert-MockCalled 'Invoke-JiraMethod' -ModuleName JiraPS -ParameterFilter { $Method -eq 'Delete' -and $URI -like "$jiraServer/rest/api/latest/attachment/$attachmentId1" } -Exactly -Times 5 -Scope It
-                Assert-MockCalled 'Invoke-JiraMethod' -ModuleName JiraPS -ParameterFilter { $Method -eq 'Delete' -and $URI -like "$jiraServer/rest/api/latest/attachment/$attachmentId2" } -Exactly -Times 3 -Scope It
+                Assert-MockCalled 'Invoke-JiraMethod' -ModuleName JiraPS -ParameterFilter { $Method -eq 'Delete' -and $URI -like "rest/api/latest/attachment/$attachmentId1" } -Exactly -Times 5 -Scope It
+                Assert-MockCalled 'Invoke-JiraMethod' -ModuleName JiraPS -ParameterFilter { $Method -eq 'Delete' -and $URI -like "rest/api/latest/attachment/$attachmentId2" } -Exactly -Times 3 -Scope It
             }
             It 'accepts positional parameters' {
                 { Remove-JiraIssueAttachment $attachmentId1 -Force } | Should Not Throw

--- a/Tests/Functions/Remove-JiraIssueLink.Unit.Tests.ps1
+++ b/Tests/Functions/Remove-JiraIssueLink.Unit.Tests.ps1
@@ -37,7 +37,6 @@ Describe "Remove-JiraIssueLink" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
 
         $issueLinkId = 1234
 
@@ -51,10 +50,6 @@ Describe "Remove-JiraIssueLink" -Tag 'Unit' {
     "outwardIssue": {}
 }
 "@
-
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            Write-Output $jiraServer
-        }
 
         Mock Get-JiraIssueLink -ModuleName JiraPS {
             $obj = [PSCustomObject]@{
@@ -75,7 +70,7 @@ Describe "Remove-JiraIssueLink" -Tag 'Unit' {
             return $issue
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Delete' -and $URI -like "$jiraServer/rest/api/*/issueLink/1234"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Delete' -and $URI -like "rest/api/*/issueLink/1234"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
         }
 

--- a/Tests/Functions/Remove-JiraIssueLink.Unit.Tests.ps1
+++ b/Tests/Functions/Remove-JiraIssueLink.Unit.Tests.ps1
@@ -93,7 +93,7 @@ Describe "Remove-JiraIssueLink" -Tag 'Unit' {
             $command = Get-Command -Name Remove-JiraIssueLink
 
             defParam $command 'IssueLink'
-            defParam $command 'Credential'
+            defParam $command 'Session'
         }
 
         Context "Functionality" {

--- a/Tests/Functions/Remove-JiraIssueWatcher.Unit.Tests.ps1
+++ b/Tests/Functions/Remove-JiraIssueWatcher.Unit.Tests.ps1
@@ -78,7 +78,7 @@ Describe "Remove-JiraIssueWatcher" -Tag 'Unit' {
 
             defParam $command 'Watcher'
             defParam $command 'Issue'
-            defParam $command 'Credential'
+            defParam $command 'Session'
         }
 
         Context "Behavior testing" {

--- a/Tests/Functions/Remove-JiraIssueWatcher.Unit.Tests.ps1
+++ b/Tests/Functions/Remove-JiraIssueWatcher.Unit.Tests.ps1
@@ -37,19 +37,14 @@ Describe "Remove-JiraIssueWatcher" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
         $issueID = 41701
         $issueKey = 'IT-3676'
-
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            Write-Output $jiraServer
-        }
 
         Mock Get-JiraIssue -ModuleName JiraPS {
             $object = [PSCustomObject] @{
                 ID      = $issueID
                 Key     = $issueKey
-                RestUrl = "$jiraServer/rest/api/latest/issue/$issueID"
+                RestUrl = "rest/api/latest/issue/$issueID"
             }
             $object.PSObject.TypeNames.Insert(0, 'JiraPS.Issue')
             return $object
@@ -59,7 +54,7 @@ Describe "Remove-JiraIssueWatcher" -Tag 'Unit' {
             Get-JiraIssue -Key $Issue
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'DELETE' -and $URI -eq "$jiraServer/rest/api/latest/issue/$issueID/watchers?username=fred"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'DELETE' -and $URI -eq "rest/api/latest/issue/$issueID/watchers?username=fred"} {
             ShowMockInfo 'Invoke-JiraMethod' -Params 'Uri', 'Method'
         }
 

--- a/Tests/Functions/Remove-JiraRemoteLink.Unit.Tests.ps1
+++ b/Tests/Functions/Remove-JiraRemoteLink.Unit.Tests.ps1
@@ -37,7 +37,6 @@ Describe "Remove-JiraRemoteLink" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
 
         $testIssueKey = 'EX-1'
 
@@ -62,10 +61,6 @@ Describe "Remove-JiraRemoteLink" -Tag 'Unit' {
     }
 }
 "@
-
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            Write-Output $jiraServer
-        }
 
         Mock Get-JiraIssue {
             $object = [PSCustomObject] @{

--- a/Tests/Functions/Remove-JiraSession.Unit.Tests.ps1
+++ b/Tests/Functions/Remove-JiraSession.Unit.Tests.ps1
@@ -37,8 +37,6 @@ Describe "Remove-JiraSession" -Tag 'Unit' {
 
     $newObjectSplat = @{
         Name = "One"
-        WebSession = $webSession
-        ServerConfig = $ServerConfig
     }
 
     $sampleSession = New-Object -TypeName PSObject -Property $newObjectSplat

--- a/Tests/Functions/Remove-JiraUser.Unit.Tests.ps1
+++ b/Tests/Functions/Remove-JiraUser.Unit.Tests.ps1
@@ -37,7 +37,6 @@ Describe "Remove-JiraUser" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
 
         $testUsername = 'powershell-test'
         $testEmail = "$testUsername@example.com"
@@ -46,7 +45,7 @@ Describe "Remove-JiraUser" -Tag 'Unit' {
         # Trimmed from this example JSON: expand, groups, avatarURL
         $testJsonGet = @"
 {
-    "self": "$jiraServer/rest/api/2/user?username=$testUsername",
+    "self": "rest/api/2/user?username=$testUsername",
     "key": "$testUsername",
     "name": "$testUsername",
     "emailAddress": "$testEmail",
@@ -55,17 +54,13 @@ Describe "Remove-JiraUser" -Tag 'Unit' {
 }
 "@
 
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            Write-Output $jiraServer
-        }
-
         Mock Get-JiraUser -ModuleName JiraPS {
             $object = ConvertFrom-Json $testJsonGet
             $object.PSObject.TypeNames.Insert(0, 'JiraPS.User')
             return $object
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'DELETE' -and $URI -like "$jiraServer/rest/api/*/user?username=$testUsername"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'DELETE' -and $URI -like "rest/api/*/user?username=$testUsername"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             # This REST method should produce no output
         }

--- a/Tests/Functions/Remove-JiraVersion.Unit.Tests.ps1
+++ b/Tests/Functions/Remove-JiraVersion.Unit.Tests.ps1
@@ -37,7 +37,6 @@ Describe "Get-JiraVersion" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
         $versionName = '$versionName'
         $versionID1 = 16840
         $versionID2 = 16940
@@ -58,7 +57,7 @@ Describe "Get-JiraVersion" -Tag 'Unit' {
 "@
         $testJsonOne = @"
     {
-        "self" : "$jiraServer/rest/api/latest/version/$versionID1",
+        "self" : "rest/api/latest/version/$versionID1",
         "id" : $versionID1,
         "description" : "$versionName",
         "name" : "$versionName",
@@ -70,7 +69,7 @@ Describe "Get-JiraVersion" -Tag 'Unit' {
         $testJsonAll = @"
 [
     {
-        "self" : "$jiraServer/rest/api/latest/version/$versionID1",
+        "self" : "rest/api/latest/version/$versionID1",
         "id" : $versionID1,
         "description" : "$versionName1",
         "name" : "$versionName1",
@@ -79,7 +78,7 @@ Describe "Get-JiraVersion" -Tag 'Unit' {
         "projectId" : "$projectId"
     },
     {
-        "self" : "$jiraServer/rest/api/latest/version/$versionID2",
+        "self" : "rest/api/latest/version/$versionID2",
         "id" : $versionID2,
         "description" : "$versionName2",
         "name" : "$versionName2",
@@ -88,7 +87,7 @@ Describe "Get-JiraVersion" -Tag 'Unit' {
         "projectId" : "$projectId"
     },
     {
-        "self" : "$jiraServer/rest/api/latest/version/$versionID3",
+        "self" : "rest/api/latest/version/$versionID3",
         "id" : $versionID3,
         "description" : "$versionName2",
         "name" : "$versionName2",
@@ -100,9 +99,6 @@ Describe "Get-JiraVersion" -Tag 'Unit' {
 "@
 
         #region Mock
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            Write-Output $jiraServer
-        }
 
         Mock Get-JiraProject -ModuleName JiraPS {
             $Projects = ConvertFrom-Json $JiraProjectData
@@ -119,7 +115,7 @@ Describe "Get-JiraVersion" -Tag 'Unit' {
                     Project     = (Get-JiraProject -Project $projectKey)
                     ReleaseDate = (Get-Date "2017-12-01")
                     StartDate   = (Get-Date "2017-01-01")
-                    RestUrl     = "$jiraServer/rest/api/latest/version/$_Id"
+                    RestUrl     = "rest/api/latest/version/$_Id"
                 }
                 $Version.PSObject.TypeNames.Insert(0, 'JiraPS.Version')
                 $Version
@@ -137,11 +133,11 @@ Describe "Get-JiraVersion" -Tag 'Unit' {
             $result
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Delete' -and $URI -like "$jiraServer/rest/api/*/version/$versionID1" } {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Delete' -and $URI -like "rest/api/*/version/$versionID1" } {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Delete' -and $URI -like "$jiraServer/rest/api/*/version/$versionID2" } {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Delete' -and $URI -like "rest/api/*/version/$versionID2" } {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
         }
 
@@ -165,7 +161,7 @@ Describe "Get-JiraVersion" -Tag 'Unit' {
                 { Remove-JiraVersion -Version $versionID1 -Force -ErrorAction Stop } | Should Not Throw
                 Assert-MockCalled 'Get-JiraVersion' -Times 1 -Scope It -ModuleName JiraPS -Exactly
                 Assert-MockCalled 'Get-JiraProject' -Times 1 -Scope It -ModuleName JiraPS -Exactly
-                Assert-MockCalled 'Invoke-JiraMethod' -Times 1 -Scope It -ModuleName JiraPS -Exactly -ParameterFilter { $Method -eq 'Delete' -and $URI -like "$jiraServer/rest/api/latest/version/$versionID1" }
+                Assert-MockCalled 'Invoke-JiraMethod' -Times 1 -Scope It -ModuleName JiraPS -Exactly -ParameterFilter { $Method -eq 'Delete' -and $URI -like "rest/api/latest/version/$versionID1" }
             }
             It 'removes a Version using the Version Object' {
                 {
@@ -174,7 +170,7 @@ Describe "Get-JiraVersion" -Tag 'Unit' {
                 } | Should Not Throw
                 Assert-MockCalled 'Get-JiraVersion' -Times 2 -Scope It -ModuleName JiraPS -Exactly
                 Assert-MockCalled 'Get-JiraProject' -Times 2 -Scope It -ModuleName JiraPS -Exactly
-                Assert-MockCalled 'Invoke-JiraMethod' -Times 1 -Scope It -ModuleName JiraPS -Exactly -ParameterFilter { $Method -eq 'Delete' -and $URI -like "$jiraServer/rest/api/latest/version/$versionID1" }
+                Assert-MockCalled 'Invoke-JiraMethod' -Times 1 -Scope It -ModuleName JiraPS -Exactly -ParameterFilter { $Method -eq 'Delete' -and $URI -like "rest/api/latest/version/$versionID1" }
             }
             It 'removes a Version using several Version Objects' {
                 {
@@ -183,15 +179,15 @@ Describe "Get-JiraVersion" -Tag 'Unit' {
                 } | Should Not Throw
                 Assert-MockCalled 'Get-JiraVersion' -Times 3 -Scope It -ModuleName JiraPS -Exactly
                 Assert-MockCalled 'Get-JiraProject' -Times 4 -Scope It -ModuleName JiraPS -Exactly
-                Assert-MockCalled 'Invoke-JiraMethod' -Times 1 -Scope It -ModuleName JiraPS -Exactly -ParameterFilter { $Method -eq 'Delete' -and $URI -like "$jiraServer/rest/api/latest/version/$versionID1" }
-                Assert-MockCalled 'Invoke-JiraMethod' -Times 1 -Scope It -ModuleName JiraPS -Exactly -ParameterFilter { $Method -eq 'Delete' -and $URI -like "$jiraServer/rest/api/latest/version/$versionID2" }
+                Assert-MockCalled 'Invoke-JiraMethod' -Times 1 -Scope It -ModuleName JiraPS -Exactly -ParameterFilter { $Method -eq 'Delete' -and $URI -like "rest/api/latest/version/$versionID1" }
+                Assert-MockCalled 'Invoke-JiraMethod' -Times 1 -Scope It -ModuleName JiraPS -Exactly -ParameterFilter { $Method -eq 'Delete' -and $URI -like "rest/api/latest/version/$versionID2" }
             }
             It 'removes a Version using Version as input over the pipeline' {
                 { Get-JiraVersion -Id $versionID1, $versionID2 | Remove-JiraVersion -Force -ErrorAction Stop } | Should Not Throw
                 Assert-MockCalled 'Get-JiraVersion' -Times 3 -Scope It -ModuleName JiraPS -Exactly
                 Assert-MockCalled 'Get-JiraProject' -Times 4 -Scope It -ModuleName JiraPS -Exactly
-                Assert-MockCalled 'Invoke-JiraMethod' -Times 1 -Scope It -ModuleName JiraPS -Exactly -ParameterFilter { $Method -eq 'Delete' -and $URI -like "$jiraServer/rest/api/latest/version/$versionID1" }
-                Assert-MockCalled 'Invoke-JiraMethod' -Times 1 -Scope It -ModuleName JiraPS -Exactly -ParameterFilter { $Method -eq 'Delete' -and $URI -like "$jiraServer/rest/api/latest/version/$versionID2" }
+                Assert-MockCalled 'Invoke-JiraMethod' -Times 1 -Scope It -ModuleName JiraPS -Exactly -ParameterFilter { $Method -eq 'Delete' -and $URI -like "rest/api/latest/version/$versionID1" }
+                Assert-MockCalled 'Invoke-JiraMethod' -Times 1 -Scope It -ModuleName JiraPS -Exactly -ParameterFilter { $Method -eq 'Delete' -and $URI -like "rest/api/latest/version/$versionID2" }
             }
             It "assert VerifiableMock" {
                 Assert-VerifiableMock

--- a/Tests/Functions/Remove-JiraVersion.Unit.Tests.ps1
+++ b/Tests/Functions/Remove-JiraVersion.Unit.Tests.ps1
@@ -156,7 +156,7 @@ Describe "Get-JiraVersion" -Tag 'Unit' {
             $command = Get-Command -Name Remove-JiraVersion
 
             defParam $command 'Version'
-            defParam $command 'Credential'
+            defParam $command 'Session'
             defParam $command 'Force'
         }
 

--- a/Tests/Functions/Set-JiraConfigServer.Unit.Tests.ps1
+++ b/Tests/Functions/Set-JiraConfigServer.Unit.Tests.ps1
@@ -37,7 +37,8 @@ Describe "Set-JiraConfigServer" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
+        $jiraServer = "http://jiraserver.example.com"
+
         $sampleServersConfigContent =
             "{`r`n" +
             "    `"Test`":  {`r`n" +

--- a/Tests/Functions/Set-JiraConfigServer.Unit.Tests.ps1
+++ b/Tests/Functions/Set-JiraConfigServer.Unit.Tests.ps1
@@ -38,17 +38,38 @@ Describe "Set-JiraConfigServer" -Tag 'Unit' {
         . "$PSScriptRoot/../Shared.ps1"
 
         $jiraServer = 'http://jiraserver.example.com'
+        $sampleServersConfigContent =
+            "{`r`n" +
+            "    `"Test`":  {`r`n" +
+            "                 `"Server`":  `"http://jiraserver.example.com/`"`r`n" +
+            "             },`r`n" +
+            "    `"Default`":  {`r`n" +
+            "                    `"Server`":  `"http://jiraserver.example.com/`"`r`n" +
+            "                }`r`n" +
+            "}`r`n"
+
+        $script:serversConfig = "TestDrive:\serversConfig"
 
         It "stores the server address in the module session" {
             Set-JiraConfigServer -Server $jiraServer
 
-            $script:JiraServerUrl | Should -Be "$jiraServer/"
+            $config = $script:JiraServerConfigs["Default"]
+            $config | Should -Not -BeNullOrEmpty
+            $config.Server | Should -Be "$jiraServer/"
+        }
+
+        It "can store few servers configs" {
+            Set-JiraConfigServer -Server $jiraServer -Name "Test"
+
+            $config = $script:JiraServerConfigs["Test"]
+            $config | Should -Not -BeNullOrEmpty
+            $config.Server | Should -Be "$jiraServer/"
         }
 
         It "stores the server address in a config file" {
-            $script:serverConfig | Should -Exist
+            $script:serversConfig | Should -Exist
 
-            Get-Content $script:serverConfig | Should -Be "$jiraServer/"
+            Get-Content -Path $script:serversConfig -Raw | Should -Be $sampleServersConfigContent
         }
     }
 }

--- a/Tests/Functions/Set-JiraConfigServer.Unit.Tests.ps1
+++ b/Tests/Functions/Set-JiraConfigServer.Unit.Tests.ps1
@@ -41,20 +41,21 @@ Describe "Set-JiraConfigServer" -Tag 'Unit' {
 
         $sampleServersConfigContent =
             "{`r`n" +
-            "    `"Test`":  {`r`n" +
-            "                 `"Server`":  `"http://jiraserver.example.com/`"`r`n" +
-            "             },`r`n" +
             "    `"Default`":  {`r`n" +
             "                    `"Server`":  `"http://jiraserver.example.com/`"`r`n" +
-            "                }`r`n" +
+            "                },`r`n" +
+            "    `"Test`":  {`r`n" +
+            "                 `"Server`":  `"http://jiraserver.example.com/`"`r`n" +
+            "             }`r`n" +
             "}`r`n"
 
         $script:serversConfig = "TestDrive:\serversConfig"
+        $script:JiraServerConfigs = New-Object psobject
 
         It "stores the server address in the module session" {
             Set-JiraConfigServer -Server $jiraServer
 
-            $config = $script:JiraServerConfigs["Default"]
+            $config = $script:JiraServerConfigs.Default
             $config | Should -Not -BeNullOrEmpty
             $config.Server | Should -Be "$jiraServer/"
         }
@@ -62,7 +63,7 @@ Describe "Set-JiraConfigServer" -Tag 'Unit' {
         It "can store few servers configs" {
             Set-JiraConfigServer -Server $jiraServer -Name "Test"
 
-            $config = $script:JiraServerConfigs["Test"]
+            $config = $script:JiraServerConfigs.Test
             $config | Should -Not -BeNullOrEmpty
             $config.Server | Should -Be "$jiraServer/"
         }

--- a/Tests/Functions/Set-JiraConfigServer.Unit.Tests.ps1
+++ b/Tests/Functions/Set-JiraConfigServer.Unit.Tests.ps1
@@ -40,14 +40,10 @@ Describe "Set-JiraConfigServer" -Tag 'Unit' {
         $jiraServer = "http://jiraserver.example.com"
 
         $sampleServersConfigContent =
-            "{`r`n" +
-            "    `"Default`":  {`r`n" +
-            "                    `"Server`":  `"http://jiraserver.example.com/`"`r`n" +
-            "                },`r`n" +
-            "    `"Test`":  {`r`n" +
-            "                 `"Server`":  `"http://jiraserver.example.com/`"`r`n" +
-            "             }`r`n" +
-            "}`r`n"
+            New-Object psobject |
+            Add-Member "Default" (New-Object psobject -Property @{ Server =  "http://jiraserver.example.com/" }) -PassThru |
+            Add-Member "Test" (New-Object psobject -Property @{ Server =  "http://jiraserver.example.com/" }) -PassThru |
+            ConvertTo-Json
 
         $script:serversConfig = "TestDrive:\serversConfig"
         $script:JiraServerConfigs = New-Object psobject

--- a/Tests/Functions/Set-JiraConfigServer.Unit.Tests.ps1
+++ b/Tests/Functions/Set-JiraConfigServer.Unit.Tests.ps1
@@ -37,13 +37,7 @@ Describe "Set-JiraConfigServer" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = "http://jiraserver.example.com"
-
-        $sampleServersConfigContent =
-            New-Object psobject |
-            Add-Member "Default" (New-Object psobject -Property @{ Server =  "http://jiraserver.example.com/" }) -PassThru |
-            Add-Member "Test" (New-Object psobject -Property @{ Server =  "http://jiraserver.example.com/" }) -PassThru |
-            ConvertTo-Json
+        $jiraServer = 'http://jiraserver.example.com'
 
         $script:serversConfig = "TestDrive:\serversConfig"
         $script:JiraServerConfigs = New-Object psobject
@@ -67,7 +61,9 @@ Describe "Set-JiraConfigServer" -Tag 'Unit' {
         It "stores the server address in a config file" {
             $script:serversConfig | Should -Exist
 
-            Get-Content -Path $script:serversConfig -Raw | Should -Be $sampleServersConfigContent
+            $config = Get-Content -Path $script:serversConfig -Raw | ConvertFrom-Json
+            $config.Default.Server | Should -BeExactly "http://jiraserver.example.com/"
+            $config.Test.Server | Should -BeExactly "http://jiraserver.example.com/"
         }
     }
 }

--- a/Tests/Functions/Set-JiraConfigServer.Unit.Tests.ps1
+++ b/Tests/Functions/Set-JiraConfigServer.Unit.Tests.ps1
@@ -62,8 +62,8 @@ Describe "Set-JiraConfigServer" -Tag 'Unit' {
             $script:serversConfig | Should -Exist
 
             $config = Get-Content -Path $script:serversConfig -Raw | ConvertFrom-Json
-            $config.Default.Server | Should -BeExactly "http://jiraserver.example.com/"
-            $config.Test.Server | Should -BeExactly "http://jiraserver.example.com/"
+            $config.Default.Server | Should -BeExactly "$jiraServer/"
+            $config.Test.Server | Should -BeExactly "$jiraServer/"
         }
     }
 }

--- a/Tests/Functions/Set-JiraFilter.Unit.Tests.ps1
+++ b/Tests/Functions/Set-JiraFilter.Unit.Tests.ps1
@@ -101,7 +101,7 @@ Describe 'Set-JiraFilter' -Tag 'Unit' {
             }
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Put' -and $URI -is [string] -and $URI -like "rest/api/*/filter/*"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Put' -and $URI -like "rest/api/*/filter/*"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri', 'Body'
             ConvertFrom-Json $responseFilter
         }

--- a/Tests/Functions/Set-JiraFilter.Unit.Tests.ps1
+++ b/Tests/Functions/Set-JiraFilter.Unit.Tests.ps1
@@ -38,7 +38,6 @@ Describe 'Set-JiraFilter' -Tag 'Unit' {
         . "$PSScriptRoot/../Shared.ps1"
 
         #region Definitions
-        $jiraServer = "https://jira.example.com"
 
         $responseFilter = @"
 {
@@ -87,9 +86,6 @@ Describe 'Set-JiraFilter' -Tag 'Unit' {
         #endregion Definitions
 
         #region Mocks
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            $jiraServer
-        }
 
         Mock ConvertTo-JiraFilter -ModuleName JiraPS {
             foreach ($i in $InputObject) {
@@ -124,7 +120,7 @@ Describe 'Set-JiraFilter' -Tag 'Unit' {
             defParam $command 'Description'
             defParam $command 'JQL'
             defParam $command 'Favorite'
-            defParam $command 'Credential'
+            defParam $command 'Session'
 
             defAlias $command 'Favourite' 'Favorite'
         }

--- a/Tests/Functions/Set-JiraFilter.Unit.Tests.ps1
+++ b/Tests/Functions/Set-JiraFilter.Unit.Tests.ps1
@@ -41,11 +41,11 @@ Describe 'Set-JiraFilter' -Tag 'Unit' {
 
         $responseFilter = @"
 {
-    "self": "$jiraServer/rest/api/latest/filter/12844",
+    "self": "rest/api/latest/filter/12844",
     "id": "12844",
     "name": "All JIRA Bugs",
     "owner": {
-        "self": "$jiraServer/rest/api/2/user?username=scott@atlassian.com",
+        "self": "rest/api/2/user?username=scott@atlassian.com",
         "key": "scott@atlassian.com",
         "name": "scott@atlassian.com",
         "avatarUrls": {
@@ -59,7 +59,7 @@ Describe 'Set-JiraFilter' -Tag 'Unit' {
     },
     "jql": "project = 10240 AND issuetype = 1 ORDER BY key DESC",
     "viewUrl": "$jiraServer/secure/IssueNavigator.jspa?mode=hide&requestId=12844",
-    "searchUrl": "$jiraServer/rest/api/latest/search?jql=project+%3D+10240+AND+issuetype+%3D+1+ORDER+BY+key+DESC",
+    "searchUrl": "rest/api/latest/search?jql=project+%3D+10240+AND+issuetype+%3D+1+ORDER+BY+key+DESC",
     "favourite": false,
     "sharePermissions": [
         {
@@ -101,7 +101,7 @@ Describe 'Set-JiraFilter' -Tag 'Unit' {
             }
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Put' -and $URI -like "$jiraServer/rest/api/*/filter/*"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Put' -and $URI -is [string] -and $URI -like "rest/api/*/filter/*"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri', 'Body'
             ConvertFrom-Json $responseFilter
         }
@@ -139,7 +139,7 @@ Describe 'Set-JiraFilter' -Tag 'Unit' {
 
                 Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -Scope It -ParameterFilter {
                     $Method -eq 'Put' -and
-                    $URI -like '*/rest/api/*/filter/12844' -and
+                    $URI -like 'rest/api/*/filter/12844' -and
                     $Body -match "`"name`":\s*`"newName`"" -and
                     $Body -match "`"description`":\s*`"newDescription`"" -and
                     $Body -match "`"jql`":\s*`"newJQL`"" -and
@@ -157,7 +157,7 @@ Describe 'Set-JiraFilter' -Tag 'Unit' {
 
                 Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -Scope It -ParameterFilter {
                     $Method -eq 'Put' -and
-                    $URI -like '*/rest/api/*/filter/12844' -and
+                    $URI -like 'rest/api/*/filter/12844' -and
                     $Body -match "`"description`":\s*`"`""
                 }
             }

--- a/Tests/Functions/Set-JiraIssue.Unit.Tests.ps1
+++ b/Tests/Functions/Set-JiraIssue.Unit.Tests.ps1
@@ -37,10 +37,6 @@ Describe "Set-JiraIssue" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-
-        Mock Get-JiraConfigServer {
-            $jiraServer
-        }
         Mock Get-JiraUser {
             [PSCustomObject] @{
                 'Name' = 'username'
@@ -51,7 +47,7 @@ Describe "Set-JiraIssue" -Tag 'Unit' {
 
         Mock Get-JiraIssue {
             $object = [PSCustomObject] @{
-                'RestURL' = "$jiraServer/rest/api/2/issue/12345"
+                'RestURL' = "rest/api/2/issue/12345"
             }
             $object.PSObject.TypeNames.Insert(0, 'JiraPS.Issue')
             return $object
@@ -61,10 +57,10 @@ Describe "Set-JiraIssue" -Tag 'Unit' {
             Get-JiraIssue -Key $Issue
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq "Put" -and $Uri -like "$jiraServer/rest/api/*/issue/12345"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq "Put" -and $Uri -like "rest/api/*/issue/12345"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
         }
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq "Put" -and $Uri -like "$jiraServer/rest/api/*/issue/12345/assignee"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq "Put" -and $Uri -like "rest/api/*/issue/12345/assignee"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
         }
 
@@ -100,38 +96,38 @@ Describe "Set-JiraIssue" -Tag 'Unit' {
                 # The String in the ParameterFilter is made from the keywords
                 # we should expect to see in the JSON that should be sent,
                 # including the summary provided in the test call above.
-                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Put' -and $URI -like "$jiraServer/rest/api/2/issue/12345" -and $Body -like '*summary*set*New summary*' }
+                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Put' -and $URI -like "rest/api/2/issue/12345" -and $Body -like '*summary*set*New summary*' }
             }
 
             It "Modifies the description of an issue if the -Description parameter is passed" {
                 { Set-JiraIssue -Issue TEST-001 -Description 'New description' } | Should Not Throw
-                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Put' -and $URI -like "$jiraServer/rest/api/2/issue/12345" -and $Body -like '*description*set*New description*' }
+                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Put' -and $URI -like "rest/api/2/issue/12345" -and $Body -like '*description*set*New description*' }
             }
 
             It "Modifies the description of an issue without sending notifications if the -Description parameter is passed" {
                 { Set-JiraIssue -Issue TEST-001 -Description 'New description' -SkipNotification } | Should Not Throw
-                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Put' -and $URI -like "$jiraServer/rest/api/2/issue/12345" -and $Body -like '*description*set*New description*' }
+                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Put' -and $URI -like "rest/api/2/issue/12345" -and $Body -like '*description*set*New description*' }
             }
 
             It "Modifies the assignee of an issue if -Assignee is passed" {
                 { Set-JiraIssue -Issue TEST-001 -Assignee username } | Should Not Throw
-                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Put' -and $URI -like "$jiraServer/rest/api/2/issue/12345/assignee" -and $Body -like '*name*username*' }
+                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Put' -and $URI -like "rest/api/2/issue/12345/assignee" -and $Body -like '*name*username*' }
             }
 
             It "Unassigns an issue if 'Unassigned' is passed to the -Assignee parameter" {
                 { Set-JiraIssue -Issue TEST-001 -Assignee unassigned } | Should Not Throw
-                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Put' -and $URI -like "$jiraServer/rest/api/2/issue/12345/assignee" -and $Body -like '*"name":*null*' }
+                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Put' -and $URI -like "rest/api/2/issue/12345/assignee" -and $Body -like '*"name":*null*' }
             }
 
             It "Sets the default assignee to an issue if 'Default' is passed to the -Assignee parameter" {
                 { Set-JiraIssue -Issue TEST-001 -Assignee default } | Should Not Throw
-                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Put' -and $URI -like "$jiraServer/rest/api/2/issue/12345/assignee" -and $Body -like '*"name":*"-1"*' }
+                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Put' -and $URI -like "rest/api/2/issue/12345/assignee" -and $Body -like '*"name":*"-1"*' }
             }
 
             It "Calls Invoke-JiraMethod twice if using Assignee and another field" {
                 { Set-JiraIssue -Issue TEST-001 -Summary 'New summary' -Assignee username } | Should Not Throw
-                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Put' -and $URI -like "$jiraServer/rest/api/2/issue/12345" -and $Body -like '*summary*set*New summary*' }
-                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Put' -and $URI -like "$jiraServer/rest/api/2/issue/12345/assignee" -and $Body -like '*name*username*' }
+                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Put' -and $URI -like "rest/api/2/issue/12345" -and $Body -like '*summary*set*New summary*' }
+                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Put' -and $URI -like "rest/api/2/issue/12345/assignee" -and $Body -like '*name*username*' }
             }
 
             It "Uses Set-JiraIssueLabel with the -Set parameter when the -Label parameter is used" {
@@ -141,7 +137,7 @@ Describe "Set-JiraIssue" -Tag 'Unit' {
 
             It "Adds a comment if the -AddComemnt parameter is passed" {
                 { Set-JiraIssue -Issue TEST-001 -AddComment 'New Comment' } | Should Not Throw
-                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Put' -and $Uri -like "$jiraServer/rest/api/2/issue/12345" -and $Body -like '*comment*add*body*New Comment*' }
+                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Put' -and $Uri -like "rest/api/2/issue/12345" -and $Body -like '*comment*add*body*New Comment*' }
             }
 
             It "Updates custom fields if provided to the -Fields parameter" {
@@ -152,9 +148,9 @@ Describe "Set-JiraIssue" -Tag 'Unit' {
                     }
                 }
                 { Set-JiraIssue -Issue TEST-001 -Fields @{'customfield_12345' = 'foo'; 'customfield_67890' = 'bar'; 'customfield_111222' = @(@{'value' = 'foobar'})} } | Should Not Throw
-                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Put' -and $URI -like "$jiraServer/rest/api/*/issue/12345" -and $Body -like '*customfield_12345*set*foo*' }
-                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Put' -and $URI -like "$jiraServer/rest/api/*/issue/12345" -and $Body -like '*customfield_67890*set*bar*' }
-                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Put' -and $URI -like "$jiraServer/rest/api/*/issue/12345" -and $Body -like '*customfield_111222*set*foobar*' }
+                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Put' -and $URI -like "rest/api/*/issue/12345" -and $Body -like '*customfield_12345*set*foo*' }
+                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Put' -and $URI -like "rest/api/*/issue/12345" -and $Body -like '*customfield_67890*set*bar*' }
+                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Put' -and $URI -like "rest/api/*/issue/12345" -and $Body -like '*customfield_111222*set*foobar*' }
             }
 
         }

--- a/Tests/Functions/Set-JiraIssue.Unit.Tests.ps1
+++ b/Tests/Functions/Set-JiraIssue.Unit.Tests.ps1
@@ -37,7 +37,6 @@ Describe "Set-JiraIssue" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = "https://jira.example.com"
 
         Mock Get-JiraConfigServer {
             $jiraServer
@@ -86,7 +85,7 @@ Describe "Set-JiraIssue" -Tag 'Unit' {
             defParam $command 'Label'
             defParam $command 'AddComment'
             defParam $command 'Fields'
-            defParam $command 'Credential'
+            defParam $command 'Session'
             defParam $command 'PassThru'
 
             It "Supports the Key alias for the Issue parameter" {

--- a/Tests/Functions/Set-JiraIssueLabel.Unit.Tests.ps1
+++ b/Tests/Functions/Set-JiraIssueLabel.Unit.Tests.ps1
@@ -73,7 +73,7 @@ Describe "Set-JiraIssueLabel" -Tag 'Unit' {
             defParam $command 'Add'
             defParam $command 'Remove'
             defParam $command 'Clear'
-            defParam $command 'Credential'
+            defParam $command 'Session'
             defParam $command 'PassThru'
 
             defAlias $command 'Key' 'Issue'

--- a/Tests/Functions/Set-JiraIssueLabel.Unit.Tests.ps1
+++ b/Tests/Functions/Set-JiraIssueLabel.Unit.Tests.ps1
@@ -37,16 +37,10 @@ Describe "Set-JiraIssueLabel" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'https://jira.example.com'
-
-        Mock Get-JiraConfigServer {
-            $jiraServer
-        }
-
         Mock Get-JiraIssue {
             $object = [PSCustomObject] @{
                 'Id'      = 123
-                'RestURL' = "$jiraServer/rest/api/2/issue/12345"
+                'RestURL' = "rest/api/2/issue/12345"
                 'Labels'  = @('existingLabel1', 'existingLabel2')
             }
             $object.PSObject.TypeNames.Insert(0, 'JiraPS.Issue')
@@ -57,7 +51,7 @@ Describe "Set-JiraIssueLabel" -Tag 'Unit' {
             Get-JiraIssue -Key $Issue
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq "Put" -and $Uri -like "$jiraServer/rest/api/*/issue/12345"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq "Put" -and $Uri -like "rest/api/*/issue/12345"} {
         }
 
         Mock Invoke-JiraMethod {
@@ -87,24 +81,24 @@ Describe "Set-JiraIssueLabel" -Tag 'Unit' {
                 # The String in the ParameterFilter is made from the keywords
                 # we should expect to see in the JSON that should be sent,
                 # including the summary provided in the test call above.
-                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Put' -and $URI -like '*/rest/api/2/issue/12345' -and $Body -like '*update*labels*set*testLabel1*testLabel2*' }
+                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Put' -and $URI -like 'rest/api/2/issue/12345' -and $Body -like '*update*labels*set*testLabel1*testLabel2*' }
             }
 
             It "Adds new labels if the Add parameter is supplied" {
                 { Set-JiraIssueLabel -Issue TEST-001 -Add 'testLabel3' } | Should Not Throw
-                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Put' -and $URI -like '*/rest/api/2/issue/12345' -and $Body -like '*update*labels*set*testLabel3*' }
+                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Put' -and $URI -like 'rest/api/2/issue/12345' -and $Body -like '*update*labels*set*testLabel3*' }
             }
 
             It "Removes labels if the Remove parameter is supplied" {
                 # The issue already has labels existingLabel1 and
                 # existingLabel2. It should be set to just existingLabel2.
                 { Set-JiraIssueLabel -Issue TEST-001 -Remove 'existingLabel1' } | Should Not Throw
-                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Put' -and $URI -like '*/rest/api/2/issue/12345' -and $Body -like '*update*labels*set*existingLabel2*' }
+                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Put' -and $URI -like 'rest/api/2/issue/12345' -and $Body -like '*update*labels*set*existingLabel2*' }
             }
 
             It "Clears all labels if the Clear parameter is supplied" {
                 { Set-JiraIssueLabel -Issue TEST-001 -Clear } | Should Not Throw
-                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Put' -and $URI -like '*/rest/api/2/issue/12345' -and $Body -like '*update*labels*set*' }
+                Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Put' -and $URI -like 'rest/api/2/issue/12345' -and $Body -like '*update*labels*set*' }
             }
 
             It "Allows use of both Add and Remove parameters at the same time" {

--- a/Tests/Functions/Set-JiraUser.Unit.Tests.ps1
+++ b/Tests/Functions/Set-JiraUser.Unit.Tests.ps1
@@ -37,7 +37,6 @@ Describe "Set-JiraUser" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
 
         $testUsername = 'powershell-test'
         $testDisplayName = 'PowerShell Test User'
@@ -48,7 +47,7 @@ Describe "Set-JiraUser" -Tag 'Unit' {
 
         $restResultGet = @"
 {
-    "self": "$jiraServer/rest/api/2/user?username=$testUsername",
+    "self": "rest/api/2/user?username=$testUsername",
     "key": "$testUsername",
     "name": "$testUsername",
     "displayName": "$testDisplayName",
@@ -57,17 +56,13 @@ Describe "Set-JiraUser" -Tag 'Unit' {
 }
 "@
 
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            Write-Output $jiraServer
-        }
-
         Mock Get-JiraUser -ModuleName JiraPS {
             $object = ConvertFrom-Json $restResultGet
             $object.PSObject.TypeNames.Insert(0, 'JiraPS.User')
             return $object
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Put' -and $URI -eq "$jiraServer/rest/api/latest/user?username=$testUsername"} {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {$Method -eq 'Put' -and $URI -eq "rest/api/latest/user?username=$testUsername"} {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             ConvertFrom-Json $restResultGet
         }

--- a/Tests/Functions/Set-JiraVersion.Unit.Tests.ps1
+++ b/Tests/Functions/Set-JiraVersion.Unit.Tests.ps1
@@ -116,7 +116,7 @@ Describe "Set-JiraVersion" -Tag 'Unit' {
             defParam $command 'ReleaseDate'
             defParam $command 'StartDate'
             defParam $command 'Project'
-            defParam $command 'Credential'
+            defParam $command 'Session'
         }
 
         Context "Behavior checking" {

--- a/Tests/Functions/Set-JiraVersion.Unit.Tests.ps1
+++ b/Tests/Functions/Set-JiraVersion.Unit.Tests.ps1
@@ -37,7 +37,6 @@ Describe "Set-JiraVersion" -Tag 'Unit' {
 
         . "$PSScriptRoot/../Shared.ps1"
 
-        $jiraServer = 'http://jiraserver.example.com'
         $versionName = '1.0.0.0'
         $versionID = '16840'
         $projectKey = 'LDD'
@@ -57,7 +56,7 @@ Describe "Set-JiraVersion" -Tag 'Unit' {
 "@
         $testJsonOne = @"
 {
-    "self" : "$jiraServer/rest/api/2/version/$versionID",
+    "self" : "rest/api/2/version/$versionID",
     "id" : $versionID,
     "description" : "$versionName",
     "name" : "$versionName",
@@ -68,9 +67,6 @@ Describe "Set-JiraVersion" -Tag 'Unit' {
 "@
 
         #region Mock
-        Mock Get-JiraConfigServer -ModuleName JiraPS {
-            Write-Output $jiraServer
-        }
 
         Mock Get-JiraProject -ModuleName JiraPS {
             $Projects = ConvertFrom-Json $JiraProjectData
@@ -93,7 +89,7 @@ Describe "Set-JiraVersion" -Tag 'Unit' {
             $result
         }
 
-        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Put' -and $URI -like "$jiraServer/rest/api/*/version/$versionID" } {
+        Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Put' -and $URI -like "rest/api/*/version/$versionID" } {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             ConvertFrom-Json $testJsonOne
         }
@@ -128,7 +124,7 @@ Describe "Set-JiraVersion" -Tag 'Unit' {
                 Assert-MockCalled 'Get-JiraVersion' -Times 2 -Scope It -ModuleName JiraPS -Exactly
                 Assert-MockCalled 'Get-JiraProject' -Times 0 -Scope It -ModuleName JiraPS -Exactly
                 Assert-MockCalled 'ConvertTo-JiraVersion' -Times 3 -Scope It -ModuleName JiraPS -Exactly
-                Assert-MockCalled 'Invoke-JiraMethod' -Times 1 -Scope It -ModuleName JiraPS -Exactly -ParameterFilter { $Method -eq 'Put' -and $URI -like "$jiraServer/rest/api/*/version/$versionID" }
+                Assert-MockCalled 'Invoke-JiraMethod' -Times 1 -Scope It -ModuleName JiraPS -Exactly -ParameterFilter { $Method -eq 'Put' -and $URI -like "rest/api/*/version/$versionID" }
             }
             It "sets an Issue's Version Name using the pipeline" {
                 $results = Get-JiraVersion -Project $projectKey | Set-JiraVersion -Name "NewName" -ErrorAction Stop
@@ -137,7 +133,7 @@ Describe "Set-JiraVersion" -Tag 'Unit' {
                 Assert-MockCalled 'Get-JiraVersion' -Times 2 -Scope It -ModuleName JiraPS -Exactly
                 Assert-MockCalled 'Get-JiraProject' -Times 0 -Scope It -ModuleName JiraPS -Exactly
                 Assert-MockCalled 'ConvertTo-JiraVersion' -Times 3 -Scope It -ModuleName JiraPS -Exactly
-                Assert-MockCalled 'Invoke-JiraMethod' -Times 1 -Scope It -ModuleName JiraPS -Exactly -ParameterFilter { $Method -eq 'Put' -and $URI -like "$jiraServer/rest/api/*/version/$versionID" }
+                Assert-MockCalled 'Invoke-JiraMethod' -Times 1 -Scope It -ModuleName JiraPS -Exactly -ParameterFilter { $Method -eq 'Put' -and $URI -like "rest/api/*/version/$versionID" }
             }
             It "assert VerifiableMock" {
                 Assert-VerifiableMock

--- a/Tests/JiraPS.Tests.ps1
+++ b/Tests/JiraPS.Tests.ps1
@@ -25,14 +25,23 @@ Describe "General project validation" -Tag Unit {
         Import-Module "$env:BHProjectPath/Tools/BuildTools.psm1"
 
         Remove-Module $env:BHProjectName -ErrorAction SilentlyContinue
-
         # Import-Module $env:BHManifestToTest
 
-        $oldAPPDATA = $env:APPDATA
-        $env:APPDATA = "TestDrive:\"
+        $configFile = ("{0}/AtlassianPS/JiraPS/servers.json" -f [Environment]::GetFolderPath('ApplicationData'))
+        $legacyConfigFile = ("{0}/AtlassianPS/JiraPS/server_config" -f [Environment]::GetFolderPath('ApplicationData'))
+
+        $configContent = Get-Content $configFile -ErrorAction SilentlyContinue
+        $legacyConfigContent = Get-Content $legacyConfigFile -ErrorAction SilentlyContinue
     }
     AfterAll {
-        $env:APPDATA = $oldAPPDATA
+
+        if ($configContent) {
+            Set-Content -Value $configContent -Path $configFile -Force
+        }
+
+        if ($legacyConfigContent) {
+            Set-Content -Value $legacyConfigContent -Path $legacyConfigFile -Force
+        }
 
         Remove-Module $env:BHProjectName -ErrorAction SilentlyContinue
         Remove-Module BuildHelpers -ErrorAction SilentlyContinue
@@ -67,8 +76,8 @@ Describe "General project validation" -Tag Unit {
     }
 
     It "module uses the previous server config when loaded" {
-        New-Item -Path "$($env:APPDATA)/AtlassianPS/JiraPS/servers.json" -Force | Out-Null
-        Set-Content -Path "$($env:APPDATA)/AtlassianPS/JiraPS/servers.json" -Value "{ Default: { Server: `"https://example.com`" } }" -Force
+        New-Item -Path $configFile -Force | Out-Null
+        Set-Content -Path $configFile -Value "{ Default: { Server: `"https://example.com`" } }" -Force
 
         Import-Module $env:BHManifestToTest -Force
 

--- a/Tests/JiraPS.Tests.ps1
+++ b/Tests/JiraPS.Tests.ps1
@@ -25,13 +25,14 @@ Describe "General project validation" -Tag Unit {
         Import-Module "$env:BHProjectPath/Tools/BuildTools.psm1"
 
         Remove-Module $env:BHProjectName -ErrorAction SilentlyContinue
+
         # Import-Module $env:BHManifestToTest
 
-        $configFile = ("{0}/AtlassianPS/JiraPS/server_config" -f [Environment]::GetFolderPath('ApplicationData'))
-        $oldConfig = Get-Content $configFile
+        $oldAPPDATA = $env:APPDATA
+        $env:APPDATA = "TestDrive:\"
     }
     AfterAll {
-        Set-Content -Value $oldConfig -Path $configFile -Force
+        $env:APPDATA = $oldAPPDATA
 
         Remove-Module $env:BHProjectName -ErrorAction SilentlyContinue
         Remove-Module BuildHelpers -ErrorAction SilentlyContinue
@@ -66,7 +67,8 @@ Describe "General project validation" -Tag Unit {
     }
 
     It "module uses the previous server config when loaded" {
-        Set-Content -Value "https://example.com" -Path $configFile -Force
+        New-Item -Path "$($env:APPDATA)/AtlassianPS/JiraPS/servers.json" -Force | Out-Null
+        Set-Content -Path "$($env:APPDATA)/AtlassianPS/JiraPS/servers.json" -Value "{ Default: { Server: `"https://example.com`" } }" -Force
 
         Import-Module $env:BHManifestToTest -Force
 

--- a/Tests/JiraPS.Tests.ps1
+++ b/Tests/JiraPS.Tests.ps1
@@ -70,7 +70,8 @@ Describe "General project validation" -Tag Unit {
 
         Import-Module $env:BHManifestToTest -Force
 
-        Get-JiraConfigServer | Should -Be "https://example.com"
+        $config = Get-JiraConfigServer
+        $config.Server | Should -Be "https://example.com"
     }
 
     # It "module is imported with default prefix" {

--- a/docs/en-US/commands/Add-JiraFilterPermission.md
+++ b/docs/en-US/commands/Add-JiraFilterPermission.md
@@ -19,7 +19,7 @@ Share a Filter with other users.
 
 ```powershell
 Add-JiraFilterPermission [-Filter] <JiraPS.Filter> [-Type] <String>
- [[-Value] <String>] [[-Credential] <PSCredential>] [-WhatIf] [-Confirm]
+ [[-Value] <String>] [[-Session] <PSObject>] [-WhatIf] [-Confirm]
   [<CommonParameters>]
 ```
 
@@ -27,7 +27,7 @@ Add-JiraFilterPermission [-Filter] <JiraPS.Filter> [-Type] <String>
 
 ```powershell
 Add-JiraFilterPermission [-Id] <UInt32> [-Type] <String> [[-Value] <String>]
- [[-Credential] <PSCredential>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-Session] <PSObject>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -145,15 +145,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: 3
@@ -217,8 +218,7 @@ This functions does not validate the input for `-Value`.
 In case the value is invalid, unexpected or missing, the API will response with
 an error.
 
-This function requires either the `-Credential` parameter to be passed or
-a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Add-JiraGroupMember.md
+++ b/docs/en-US/commands/Add-JiraGroupMember.md
@@ -16,7 +16,7 @@ Adds a user to a JIRA group
 ## SYNTAX
 
 ```powershell
-Add-JiraGroupMember [-Group] <Object[]> [-UserName] <Object[]> [[-Credential] <PSCredential>] [-PassThru]
+Add-JiraGroupMember [-Group] <Object[]> [-UserName] <Object[]> [[-Session] <PSObject>] [-PassThru]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -77,15 +77,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: 3
@@ -167,7 +168,7 @@ This REST method is still marked Experimental in JIRA's REST API.
 That means that there is a high probability this will break in future versions of JIRA.
 The function will need to be re-written at that time.
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Add-JiraIssueAttachment.md
+++ b/docs/en-US/commands/Add-JiraIssueAttachment.md
@@ -16,7 +16,7 @@ Adds a file attachment to an existing Jira Issue
 ## SYNTAX
 
 ```powershell
-Add-JiraIssueAttachment [-Issue] <Object> [-FilePath] <String[]> [[-Credential] <PSCredential>] [-PassThru]
+Add-JiraIssueAttachment [-Issue] <Object> [-FilePath] <String[]> [[-Session] <PSObject>] [-PassThru]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -78,15 +78,16 @@ Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: 3
@@ -161,7 +162,7 @@ This function outputs the results of the attachment add.
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Add-JiraIssueComment.md
+++ b/docs/en-US/commands/Add-JiraIssueComment.md
@@ -17,7 +17,7 @@ Adds a comment to an existing JIRA issue
 
 ```powershell
 Add-JiraIssueComment [-Comment] <String> [-Issue] <Object> [[-VisibleRole] <String>]
- [[-Credential] <PSCredential>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-Session] <PSObject>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -122,15 +122,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: 4
@@ -187,7 +188,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Add-JiraIssueLink.md
+++ b/docs/en-US/commands/Add-JiraIssueLink.md
@@ -17,7 +17,7 @@ Adds a link between two Issues on Jira
 
 ```powershell
 Add-JiraIssueLink [-Issue] <Object[]> [-IssueLink] <Object[]> [[-Comment] <String>]
- [[-Credential] <PSCredential>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-Session] <PSObject>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -90,15 +90,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: 4
@@ -156,7 +157,7 @@ The JIRA issue link that should be used
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Add-JiraIssueWatcher.md
+++ b/docs/en-US/commands/Add-JiraIssueWatcher.md
@@ -16,7 +16,7 @@ Adds a watcher to an existing JIRA issue
 ## SYNTAX
 
 ```powershell
-Add-JiraIssueWatcher [-Watcher] <String[]> [-Issue] <Object> [[-Credential] <PSCredential>] [-WhatIf]
+Add-JiraIssueWatcher [-Watcher] <String[]> [-Issue] <Object> [[-Session] <PSObject>] [-WhatIf]
  [-Confirm] [<CommonParameters>]
 ```
 
@@ -88,15 +88,16 @@ Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: 3
@@ -151,7 +152,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Add-JiraIssueWorklog.md
+++ b/docs/en-US/commands/Add-JiraIssueWorklog.md
@@ -17,7 +17,7 @@ Adds a worklog item to an existing JIRA issue
 
 ```powershell
 Add-JiraIssueWorklog [-Comment] <String> [-Issue] <Object> [-TimeSpent] <TimeSpan> [-DateStarted] <DateTime>
- [[-VisibleRole] <String>] [[-Credential] <PSCredential>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-VisibleRole] <String>] [[-Session] <PSObject>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -155,15 +155,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: 6
@@ -220,7 +221,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Find-JiraFilter.md
+++ b/docs/en-US/commands/Find-JiraFilter.md
@@ -19,7 +19,7 @@ Find JIRA filter(s).
 
 ```powershell
 Find-JiraFilter [[-Name] <string[]>] [[-AccountId] <string>] [[-GroupName] <string>] [[-Project] <Object>] [[-Fields] {description | favourite | favouritedCount | jql | owner |
-    searchUrl | sharePermissions | subscriptions | viewUrl}] [[-Sort] <string>] [[-Credential] <pscredential>] [-IncludeTotalCount] [-Skip <uint64>] [-First <uint64>]
+    searchUrl | sharePermissions | subscriptions | viewUrl}] [[-Sort] <string>] [[-Session] <PSObject>] [-IncludeTotalCount] [-Skip <uint64>] [-First <uint64>]
     [<CommonParameters>]
 ```
 
@@ -27,7 +27,7 @@ Find-JiraFilter [[-Name] <string[]>] [[-AccountId] <string>] [[-GroupName] <stri
 
 ```powershell
 Find-JiraFilter [[-Name] <string[]>] [-Owner] <string> [[-GroupName] <string>] [[-Project] <Object>] [[-Fields] {description | favourite | favouritedCount | jql | owner |
-    searchUrl | sharePermissions | subscriptions | viewUrl}] [[-Sort] <string>] [[-Credential] <pscredential>] [-IncludeTotalCount] [-Skip <uint64>] [-First <uint64>]
+    searchUrl | sharePermissions | subscriptions | viewUrl}] [[-Sort] <string>] [[-Session] <PSObject>] [-IncludeTotalCount] [-Skip <uint64>] [-First <uint64>]
     [<CommonParameters>]
 ```
 
@@ -286,15 +286,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: Named
@@ -316,7 +317,7 @@ For more information, see [about_CommonParameters](http://go.microsoft.com/fwlin
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Get-JiraComponent.md
+++ b/docs/en-US/commands/Get-JiraComponent.md
@@ -18,13 +18,13 @@ Returns a Component from Jira
 ### ByID (Default)
 
 ```powershell
-Get-JiraComponent [-ComponentId] <Int32[]> [-Credential <PSCredential>] [<CommonParameters>]
+Get-JiraComponent [-ComponentId] <Int32[]> [-Session <PSObject>] [<CommonParameters>]
 ```
 
 ### ByProject
 
 ```powershell
-Get-JiraComponent [-Project] <Object[]> [-Credential <PSCredential>] [<CommonParameters>]
+Get-JiraComponent [-Project] <Object[]> [-Session <PSObject>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -47,7 +47,7 @@ Returns information about the component with ID 10000
 ### EXAMPLE 2
 
 ```powershell
-Get-JiraComponent 20000 -Credential $cred
+Get-JiraComponent 20000 -Session $session
 ```
 
 Returns information about the component with ID 20000
@@ -102,15 +102,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: Named
@@ -140,7 +141,7 @@ Retrieve specific Components by theirs id.
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Get-JiraField.md
+++ b/docs/en-US/commands/Get-JiraField.md
@@ -18,13 +18,13 @@ This function returns information about JIRA fields
 ### _All (Default)
 
 ```powershell
-Get-JiraField [-Credential <PSCredential>] [<CommonParameters>]
+Get-JiraField [-Session <PSObject>] [<CommonParameters>]
 ```
 
 ### _Search
 
 ```powershell
-Get-JiraField [-Field] <String[]> [-Credential <PSCredential>] [<CommonParameters>]
+Get-JiraField [-Field] <String[]> [-Session <PSObject>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -71,15 +71,16 @@ Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: Named
@@ -101,7 +102,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Get-JiraFilter.md
+++ b/docs/en-US/commands/Get-JiraFilter.md
@@ -18,20 +18,20 @@ Returns information about a filter in JIRA
 ### ByFilterID (Default)
 
 ```powershell
-Get-JiraFilter [-Id] <String[]> [-Credential <PSCredential>] [<CommonParameters>]
+Get-JiraFilter [-Id] <String[]> [-Session <PSObject>] [<CommonParameters>]
 ```
 
 ### ByInputObject
 
 ```powershell
-Get-JiraFilter -InputObject <Object[]> [-Credential <PSCredential>]
+Get-JiraFilter -InputObject <Object[]> [-Session <PSObject>]
  [<CommonParameters>]
 ```
 
 ### MyFavorite
 
 ```powershell
-Get-JiraFilter -Favorite [-Credential <PSCredential>] [<CommonParameters>]
+Get-JiraFilter -Favorite [-Session <PSObject>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -122,15 +122,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: Named
@@ -159,8 +160,7 @@ The filter to look up in JIRA. This can be a String (filter ID) or a JiraPS.Filt
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or
-a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Get-JiraFilterPermission.md
+++ b/docs/en-US/commands/Get-JiraFilterPermission.md
@@ -18,14 +18,14 @@ Fetch the permissions of a specific Filter.
 ### ByInputObject (Default)
 
 ```powershell
-Get-JiraFilterPermission [-Filter] <JiraPS.Filter> [[-Credential] <PSCredential>]
+Get-JiraFilterPermission [-Filter] <JiraPS.Filter> [[-Session] <PSObject>]
  [<CommonParameters>]
 ```
 
 ### ById
 
 ```powershell
-Get-JiraFilterPermission [-Id] <UInt32[]> [[-Credential] <PSCredential>]
+Get-JiraFilterPermission [-Id] <UInt32[]> [[-Session] <PSObject>]
  [<CommonParameters>]
 ```
 
@@ -91,15 +91,16 @@ Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: 1
@@ -126,8 +127,7 @@ For more information, see about_CommonParameters
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or
-a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Get-JiraGroup.md
+++ b/docs/en-US/commands/Get-JiraGroup.md
@@ -16,7 +16,7 @@ Returns a group from Jira
 ## SYNTAX
 
 ```powershell
-Get-JiraGroup [-GroupName] <String[]> [[-Credential] <PSCredential>] [<CommonParameters>]
+Get-JiraGroup [-GroupName] <String[]> [[-Session] <PSObject>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -62,15 +62,16 @@ Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: 2
@@ -92,7 +93,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Get-JiraGroupMember.md
+++ b/docs/en-US/commands/Get-JiraGroupMember.md
@@ -17,7 +17,7 @@ Returns members of a given group in JIRA
 
 ```powershell
 Get-JiraGroupMember [-Group] <Object[]> [[-IncludeInactive] <Switch>] [[-StartIndex] <UInt32>] [[-MaxResults] <UInt32>]
- [[PageSize] <UInt32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>] [[-Credential] <PSCredential>] [<CommonParameters>]
+ [[PageSize] <UInt32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>] [[-Session] <PSObject>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -193,15 +193,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: 4
@@ -235,7 +236,7 @@ You can also combine this with the `-StartIndex` parameter to "page" through res
 This function does not return inactive users.
 This appears to be a limitation of JIRA's REST API.
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Get-JiraIssue.md
+++ b/docs/en-US/commands/Get-JiraIssue.md
@@ -19,14 +19,14 @@ Returns information about an issue in JIRA.
 
 ```powershell
 Get-JiraIssue [-Key] <String[]> [-Fields <String[]>] [-IncludeTotalCount]
- [-Skip <UInt64>] [-First <UInt64>] [-Credential <PSCredential>] [<CommonParameters>]
+ [-Skip <UInt64>] [-First <UInt64>] [-Session <PSObject>] [<CommonParameters>]
 ```
 
 ### ByInputObject
 
 ```powershell
 Get-JiraIssue [-InputObject] <Object[]> [-Fields <String[]>] [-IncludeTotalCount]
- [-Skip <UInt64>] [-First <UInt64>] [-Credential <PSCredential>] [<CommonParameters>]
+ [-Skip <UInt64>] [-First <UInt64>] [-Session <PSObject>] [<CommonParameters>]
 ```
 
 ### ByJQL
@@ -34,7 +34,7 @@ Get-JiraIssue [-InputObject] <Object[]> [-Fields <String[]>] [-IncludeTotalCount
 ```powershell
 Get-JiraIssue -Query <String> [-Fields <String[]>] [-StartIndex <UInt32>]
 [-MaxResults <UInt32>] [[PageSize] <UInt32>] [-IncludeTotalCount] [-Skip <UInt64>]
- [-First <UInt64>] [-Credential <PSCredential>] [<CommonParameters>]
+ [-First <UInt64>] [-Session <PSObject>] [<CommonParameters>]
 ```
 
 ### ByFilter
@@ -42,7 +42,7 @@ Get-JiraIssue -Query <String> [-Fields <String[]>] [-StartIndex <UInt32>]
 ```powershell
 Get-JiraIssue -Filter <Object> [-Fields <String[]>][-StartIndex <UInt32>]
  [-MaxResults <UInt32>] [[PageSize] <UInt32>] [-IncludeTotalCount] [-Skip <UInt64>]
- [-First <UInt64>] [-Credential <PSCredential>] [<CommonParameters>]
+ [-First <UInt64>] [-Session <PSObject>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -328,15 +328,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: Named
@@ -364,7 +365,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Get-JiraIssueAttachment.md
+++ b/docs/en-US/commands/Get-JiraIssueAttachment.md
@@ -16,7 +16,7 @@ Returns attachments of an issue in JIRA.
 ## SYNTAX
 
 ```powershell
-Get-JiraIssueAttachment [-Issue] <Object> [[-FileName] <String>] [[-Credential] <PSCredential>]
+Get-JiraIssueAttachment [-Issue] <Object> [[-FileName] <String>] [[-Session] <PSObject>]
  [<CommonParameters>]
 ```
 
@@ -88,15 +88,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: 3
@@ -120,7 +121,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Get-JiraIssueAttachmentFile.md
+++ b/docs/en-US/commands/Get-JiraIssueAttachmentFile.md
@@ -17,7 +17,7 @@ Save an attachment to disk.
 
 ```powershell
 Get-JiraIssueAttachmentFile [-Attachment] <JiraPS.Attachment> [[-Path] <String>]]
- [[-Credential] <PSCredential>] [<CommonParameters>]
+ [[-Session] <PSObject>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -91,15 +91,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: 3
@@ -123,7 +124,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Get-JiraIssueComment.md
+++ b/docs/en-US/commands/Get-JiraIssueComment.md
@@ -16,7 +16,7 @@ Returns comments on an issue in JIRA.
 ## SYNTAX
 
 ```powershell
-Get-JiraIssueComment [-Issue] <Object> [[-Credential] <PSCredential>] [<CommonParameters>]
+Get-JiraIssueComment [-Issue] <Object> [[-Session] <PSObject>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -61,15 +61,16 @@ Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: 2
@@ -93,7 +94,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Get-JiraIssueCreateMetadata.md
+++ b/docs/en-US/commands/Get-JiraIssueCreateMetadata.md
@@ -16,7 +16,7 @@ Returns metadata required to create an issue in JIRA
 ## SYNTAX
 
 ```powershell
-Get-JiraIssueCreateMetadata [-Project] <String> [-IssueType] <String> [[-Credential] <PSCredential>]
+Get-JiraIssueCreateMetadata [-Project] <String> [-IssueType] <String> [[-Session] <PSObject>]
  [<CommonParameters>]
 ```
 
@@ -81,15 +81,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: 3
@@ -111,7 +112,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Get-JiraIssueEditMetadata.md
+++ b/docs/en-US/commands/Get-JiraIssueEditMetadata.md
@@ -16,7 +16,7 @@ Returns metadata required to change an issue in JIRA
 ## SYNTAX
 
 ```powershell
-Get-JiraIssueEditMetadata [-Issue] <String> [[-Credential] <PSCredential>] [<CommonParameters>]
+Get-JiraIssueEditMetadata [-Issue] <String> [[-Session] <PSObject>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -63,15 +63,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: 2
@@ -93,7 +94,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Get-JiraIssueLink.md
+++ b/docs/en-US/commands/Get-JiraIssueLink.md
@@ -16,7 +16,7 @@ Returns a specific issueLink from Jira
 ## SYNTAX
 
 ```powershell
-Get-JiraIssueLink [-Id] <Int32[]> [[-Credential] <PSCredential>] [<CommonParameters>]
+Get-JiraIssueLink [-Id] <Int32[]> [[-Session] <PSObject>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -69,15 +69,16 @@ Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: 2
@@ -101,7 +102,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Get-JiraIssueLinkType.md
+++ b/docs/en-US/commands/Get-JiraIssueLinkType.md
@@ -18,13 +18,13 @@ Gets available issue link types
 ### _All (Default)
 
 ```powershell
-Get-JiraIssueLinkType [-Credential <PSCredential>] [<CommonParameters>]
+Get-JiraIssueLinkType [-Session <PSObject>] [<CommonParameters>]
 ```
 
 ### _Search
 
 ```powershell
-Get-JiraIssueLinkType [-LinkType] <Object> [-Credential <PSCredential>] [<CommonParameters>]
+Get-JiraIssueLinkType [-LinkType] <Object> [-Session <PSObject>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -70,15 +70,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: Named
@@ -102,7 +103,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Get-JiraIssueType.md
+++ b/docs/en-US/commands/Get-JiraIssueType.md
@@ -18,13 +18,13 @@ Returns information about the available issue type in JIRA.
 ### _All (Default)
 
 ```powershell
-Get-JiraIssueType [-Credential <PSCredential>] [<CommonParameters>]
+Get-JiraIssueType [-Session <PSObject>] [<CommonParameters>]
 ```
 
 ### _Search
 
 ```powershell
-Get-JiraIssueType [-IssueType] <String[]> [-Credential <PSCredential>] [<CommonParameters>]
+Get-JiraIssueType [-IssueType] <String[]> [-Session <PSObject>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -77,15 +77,16 @@ Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: Named
@@ -109,7 +110,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Get-JiraIssueWatcher.md
+++ b/docs/en-US/commands/Get-JiraIssueWatcher.md
@@ -16,7 +16,7 @@ Returns watchers on an issue in JIRA.
 ## SYNTAX
 
 ```powershell
-Get-JiraIssueWatcher [-Issue] <Object> [[-Credential] <PSCredential>] [<CommonParameters>]
+Get-JiraIssueWatcher [-Issue] <Object> [[-Session] <PSObject>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -61,15 +61,16 @@ Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: 2
@@ -93,7 +94,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Get-JiraPriority.md
+++ b/docs/en-US/commands/Get-JiraPriority.md
@@ -18,13 +18,13 @@ Returns information about the available priorities in JIRA.
 ### _All (Default)
 
 ```powershell
-Get-JiraPriority [-Credential <PSCredential>] [<CommonParameters>]
+Get-JiraPriority [-Session <PSObject>] [<CommonParameters>]
 ```
 
 ### _Search
 
 ```powershell
-Get-JiraPriority [-Id] <Int32[]> [-Credential <PSCredential>] [<CommonParameters>]
+Get-JiraPriority [-Id] <Int32[]> [-Session <PSObject>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -69,15 +69,16 @@ Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: Named
@@ -99,7 +100,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Get-JiraProject.md
+++ b/docs/en-US/commands/Get-JiraProject.md
@@ -18,13 +18,13 @@ Returns a project from Jira
 ### _All (Default)
 
 ```powershell
-Get-JiraProject [-Credential <PSCredential>] [<CommonParameters>]
+Get-JiraProject [-Session <PSObject>] [<CommonParameters>]
 ```
 
 ### _Search
 
 ```powershell
-Get-JiraProject [-Project] <String[]> [-Credential <PSCredential>] [<CommonParameters>]
+Get-JiraProject [-Project] <String[]> [-Session <PSObject>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -41,7 +41,7 @@ The `-Project` parameter will accept either a project ID or a project key.
 ### EXAMPLE 1
 
 ```powershell
-Get-JiraProject -Project TEST -Credential $cred
+Get-JiraProject -Project TEST -Session $session
 ```
 
 Returns information about the project TEST
@@ -49,7 +49,7 @@ Returns information about the project TEST
 ### EXAMPLE 2
 
 ```powershell
-Get-JiraProject 2 -Credential $cred
+Get-JiraProject 2 -Session $session
 ```
 
 Returns information about the project with ID 2
@@ -80,15 +80,16 @@ Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: Named
@@ -110,7 +111,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Get-JiraRemoteLink.md
+++ b/docs/en-US/commands/Get-JiraRemoteLink.md
@@ -16,7 +16,7 @@ Returns a remote link from a Jira issue
 ## SYNTAX
 
 ```powershell
-Get-JiraRemoteLink [-Issue] <Object> [[-LinkId] <Int32>] [[-Credential] <PSCredential>] [<CommonParameters>]
+Get-JiraRemoteLink [-Issue] <Object> [[-LinkId] <Int32>] [[-Session] <PSObject>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -28,7 +28,7 @@ This function returns information on remote links from a  JIRA issue.
 ### EXAMPLE 1
 
 ```powershell
-Get-JiraRemoteLink -Issue TEST-001 -Credential $cred
+Get-JiraRemoteLink -Issue TEST-001 -Session $session
 ```
 
 Returns information about all remote links from the issue "TEST-001"
@@ -36,7 +36,7 @@ Returns information about all remote links from the issue "TEST-001"
 ### EXAMPLE 2
 
 ```powershell
-Get-JiraRemoteLink -Issue TEST-001 -LinkId 100000 -Credential $cred
+Get-JiraRemoteLink -Issue TEST-001 -LinkId 100000 -Session $session
 ```
 
 Returns information about a specific remote link from the issue "TEST-001"
@@ -77,15 +77,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: 3
@@ -109,7 +110,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Get-JiraServerInformation.md
+++ b/docs/en-US/commands/Get-JiraServerInformation.md
@@ -16,7 +16,7 @@ This function returns the information about the JIRA Server
 ## SYNTAX
 
 ```powershell
-Get-JiraServerInformation [[-Credential] <PSCredential>] [<CommonParameters>]
+Get-JiraServerInformation [[-Session] <PSObject>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -35,15 +35,16 @@ This example returns information about the JIRA server.
 
 ## PARAMETERS
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: 1
@@ -65,7 +66,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Get-JiraUser.md
+++ b/docs/en-US/commands/Get-JiraUser.md
@@ -18,19 +18,19 @@ Returns a user from Jira
 ### Self (Default)
 
 ```powershell
-Get-JiraUser [-Credential <PSCredential>] [<CommonParameters>]
+Get-JiraUser [-Session <PSObject>] [<CommonParameters>]
 ```
 
 ### ByUserName
 
 ```powershell
-Get-JiraUser [-UserName] <String[]> [-IncludeInactive] [[-MaxResults] <UInt32>] [[-Skip] <UInt64>] [-Credential <PSCredential>] [-Exact] [<CommonParameters>]
+Get-JiraUser [-UserName] <String[]> [-IncludeInactive] [[-MaxResults] <UInt32>] [[-Skip] <UInt64>] [-Session <PSObject>] [-Exact] [<CommonParameters>]
 ```
 
 ### ByInputObject
 
 ```powershell
-Get-JiraUser [-InputObject] <Object[]> [-IncludeInactive] [-Credential <PSCredential>] [-Exact] [<CommonParameters>]
+Get-JiraUser [-InputObject] <Object[]> [-IncludeInactive] [-Session <PSObject>] [-Exact] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -50,7 +50,7 @@ Returns information about all users with username like user1
 ### EXAMPLE 2
 
 ```powershell
-Get-ADUser -filter "Name -like 'John*Smith'" | Select-Object -ExpandProperty samAccountName | Get-JiraUser -Credential $cred
+Get-ADUser -filter "Name -like 'John*Smith'" | Select-Object -ExpandProperty samAccountName | Get-JiraUser -Session $session
 ```
 
 This example searches Active Directory for "John*Smith", then obtains their JIRA user accounts.
@@ -58,7 +58,7 @@ This example searches Active Directory for "John*Smith", then obtains their JIRA
 ### EXAMPLE 3
 
 ```powershell
-Get-JiraUser -Credential $cred
+Get-JiraUser -Session $session
 ```
 
 This example returns the JIRA user that is executing the command.
@@ -181,15 +181,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: Named
@@ -215,7 +216,7 @@ Username, name, or e-mail address
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Get-JiraVersion.md
+++ b/docs/en-US/commands/Get-JiraVersion.md
@@ -19,14 +19,14 @@ This function returns information about a JIRA Project's Version
 
 ```powershell
 Get-JiraVersion -Id <Int32[]> [-PageSize <Int32>] [-IncludeTotalCount] [-Skip <UInt64>]
- [-First <UInt64>] [-Credential <PSCredential>] [<CommonParameters>]
+ [-First <UInt64>] [-Session <PSObject>] [<CommonParameters>]
 ```
 
 ### byInputVersion
 
 ```powershell
 Get-JiraVersion [-InputVersion] <Object> [-PageSize <Int32>] [-IncludeTotalCount]
- [-Skip <UInt64>] [-First <UInt64>] [-Credential <PSCredential>] [<CommonParameters>]
+ [-Skip <UInt64>] [-First <UInt64>] [-Session <PSObject>] [<CommonParameters>]
 ```
 
 ### byProject
@@ -34,7 +34,7 @@ Get-JiraVersion [-InputVersion] <Object> [-PageSize <Int32>] [-IncludeTotalCount
 ```powershell
 Get-JiraVersion [-Project] <String[]> [-Name <String[]>] [[-Sort] <String>]
  [-PageSize <Int32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
- [-Credential <PSCredential>] [<CommonParameters>]
+ [-Session <PSObject>] [<CommonParameters>]
 ```
 
 ### byInputProject
@@ -42,7 +42,7 @@ Get-JiraVersion [-Project] <String[]> [-Name <String[]>] [[-Sort] <String>]
 ```powershell
 Get-JiraVersion [-InputProject] <Object> [-Name <String[]>] [[-Sort] <String>]
  [-PageSize <Int32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
- [-Credential <PSCredential>] [<CommonParameters>]
+ [-Session <PSObject>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -261,15 +261,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: Named
@@ -295,7 +296,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Invoke-JiraIssueTransition.md
+++ b/docs/en-US/commands/Invoke-JiraIssueTransition.md
@@ -17,7 +17,7 @@ Performs an issue transition on a JIRA issue changing it's status
 
 ```powershell
 Invoke-JiraIssueTransition [-Issue] <Object> [-Transition] <Object> [[-Fields] <PSCustomObject>]
- [[-Assignee] <Object>] [[-Comment] <String>] [[-Credential] <PSCredential>] [-Passthru] [<CommonParameters>]
+ [[-Assignee] <Object>] [[-Comment] <String>] [[-Session] <PSObject>] [-Passthru] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -176,15 +176,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: 6
@@ -226,7 +227,7 @@ When `-Passthru` is provided, the issue will be returned.
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Invoke-JiraMethod.md
+++ b/docs/en-US/commands/Invoke-JiraMethod.md
@@ -18,7 +18,7 @@ Invoke a specific call to a Jira REST Api endpoint
 ```powershell
 Invoke-JiraMethod [-URI] <Uri> [[-Method] <WebRequestMethod>] [[-Body] <String>] [-RawBody]
  [[-Headers] <Hashtable>] [[-GetParameter] <Hashtable>] [[-Paging] <Switch>] [[-InFile] <String>]
- [[-OutFile] <String>] [-StoreSession] [[-OutputType] <String>] [[-Credential] <PSCredential>]
+ [[-OutFile] <String>] [[-OutputType] <String>] [[-Session] <PSObject>]
  [[-Cmdlet] <System.Management.Automation.PSCmdlet>] [<CommonParameters>]
 ```
 
@@ -53,7 +53,7 @@ This call would either be executed anonymously or require a session to be availa
 ### Example 2
 
 ```powershell
-Invoke-JiraMethod -URI "rest/api/latest/project" -Credential (Get-Credential)
+Invoke-JiraMethod -URI "rest/api/latest/project" -Session $session
 ```
 
 Prompts the user for his Jira credentials and send a GET request,
@@ -98,7 +98,6 @@ $params = @{
     Uri = "rest/api/latest/mypermissions"
     Method = "GET"
     Body = $body
-    StoreSession = $true
     Credential = $cred
 }
 Invoke-JiraMethod @params
@@ -160,7 +159,7 @@ Could be relative or absolute URL.
 Keep in mind that mostly you should use relative path (ex. rest/api) and seek to avoid use absolute path (ex. /rest/api).
 
 ```yaml
-Type: Uri, string
+Type: Uri
 Parameter Sets: (All)
 Aliases:
 
@@ -313,22 +312,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -StoreSession
-
-Instead of returning the response, it returns a `[JiraPS.Session]` which contains the `[WebRequestSession]`.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: 7
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -OutputType
 
 Name of the data type that is expected to be returned.
@@ -347,17 +330,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use for the authentication with the REST Api.
-
-If none are provided, `Get-JiraSession` will be used for authentication.
-If no sessions is available, the request will be executed anonymously.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: 9

--- a/docs/en-US/commands/Invoke-JiraMethod.md
+++ b/docs/en-US/commands/Invoke-JiraMethod.md
@@ -44,7 +44,7 @@ This will import the module if not already loaded or even download it from the P
 ### Example 1
 
 ```powershell
-Invoke-JiraMethod -URI "$(Get-JiraConfigServer)/rest/api/latest/project"
+Invoke-JiraMethod -URI "rest/api/latest/project"
 ```
 
 Sends a GET request which will return all the projects on the Jira server.
@@ -53,7 +53,7 @@ This call would either be executed anonymously or require a session to be availa
 ### Example 2
 
 ```powershell
-Invoke-JiraMethod -URI "$(Get-JiraConfigServer)/rest/api/latest/project" -Credential (Get-Credential)
+Invoke-JiraMethod -URI "rest/api/latest/project" -Credential (Get-Credential)
 ```
 
 Prompts the user for his Jira credentials and send a GET request,
@@ -63,7 +63,7 @@ which will return all the projects on the Jira server.
 
 ```powershell
 $parameter = @{
-    URI = "$(Get-JiraConfigServer)/rest/api/latest/project"
+    URI = "rest/api/latest/project"
     Method = "POST"
     Credential = $cred
 }
@@ -81,7 +81,7 @@ See next example
 ```powershell
 $body = '{"name": "NewGroup"}'
 $params = @{
-    Uri = "$(Get-JiraConfigServer)/rest/api/latest/group"
+    Uri = "rest/api/latest/group"
     Method = "POST"
     Body = $body
     Credential = $cred
@@ -95,7 +95,7 @@ Creates a new group named "NewGroup"
 
 ```powershell
 $params = @{
-    Uri = "$(Get-JiraConfigServer)/rest/api/latest/mypermissions"
+    Uri = "rest/api/latest/mypermissions"
     Method = "GET"
     Body = $body
     StoreSession = $true
@@ -111,7 +111,7 @@ it returns a `[JiraPS.Session]` which contains the `[WebRequestSession]`.
 
 ```powershell
 $params = @{
-    Uri = "$(Get-JiraConfigServer)/rest/api/latest/issue/10000"
+    Uri = "rest/api/latest/issue/10000"
     Method = "POST"
     InFile = "c:\temp\20001231_Connection.log"
     Credential = $cred
@@ -125,7 +125,7 @@ Executes a POST request on the defined URI and uploads the InFile with a multipa
 
 ```powershell
 $parameter = @{
-    URI = "$(Get-JiraConfigServer)/rest/api/latest/project"
+    URI = "rest/api/latest/project"
     Method = "GET"
     OutFile = "c:\temp\jira_projects.json"
     Credential = $cred
@@ -139,7 +139,7 @@ Executes a GET request on all available projects and stores the response json in
 
 ```powershell
 $parameter = @{
-    URI = "$(Get-JiraConfigServer)/rest/api/latest/project"
+    URI = "rest/api/latest/project"
     Method = "GET"
     Headers = @{"Accept" = "text/plain"}
     OutFile = "c:\temp\jira_projects.json"
@@ -156,9 +156,11 @@ It also uses the Headers to define what mimeTypes are expected in the response.
 ### -URI
 
 URI address of the REST API endpoint.
+Could be relative or absolute URL.
+Keep in mind that mostly you should use relative path (ex. rest/api) and seek to avoid use absolute path (ex. /rest/api).
 
 ```yaml
-Type: Uri
+Type: Uri, string
 Parameter Sets: (All)
 Aliases:
 

--- a/docs/en-US/commands/Move-JiraVersion.md
+++ b/docs/en-US/commands/Move-JiraVersion.md
@@ -18,13 +18,13 @@ Moves an existing Version in JIRA
 ### ByAfter (Default)
 
 ```powershell
-Move-JiraVersion [-Version] <JiraPS.Version> [-After] <JiraPS.Version> [[-Credential] <PSCredential>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Move-JiraVersion [-Version] <JiraPS.Version> [-After] <JiraPS.Version> [[-Session] <PSObject>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByPosition
 
 ```powershell
-Move-JiraVersion [-Version] <JiraPS.Version> [-Position] <String> [[-Credential] <PSCredential>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Move-JiraVersion [-Version] <JiraPS.Version> [-Position] <String> [[-Session] <PSObject>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -109,15 +109,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: 3
@@ -137,7 +138,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/New-JiraFilter.md
+++ b/docs/en-US/commands/New-JiraFilter.md
@@ -16,7 +16,7 @@ Create a new Jira filter.
 ## SYNTAX
 
 ```powershell
-New-JiraFilter -Name <String> [-Description <String>] -JQL <String> [-Favorite] [-Credential <PSCredential>]
+New-JiraFilter -Name <String> [-Description <String>] -JQL <String> [-Favorite] [-Session <PSObject>]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -124,15 +124,16 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: 2
@@ -189,7 +190,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/New-JiraGroup.md
+++ b/docs/en-US/commands/New-JiraGroup.md
@@ -16,7 +16,7 @@ Creates a new group in JIRA
 ## SYNTAX
 
 ```powershell
-New-JiraGroup [-GroupName] <String[]> [[-Credential] <PSCredential>] [-WhatIf] [-Confirm] [<CommonParameters>]
+New-JiraGroup [-GroupName] <String[]> [[-Session] <PSObject>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -51,15 +51,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: 2
@@ -116,7 +117,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/New-JiraIssue.md
+++ b/docs/en-US/commands/New-JiraIssue.md
@@ -18,7 +18,7 @@ Creates a new issue in JIRA
 ```powershell
 New-JiraIssue [-Project] <String> [-IssueType] <String> [-Summary] <String> [[-Priority] <Int32>]
  [[-Description] <String>] [[-Reporter] <String>] [[-Labels] <String[]>] [[-Parent] <String>]
- [[-FixVersion] <String[]>] [[-Fields] <PSCustomObject>] [[-Credential] <PSCredential>] [-WhatIf] [-Confirm]
+ [[-FixVersion] <String[]>] [[-Fields] <PSCustomObject>] [[-Session] <PSObject>] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
@@ -258,15 +258,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: 11
@@ -321,7 +322,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/New-JiraSession.md
+++ b/docs/en-US/commands/New-JiraSession.md
@@ -16,7 +16,7 @@ Creates a persistent JIRA authenticated session which can be used by other JiraP
 ## SYNTAX
 
 ```powershell
-New-JiraSession [-Credential] <PSCredential> [[-Headers] <Hashtable>] [<CommonParameters>]
+New-JiraSession [-Credential] <PSCredential> [[-Headers] <Hashtable>] [[-SessionName] <String>] [[-ServerName] <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -71,6 +71,38 @@ Aliases:
 Required: False
 Position: 2
 Default value: @{}
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SessionName
+
+Name of an instance of session
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: Default
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ServerName
+
+Name of server's configuration that should be used by session
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: Default
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/en-US/commands/New-JiraUser.md
+++ b/docs/en-US/commands/New-JiraUser.md
@@ -17,7 +17,7 @@ Creates a new user in JIRA
 
 ```powershell
 New-JiraUser [-UserName] <String> [-EmailAddress] <String> [[-DisplayName] <String>] [[-Notify] <Boolean>]
- [[-Credential] <PSCredential>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-Session] <PSObject>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -114,15 +114,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: 5
@@ -177,7 +178,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/New-JiraVersion.md
+++ b/docs/en-US/commands/New-JiraVersion.md
@@ -18,14 +18,14 @@ Creates a new FixVersion in JIRA
 ### byObject (Default)
 
 ```powershell
-New-JiraVersion [-InputObject] <Object> [-Credential <PSCredential>] [-WhatIf] [-Confirm] [<CommonParameters>]
+New-JiraVersion [-InputObject] <Object> [-Session <PSObject>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### byParameters
 
 ```powershell
 New-JiraVersion [-Name] <String> [-Project] <Object> [-Description <String>] [-Archived <Boolean>]
- [-Released <Boolean>] [-ReleaseDate <DateTime>] [-StartDate <DateTime>] [-Credential <PSCredential>] [-WhatIf]
+ [-Released <Boolean>] [-ReleaseDate <DateTime>] [-StartDate <DateTime>] [-Session <PSObject>] [-WhatIf]
  [-Confirm] [<CommonParameters>]
 ```
 
@@ -192,15 +192,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: Named
@@ -255,7 +256,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Remove-JiraFilter.md
+++ b/docs/en-US/commands/Remove-JiraFilter.md
@@ -118,15 +118,16 @@ Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: 2
@@ -184,8 +185,7 @@ For more information, see about_CommonParameters
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or
-a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Remove-JiraFilterPermission.md
+++ b/docs/en-US/commands/Remove-JiraFilterPermission.md
@@ -18,7 +18,7 @@ Remove a permission of a Filter
 ### ByFilterId (Default)
 
 ```powershell
-Remove-JiraFilterPermission [-Filter] <JiraPS.Filter> [[-Credential] <PSCredential>]
+Remove-JiraFilterPermission [-Filter] <JiraPS.Filter> [[-Session] <PSObject>]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -26,7 +26,7 @@ Remove-JiraFilterPermission [-Filter] <JiraPS.Filter> [[-Credential] <PSCredenti
 
 ```powershell
 Remove-JiraFilterPermission [-FilterId] <UInt32> [-PermissionId] <UInt32[]>
- [[-Credential] <PSCredential>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-Session] <PSObject>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -101,15 +101,16 @@ Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: 1
@@ -169,8 +170,7 @@ For more information, see about_CommonParameters
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or
-a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Remove-JiraGroup.md
+++ b/docs/en-US/commands/Remove-JiraGroup.md
@@ -16,7 +16,7 @@ Removes an existing group from JIRA
 ## SYNTAX
 
 ```powershell
-Remove-JiraGroup [-Group] <Object[]> [[-Credential] <PSCredential>] [-Force] [-WhatIf] [-Confirm]
+Remove-JiraGroup [-Group] <Object[]> [[-Session] <PSObject>] [-Force] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
@@ -54,15 +54,16 @@ Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: 2
@@ -133,7 +134,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Remove-JiraGroupMember.md
+++ b/docs/en-US/commands/Remove-JiraGroupMember.md
@@ -16,7 +16,7 @@ Removes a user from a JIRA group
 ## SYNTAX
 
 ```powershell
-Remove-JiraGroupMember [-Group] <Object[]> [-User] <Object[]> [[-Credential] <PSCredential>] [-PassThru]
+Remove-JiraGroupMember [-Group] <Object[]> [-User] <Object[]> [[-Session] <PSObject>] [-PassThru]
  [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -76,15 +76,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: 3
@@ -186,7 +187,7 @@ This REST method is still marked Experimental in JIRA's REST API.
 That means that there is a high probability this will break in future versions of JIRA.
 The function will need to be re-written at that time.
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Remove-JiraIssue.md
+++ b/docs/en-US/commands/Remove-JiraIssue.md
@@ -19,14 +19,14 @@ Removes an existing issue from JIRA.
 ### ByInputObject (Default)
 
 ```powershell
-Remove-JiraIssue [-InputObject] <Object[]> [-IncludeSubTasks] [[-Credential] <PSCredential>] [-Force] [-WhatIf]
+Remove-JiraIssue [-InputObject] <Object[]> [-IncludeSubTasks] [[-Session] <PSObject>] [-Force] [-WhatIf]
  [-Confirm] [<CommonParameters>]
 ```
 
 ### ByIssueId 
 
 ```powershell
-Remove-JiraIssue [-IssueId] <String[]> [-IncludeSubTasks] [[-Credential] <PSCredential>] [-Force] [-WhatIf]
+Remove-JiraIssue [-IssueId] <String[]> [-IncludeSubTasks] [[-Session] <PSObject>] [-Force] [-WhatIf]
  [-Confirm] [<CommonParameters>]
 ```
 
@@ -120,14 +120,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: 2
@@ -202,7 +204,8 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 If the issue has subtasks you must include the parameter IncludeSubTasks to delete the issue. You cannot delete an issue without its subtasks also being deleted.
 
-This function requires either the \`-Credential\` parameter to be passed or a persistent JIRA session.
-See \`New-JiraSession\` for more details.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
+See `New-JiraSession` for more details.
+If neither are supplied, this function will run with anonymous access to JIRA.
 
 ## RELATED LINKS

--- a/docs/en-US/commands/Remove-JiraIssueAttachment.md
+++ b/docs/en-US/commands/Remove-JiraIssueAttachment.md
@@ -18,14 +18,14 @@ Removes an attachment from a JIRA issue
 ### byId (Default)
 
 ```powershell
-Remove-JiraIssueAttachment [-AttachmentId] <Int32[]> [-Credential <PSCredential>] [-Force] [-WhatIf] [-Confirm]
+Remove-JiraIssueAttachment [-AttachmentId] <Int32[]> [-Session <PSObject>] [-Force] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
 ### byIssue
 
 ```powershell
-Remove-JiraIssueAttachment [-Issue] <Object> [-FileName <String[]>] [-Credential <PSCredential>] [-Force]
+Remove-JiraIssueAttachment [-Issue] <Object> [-FileName <String[]>] [-Session <PSObject>] [-Force]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -111,15 +111,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: Named
@@ -190,7 +191,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Remove-JiraIssueLink.md
+++ b/docs/en-US/commands/Remove-JiraIssueLink.md
@@ -16,7 +16,7 @@ Removes a issue link from a JIRA issue
 ## SYNTAX
 
 ```powershell
-Remove-JiraIssueLink [-IssueLink] <Object[]> [[-Credential] <PSCredential>] [-WhatIf] [-Confirm]
+Remove-JiraIssueLink [-IssueLink] <Object[]> [[-Session] <PSObject>] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
@@ -62,15 +62,16 @@ Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: 2
@@ -125,7 +126,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Remove-JiraIssueWatcher.md
+++ b/docs/en-US/commands/Remove-JiraIssueWatcher.md
@@ -16,7 +16,7 @@ Removes a watcher from an existing JIRA issue
 ## SYNTAX
 
 ```powershell
-Remove-JiraIssueWatcher [-Watcher] <String[]> [-Issue] <Object> [[-Credential] <PSCredential>] [-WhatIf]
+Remove-JiraIssueWatcher [-Watcher] <String[]> [-Issue] <Object> [[-Session] <PSObject>] [-WhatIf]
  [-Confirm] [<CommonParameters>]
 ```
 
@@ -88,15 +88,16 @@ Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: 3
@@ -151,7 +152,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Remove-JiraRemoteLink.md
+++ b/docs/en-US/commands/Remove-JiraRemoteLink.md
@@ -16,7 +16,7 @@ Removes a remote link from a JIRA issue
 ## SYNTAX
 
 ```powershell
-Remove-JiraRemoteLink [-Issue] <Object[]> [-LinkId] <Int32[]> [[-Credential] <PSCredential>] [-Force] [-WhatIf]
+Remove-JiraRemoteLink [-Issue] <Object[]> [-LinkId] <Int32[]> [[-Session] <PSObject>] [-Force] [-WhatIf]
  [-Confirm] [<CommonParameters>]
 ```
 
@@ -78,15 +78,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: 3
@@ -157,7 +158,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Remove-JiraSession.md
+++ b/docs/en-US/commands/Remove-JiraSession.md
@@ -85,9 +85,8 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
-If neither are supplied, this function will run with anonymous access to JIRA.
 
 ## RELATED LINKS
 

--- a/docs/en-US/commands/Remove-JiraUser.md
+++ b/docs/en-US/commands/Remove-JiraUser.md
@@ -16,7 +16,7 @@ Removes an existing user from JIRA
 ## SYNTAX
 
 ```powershell
-Remove-JiraUser [-User] <Object[]> [[-Credential] <PSCredential>] [-Force] [-WhatIf] [-Confirm]
+Remove-JiraUser [-User] <Object[]> [[-Session] <PSObject>] [-Force] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
@@ -56,15 +56,16 @@ Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: 2
@@ -135,7 +136,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Remove-JiraVersion.md
+++ b/docs/en-US/commands/Remove-JiraVersion.md
@@ -16,7 +16,7 @@ This function removes an existing version.
 ## SYNTAX
 
 ```powershell
-Remove-JiraVersion [-Version] <Object[]> [[-Credential] <PSCredential>] [-Force] [-WhatIf] [-Confirm]
+Remove-JiraVersion [-Version] <Object[]> [[-Session] <PSObject>] [-Force] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
@@ -60,15 +60,16 @@ Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: 2
@@ -139,7 +140,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Set-JiraConfigServer.md
+++ b/docs/en-US/commands/Set-JiraConfigServer.md
@@ -17,7 +17,7 @@ Defines the configured URL for the JIRA server
 ## SYNTAX
 
 ```powershell
-Set-JiraConfigServer [-Server] <Uri> [<CommonParameters>]
+Set-JiraConfigServer [-Server] <Uri> [[-Name] <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -48,6 +48,22 @@ Aliases: Uri
 Required: True
 Position: 1
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Name
+
+The name of the Jira instance
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: "Default"
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/en-US/commands/Set-JiraFilter.md
+++ b/docs/en-US/commands/Set-JiraFilter.md
@@ -17,7 +17,7 @@ Make changes to an existing Filter.
 
 ```powershell
 Set-JiraFilter [-InputObject] <Object> [[-Name] <String>] [[-Description] <String>] [[-JQL] <String>]
- [-Favorite] [[-Credential] <PSCredential>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Favorite] [[-Session] <PSObject>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -148,15 +148,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: 2
@@ -213,7 +214,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Set-JiraIssue.md
+++ b/docs/en-US/commands/Set-JiraIssue.md
@@ -18,7 +18,7 @@ Modifies an existing issue in JIRA
 ```powershell
 Set-JiraIssue [-Issue] <Object[]> [[-Summary] <String>] [[-Description] <String>] [[-FixVersion] <String[]>]
  [[-Assignee] <Object>] [[-Label] <String[]>] [[-Fields] <PSCustomObject>] [[-AddComment] <String>]
- [[-Credential] <PSCredential>] [-SkipNotification] [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-Session] <PSObject>] [-SkipNotification] [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -231,15 +231,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: 9
@@ -332,7 +333,7 @@ Otherwise, this function does not provide output.
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Set-JiraIssueLabel.md
+++ b/docs/en-US/commands/Set-JiraIssueLabel.md
@@ -18,21 +18,21 @@ Modifies labels on an existing JIRA issue
 ### ReplaceLabels (Default)
 
 ```powershell
-Set-JiraIssueLabel [-Issue] <Object[]> -Set <String[]> [-Credential <PSCredential>] [-PassThru] [-WhatIf]
+Set-JiraIssueLabel [-Issue] <Object[]> -Set <String[]> [-Session <PSObject>] [-PassThru] [-WhatIf]
  [-Confirm] [<CommonParameters>]
 ```
 
 ### ModifyLabels
 
 ```powershell
-Set-JiraIssueLabel [-Issue] <Object[]> [-Add <String[]>] [-Remove <String[]>] [-Credential <PSCredential>]
+Set-JiraIssueLabel [-Issue] <Object[]> [-Add <String[]>] [-Remove <String[]>] [-Session <PSObject>]
  [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ClearLabels
 
 ```powershell
-Set-JiraIssueLabel [-Issue] <Object[]> [-Clear] [-Credential <PSCredential>] [-PassThru] [-WhatIf] [-Confirm]
+Set-JiraIssueLabel [-Issue] <Object[]> [-Clear] [-Session <PSObject>] [-PassThru] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
@@ -159,15 +159,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: Named
@@ -243,7 +244,7 @@ to the JIRA issue modified.  Otherwise, this function does not provide output.
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Set-JiraUser.md
+++ b/docs/en-US/commands/Set-JiraUser.md
@@ -7,6 +7,7 @@ schema: 2.0.0
 layout: documentation
 permalink: /docs/JiraPS/commands/Set-JiraUser/
 ---
+
 # Set-JiraUser
 
 ## SYNOPSIS
@@ -20,6 +21,7 @@ Modifies user properties in JIRA
 ```powershell
 Set-JiraUser [-User] <Object[]> [-DisplayName <String>] [-EmailAddress <String>] [[-Active] <Boolean>]
  [-Session <PSObject>] [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
 
 ### ByHashtable
 
@@ -216,7 +218,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ### [JiraPS.User]
 
 If the `-PassThru` parameter is provided, this function will provide a reference
-to the JIRA user modified.  Otherwise, this function does not provide output.
+to the JIRA user modified. Otherwise, this function does not provide output.
 
 ## NOTES
 

--- a/docs/en-US/commands/Set-JiraUser.md
+++ b/docs/en-US/commands/Set-JiraUser.md
@@ -18,14 +18,14 @@ Modifies user properties in JIRA
 ### ByNamedParameters (Default)
 
 ```powershell
-Set-JiraUser [-User] <Object[]> [-DisplayName <String>] [-EmailAddress <String>] [-Credential <PSCredential>]
+Set-JiraUser [-User] <Object[]> [-DisplayName <String>] [-EmailAddress <String>] [-Session <PSObject>]
  [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByHashtable
 
 ```powershell
-Set-JiraUser [-User] <Object[]> [-Property] <Hashtable> [-Credential <PSCredential>] [-PassThru] [-WhatIf]
+Set-JiraUser [-User] <Object[]> [-Property] <Hashtable> [-Session <PSObject>] [-PassThru] [-WhatIf]
  [-Confirm] [<CommonParameters>]
 ```
 
@@ -120,15 +120,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: Named
@@ -209,7 +210,7 @@ JIRA does not currently provide this ability via their REST API.
 
 > If you'd like to see this ability added to JIRA and to this module, please vote on Atlassian's site for this issue: [https://jira.atlassian.com/browse/JRA-37294](https://jira.atlassian.com/browse/JRA-37294)
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 

--- a/docs/en-US/commands/Set-JiraVersion.md
+++ b/docs/en-US/commands/Set-JiraVersion.md
@@ -18,7 +18,7 @@ Modifies an existing Version in JIRA
 ```powershell
 Set-JiraVersion [-Version] <Object[]> [[-Name] <String>] [[-Description] <String>] [[-Archived] <Boolean>]
  [[-Released] <Boolean>] [[-ReleaseDate] <DateTime>] [[-StartDate] <DateTime>] [[-Project] <Object>]
- [[-Credential] <PSCredential>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-Session] <PSObject>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -175,15 +175,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Credential
+### -Session
 
-Credentials to use to connect to JIRA.  
-If not specified, this function will use anonymous access.
+Session to use to connect to JIRA.  
+If not specified, this function will use default session.
+The name of a session, PSCredential object or session's instance itself is accepted to pass as value for the parameter.
 
 ```yaml
-Type: PSCredential
+Type: psobject
 Parameter Sets: (All)
-Aliases:
+Aliases: Credential
 
 Required: False
 Position: 9
@@ -240,7 +241,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## NOTES
 
-This function requires either the `-Credential` parameter to be passed or a persistent JIRA session.
+This function requires either the `-Session` parameter to be passed or a persistent JIRA session.
 See `New-JiraSession` for more details.
 If neither are supplied, this function will run with anonymous access to JIRA.
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 -->
<!-- markdownlint-disable MD041 -->
<!-- Provide a general summary of your changes in the Title above -->
A pull request that fixes an issue #45
### Description
This pull request allow to use few sessions to Jira server in same time.
For ex.:
```
Get-Issue -Key "AA-0000" -Session $sessionA
Get-Issue -Key "AA-0000" -Session $sessionB
Get-Issue -Key "AA-0000" -Session "SessionNameA"
Get-Issue -Key "AA-0000" -Session "SessionNameB"
```

### Motivation and Context
There is project exists that I work for.
The project requires to write a scripts that fetch information from one Jira server and create an issue on other Jira server.
Current version of JiraPS does not allow such behaviors without call to Set-JiraConfigServer.
Therefore, the pull request allow to skip a switching Jira server between cmdlets calls.

### Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have added Pester Tests that describe what my changes should do.
- [ ] I have updated the documentation accordingly.
