### PR TITLE
Modify Add-JiraGroupMember so that it honors ErrorAction

### DIFF
--- a/JiraPS/Public/Add-JiraGroupMember.ps1
+++ b/JiraPS/Public/Add-JiraGroupMember.ps1
@@ -73,10 +73,10 @@ function Add-JiraGroupMember {
                 else {
                     $errorMessage = @{
                         Category         = "ResourceExists"
-                        CategoryActivity = "Adding [$user] to [$_group]"
+                        ErrorId          = "Adding [$user] to [$_group]"
                         Message          = "User [$user] is already a member of group [$_group]"
                     }
-                    Write-Error @errorMessage
+                    WriteError @errorMessage
                 }
             }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 -->
<!-- markdownlint-disable MD041 -->
<!-- Provide a general summary of your changes in the Title above -->

### Description

In Add-JiraGroupMember.Unit.Tests.ps1, these two tests require the `Add-JiraGroupMember` to handle the supplied ErrorAction parameter:
* "Tests to see if a provided user is currently a member of the provided JIRA group before attempting to add them"
* "Gracefully handles cases where a provided user is already in the provided group"

I switched the `Write-Error` to `WriteError` and adjusted the splat parameter to supply the necessary parameters

### Motivation and Context

This change is necessary to enable the tests to pass.
closes #425

### Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have added Pester Tests that describe what my changes should do.
- [ ] I have updated the documentation accordingly.
