### PR TITLE
Add-JiraRemoteLink Allows Adding Remote Links

### DIFF
--- a/JiraPS/Private/ConvertFrom-JiraLink.ps1
+++ b/JiraPS/Private/ConvertFrom-JiraLink.ps1
@@ -1,0 +1,95 @@
+function ConvertFrom-JiraLink {
+    [CmdletBinding()]
+    param(
+        [Parameter( ValueFromPipeline )]
+        [PSObject[]]
+        $InputObject
+    )
+
+    process {
+        foreach ($i in $InputObject) {
+            Write-Debug "[$($MyInvocation.MyCommand.Name)] Converting `$InputObject to custom object"
+
+            $props = @{}
+            if ($i.Id) {
+                $props.Add('id', $i.Id)
+            }
+            if ($i.RestUrl) {
+                $props.Add('self', $i.RestUrl)
+            }
+
+            if ($i.globalId) {
+                $props.globalId = $i.globalId
+            }
+
+            if ($i.application -and ($i.application.type -or $i.application.name) ) {
+                $props.application = New-Object PSObject -Prop @{
+                    type = $i.application.type
+                    name = $i.application.name
+                }
+            }
+
+            if ($i.relationship) {
+                $props.relationship = $i.relationship
+            }
+
+            if ($i.object) {
+                if ($i.object.icon -and ($i.object.icon.title -or $i.object.icon.url16x16)) {
+                    $icon = New-Object PSObject -Prop @{
+                        url16x16 = $i.object.icon.url16x16
+                    }
+                    if ( $i.object.icon.title ) {
+                        $icon = $icon | Add-Member -MemberType NoteProperty -Name "title" -Value $i.object.icon.title -PassThru
+                    }
+                }
+                else { $icon = $null }
+
+                if ($i.object.status.icon -and ($i.object.status.icon.link -or $i.object.status.icon.title -or $i.object.status.icon.url16x16)) {
+                    $statusIcon = New-Object PSObject
+                    if ( $i.object.status.icon.title ) {
+                        $statusIcon = $statusIcon | Add-Member -MemberType NoteProperty -Name "title" -Value $i.object.status.icon.title -PassThru
+                    }
+                    if ( $i.object.status.icon.link ) {
+                        $statusIcon = $statusIcon | Add-Member -MemberType NoteProperty -Name "link" -Value $i.object.status.icon.link -PassThru
+                    }
+                    if ( $i.object.status.icon.url16x16 ) {
+                        $statusIcon = $statusIcon | Add-Member -MemberType NoteProperty -Name "url16x16" -Value $i.object.status.icon.url16x16 -PassThru
+                    }
+                }
+                else { $statusIcon = $null }
+
+                if ($i.object.status -and ($i.object.status.resolved -or $statusIcon)) {
+                    $status = New-Object PSObject -Prop @{
+                        resolved = $i.object.status.resolved
+                        icon     = $statusIcon
+                    }
+                }
+                else { $status = $null }
+
+                $props.object = New-Object PSObject -Prop @{
+                    url     = $i.object.url
+                }
+                if ( $icon ) {
+                    $props.object = $props.object | Add-Member -MemberType NoteProperty -Name "icon" -Value $icon -PassThru
+                }
+                if ( $status ) {
+                    $props.object = $props.object | Add-Member -MemberType NoteProperty -Name "status" -Value $status -PassThru
+                }
+                if ( $i.object.title ) {
+                    $props.object = $props.object | Add-Member -MemberType NoteProperty -Name "title" -Value $i.object.title -PassThru
+                }
+                if ( $i.object.summary ) {
+                    $props.object = $props.object | Add-Member -MemberType NoteProperty -Name "summary" -Value $i.object.summary -PassThru
+                }
+            }
+
+            $result = New-Object -TypeName PSObject -Property $props
+            $result.PSObject.TypeNames.Insert(0, 'JiraPS.Link')
+            $result | Add-Member -MemberType ScriptMethod -Name "ToString" -Force -Value {
+                Write-Output "$($this.Id)"
+            }
+
+            Write-Output $result
+        }
+    }
+}

