### PR TITLE
Made Credential param optional to allow for bearer token authentication

### DIFF
--- a/JiraPS/Public/New-JiraSession.ps1
+++ b/JiraPS/Public/New-JiraSession.ps1
@@ -3,7 +3,7 @@ function New-JiraSession {
     [CmdletBinding()]
     [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseShouldProcessForStateChangingFunctions', '')]
     param(
-        [Parameter( Mandatory )]
+        [Parameter( )]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
         $Credential,
@@ -29,8 +29,8 @@ function New-JiraSession {
             Method       = "GET"
             Headers      = $Headers
             StoreSession = $true
-            Credential   = $Credential
         }
+        if ($Credential) { $parameter.Add('Credential',$Credential) }
         Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
         $result = Invoke-JiraMethod @parameter
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 -->
<!-- markdownlint-disable MD041 -->
<!-- Provide a general summary of your changes in the Title above -->

### Description

Made the Credential parameter mandatory for the New-JiraSession function. If the Credential parameter is passed, add it to the parameter splat to keep existing functionality.

### Motivation and Context

It appears that using Personal Access Tokens (PATs) on Jira Server on-prem is not working as described in the official module documentation. The documentation states that you should be able to pass the email address and PAT into the username and password field respectively. However, this doesn't work in all cases. Removing the mandatory attribute on the Credential parameter for the New-JiraSession function allows us to take advantage of the Header parameter that is already available without the need to pass credentials and use basic authentication. Since the Header parameter is already there and works in New-JiraSession, with this new change we can now pass in custom headers that use the more widely available Bearer token method for authentication to the Jira REST API.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

- [x] My code follows the code style of this project.
- [ ] I have added Pester Tests that describe what my changes should do.
- [ ] I have updated the documentation accordingly.
