### PR TITLE
Add ComponentId as additional parameter in New-JiraIssue

### DIFF
--- a/JiraPS/Public/New-JiraIssue.ps1
+++ b/JiraPS/Public/New-JiraIssue.ps1
@@ -42,6 +42,11 @@ function New-JiraIssue {
         $FixVersion,
 
         [Parameter( ValueFromPipelineByPropertyName )]
+        [String[]]
+        $ComponentId,
+
+
+        [Parameter( ValueFromPipelineByPropertyName )]
         [PSCustomObject]
         $Fields,
 
@@ -116,6 +121,13 @@ function New-JiraIssue {
             foreach ($item in $FixVersion) {
                 $null = $requestBody["fixVersions"].Add( @{ name = "$item" } )
             }
+        }
+
+        if ($ComponentId) {
+            $requestBody['components'] = [System.Collections.ArrayList]@()
+            foreach ($id in $ComponentId) {
+                $null = $requestBody["components"].Add(@{ "id" = "$id"} )
+            }           
         }
 
         Write-Debug "[$($MyInvocation.MyCommand.Name)] Resolving `$Fields"


### PR DESCRIPTION
ComponentId takes an array of strings filling the fields "components" with the ID while creating a new JIRA issue.