### PR TITLE
Added Resolution Parameter to Invoke-JiraIssueTransition

### DIFF
--- a/JiraPS/Private/ConvertTo-JiraResolution.ps1
+++ b/JiraPS/Private/ConvertTo-JiraResolution.ps1
@@ -1,0 +1,29 @@
+function ConvertTo-JiraResolution {
+    [CmdletBinding()]
+    param(
+        [Parameter( ValueFromPipeline )]
+        [PSObject[]]
+        $InputObject
+    )
+
+    process {
+        foreach ($i in $InputObject) {
+            Write-Debug "[$($MyInvocation.MyCommand.Name)] Converting `$InputObject to custom object"
+
+            $props = @{
+                'ID'          = $i.id
+                'Name'        = $i.name
+                'RestUrl'     = $i.self
+                'Description' = $i.description
+            }
+
+            $result = New-Object -TypeName PSObject -Property $props
+            $result.PSObject.TypeNames.Insert(0, 'JiraPS.Resolution')
+            $result | Add-Member -MemberType ScriptMethod -Name "ToString" -Force -Value {
+                Write-Output "$($this.Name)"
+            }
+
+            Write-Output $result
+        }
+    }
+}

--- a/JiraPS/Public/Get-JiraResolution.ps1
+++ b/JiraPS/Public/Get-JiraResolution.ps1
@@ -1,0 +1,38 @@
+function Get-JiraResolution {
+    # .ExternalHelp ..\JiraPS-help.xml
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
+    )
+
+    begin {
+        Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
+
+        $server = Get-JiraConfigServer -ErrorAction Stop
+
+        $resourceURi = "$server/rest/api/2/resolution"
+    }
+
+    process {
+        Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] ParameterSetName: $($PsCmdlet.ParameterSetName)"
+        Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] PSBoundParameters: $($PSBoundParameters | Out-String)"
+
+        $parameter = @{
+            URI        = $resourceURi
+            Method     = "GET"
+            Credential = $Credential
+        }
+        Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
+        $result = Invoke-JiraMethod @parameter
+
+        Write-Output (ConvertTo-JiraResolution -InputObject $result)
+
+    }
+
+    end {
+        Write-Verbose "[$($MyInvocation.MyCommand.Name)] Complete"
+    }
+}


### PR DESCRIPTION
I needed the possibility to also set the solution

<!-- markdownlint-disable MD002 -->
<!-- markdownlint-disable MD041 -->
<!-- Provide a general summary of your changes in the Title above -->

### Description

Added the parameter Resolution to Invoke-JiraIssueTransition. Additional added the function Get-JiraResolution and ConvertTo-JiraResolution.

### Motivation and Context

Needed to set the Resolution during transition and find it more clean to add the proper function

### Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have added Pester Tests that describe what my changes should do.
- [ ] I have updated the documentation accordingly.