--- a/JiraPS/Public/Add-JiraRemoteLink.ps1
+++ b/JiraPS/Public/Add-JiraRemoteLink.ps1
@@ -1,0 +1,105 @@
+function Add-JiraRemoteLink {
+# .ExternalHelp ..\JiraPS-help.xml
+    [CmdletBinding( SupportsShouldProcess )]
+    param(
+        [Parameter( Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName )]
+        [ValidateNotNullOrEmpty()]
+        [ValidateScript(
+            {
+                if (("JiraPS.Issue" -notin $_.PSObject.TypeNames) -and (($_ -isnot [String]))) {
+                    $exception = ([System.ArgumentException]"Invalid Type for Parameter") #fix code highlighting]
+                    $errorId = 'ParameterType.NotJiraIssue'
+                    $errorCategory = 'InvalidArgument'
+                    $errorTarget = $_
+                    $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
+                    $errorItem.ErrorDetails = "Wrong object type provided for Issue. Expected [JiraPS.Issue] or [String], but was $($_.GetType().Name)"
+                    $PSCmdlet.ThrowTerminatingError($errorItem)
+                    <#
+                      #ToDo:CustomClass
+                      Once we have custom classes, this check can be done with Type declaration
+                    #>
+                }
+                else {
+                    return $true
+                }
+            }
+        )]
+        [Alias('Key')]
+        [Object[]]
+        $Issue,
+
+        [Parameter( Mandatory )]
+        [ValidateScript(
+            {
+                $objectProperties = Get-Member -InputObject $_ -MemberType *Property
+                if (-not(
+                        ($objectProperties.Name -contains "url") -and
+                        ($objectProperties.Name -contains "title")
+                    )) {
+                    $exception = ([System.ArgumentException]"Invalid Parameter") #fix code highlighting]
+                    $errorId = 'ParameterProperties.Incomplete'
+                    $errorCategory = 'InvalidArgument'
+                    $errorTarget = $_
+                    $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
+                    $errorItem.ErrorDetails = "The RemoteLink provided does not contain the information needed."
+                    $PSCmdlet.ThrowTerminatingError($errorItem)
+                    <#
+                      #ToDo:CustomClass
+                      Once we have custom classes, this check can be done with Type declaration
+                    #>
+                }
+                else {
+                    return $true
+                }
+            }
+        )]
+        [Object[]]
+        $RemoteLink,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
+    )
+
+	begin {
+        Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
+    }
+	
+
+    process {
+        Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] ParameterSetName: $($PsCmdlet.ParameterSetName)"
+        Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] PSBoundParameters: $($PSBoundParameters | Out-String)"
+
+        foreach ($_issue in $Issue) {
+            # Find the proper object for the Issue
+            $issueObj = Resolve-JiraIssueObject -InputObject $_issue -Credential $Credential
+
+            foreach ($_remoteLink in $RemoteLink) {
+
+                $body = @{
+					object = @{
+						url   = $_remoteLink.url
+						title = $_remoteLink.title
+					}
+                }
+				
+				$parameter = @{
+					URI        = "{0}/remotelink" -f $issueObj.RestUrl
+					Method     = "POST"
+					Body       = ConvertTo-Json -InputObject $body
+					Credential = $Credential
+				}
+			
+                Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
+                if ($PSCmdlet.ShouldProcess($issueObj.Key)) {
+                    Invoke-JiraMethod @parameter
+                }
+            }
+        }
+    }
+
+    end {
+        Write-Verbose "[$($MyInvocation.MyCommand.Name)] Complete"
+    }
+}


### PR DESCRIPTION
Picket the "patch zip" from #375 and created a extended version and a pull request.

### Description

This adds the Add-JiraRemoteLink function from #375 in a massive extended version. Due the original one only allowed url and txt attribute, I used the format defined by Get-JiraRemoteLink. For that I also created a ConvertFrom-JiraLink as counterpart to the existing ConvertTo-JiraLink.

### Motivation and Context

I do not understand why there was a format change of the incoming JSON, as done in Get-JiraRemoteLink, in this case useful anyway but that's an other discussion and I wanted the change to be compatible to the existing stuff as possible.

As the previous discussed original, this only allows adding additional remote links, which is also reflected in the naming of the function. For that the function verifies that there is no Id or RestUrl in the object, because that would only make sense for updating existing remote links and could confuse the user of this function.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

- [ ] My code follows the code style of this project.
- [ ] I have added Pester Tests that describe what my changes should do.
- [ ] I have updated the documentation accordingly.
