### PR TITLE
#408 when metadata reports that a field is required and does not have…

### DIFF
--- a/JiraPS/Public/New-JiraIssue.ps1
+++ b/JiraPS/Public/New-JiraIssue.ps1
@@ -145,13 +145,18 @@ function New-JiraIssue {
                     Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] Required field (id=[$($c.Id)], name=[$($c.Name)]) was provided (value=[$($requestBody.$($c.Id))])"
                 }
                 else {
-                    $exception = ([System.ArgumentException]"Invalid or missing value Parameter")
-                    $errorId = 'ParameterValue.CreateMetaFailure'
-                    $errorCategory = 'InvalidArgument'
-                    $errorTarget = $Fields
-                    $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
-                    $errorItem.ErrorDetails = "Jira's metadata for project [$Project] and issue type [$IssueType] specifies that a field is required that was not provided (name=[$($c.Name)], id=[$($c.Id)]). Use Get-JiraIssueCreateMetadata for more information."
-                    $PSCmdlet.ThrowTerminatingError($errorItem)
+                    if($c.autoCompleteUrl) {
+                        Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] Required field (id=[$($c.Id)], name=[$($c.Name)]) was not provided but it's okay, we'll rely on automCompleteUri $($c.autoCompleteUrl)"
+                    }
+                    else {
+                        $exception = ([System.ArgumentException]"Invalid or missing value Parameter")
+                        $errorId = 'ParameterValue.CreateMetaFailure'
+                        $errorCategory = 'InvalidArgument'
+                        $errorTarget = $Fields
+                        $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
+                        $errorItem.ErrorDetails = "Jira's metadata for project [$Project] and issue type [$IssueType] specifies that a field is required that was not provided (name=[$($c.Name)], id=[$($c.Id)]). Use Get-JiraIssueCreateMetadata for more information."
+                        $PSCmdlet.ThrowTerminatingError($errorItem)
+                    }
                 }
             }
             else {


### PR DESCRIPTION
… a default value we can still ignore when value is not passed if autoCompleteUri is present, e.g. with reporter field

<!-- markdownlint-disable MD002 -->
<!-- markdownlint-disable MD041 -->
<!-- Provide a general summary of your changes in the Title above -->

### Description

<!-- Describe your changes in detail -->

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here as follows: -->
<!-- closes #1, closes #2, ... -->

### Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have added Pester Tests that describe what my changes should do.
- [ ] I have updated the documentation accordingly.
