### PR TITLE
Speedup Invoke-WebRequests by disabling progress indicator.

### DIFF
--- a/JiraPS/Public/Invoke-JiraMethod.ps1
+++ b/JiraPS/Public/Invoke-JiraMethod.ps1
@@ -152,6 +152,11 @@ function Invoke-JiraMethod {
         #endregion Constructe IWR Parameter
 
         #region Execute the actual query
+        # Normal ProgressPreference really slows down invoke-webrequest as it tries to update the screen for bytes received.
+        # By setting ProgressPreference to silentlyContinue it doesn't try to update the screen and speeds up the downloads.
+        # See https://stackoverflow.com/a/43477248/2641196
+        $oldProgressPreference = $progressPreference
+        $progressPreference = 'silentlyContinue'
         try {
             Write-Verbose "[$($MyInvocation.MyCommand.Name)] $($splatParameters.Method) $($splatParameters.Uri)"
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoke-WebRequest with `$splatParameters: $($splatParameters | Out-String)"
@@ -164,6 +169,8 @@ function Invoke-JiraMethod {
             $exception = $_
             $webResponse = $exception.Exception.Response
         }
+        # Reset the progressPreference to the value it was before the Invoke-WebRequest
+        $progressPreference = $oldProgressPreference
 
         Write-Debug "[$($MyInvocation.MyCommand.Name)] Executed WebRequest. Access `$webResponse to see details"
         Test-ServerResponse -InputObject $webResponse -Cmdlet $Cmdlet


### PR DESCRIPTION
<!-- markdownlint-disable MD002 -->
<!-- markdownlint-disable MD041 -->
<!-- Provide a general summary of your changes in the Title above -->

### Description

Normal ProgressPreference really slows down invoke-webrequest as it tries to update the screen for bytes received.
By setting ProgressPreference to silentlyContinue it doesn't try to update the screen and speeds up the downloads.
See https://stackoverflow.com/a/43477248/2641196

### Motivation and Context

This change make a reasonable difference to the speed of accessing Jira systems with large numbers of fields, or for methods that make large number of calls.
This improves, but does not entirely resolve #362 

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

- [x] My code follows the code style of this project.
- [ ] I have added Pester Tests that describe what my changes should do.
- [ ] I have updated the documentation accordingly.
