### PR TITLE
Allow fields to be filtered by id only in Get-JiraField (mainly for use in Set-JiraIssue)

### DIFF
--- a/JiraPS/Public/Get-JiraField.ps1
+++ b/JiraPS/Public/Get-JiraField.ps1
@@ -6,6 +6,14 @@ function Get-JiraField {
         [String[]]
         $Field,
 
+        [Parameter]
+        [Switch]
+        $filterByName,
+
+        [Parameter]
+        [Switch]
+        $filterById,
+
         [Parameter()]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
@@ -43,7 +51,21 @@ function Get-JiraField {
 
                     $allFields = Get-JiraField -Credential $Credential
 
-                    Write-Output ($allFields | Where-Object -FilterScript { ($_.Id -eq $_field) -or ($_.Name -like $_field) })
+                    Write-Output ($allFields | Where-Object -FilterScript {
+                            if (($filterByName -and $filterById) -or (-not $filterByName -and -not $filterById))
+                            {
+                                ($_.Id -eq $_field) -or ($_.Name -like $_field)
+
+                            }
+                            elseif ($filterByName)
+                            {
+                                ($_.Name -like $_field)
+                            }
+                            elseif ($filterById)
+                            {
+                                ($_.Id -eq $_field)
+                            }
+                        })
                 }
             }
         }

--- a/JiraPS/Public/Set-JiraIssue.ps1
+++ b/JiraPS/Public/Set-JiraIssue.ps1
@@ -48,7 +48,7 @@ function Set-JiraIssue {
         $Fields,
 
         #this is to fix case when there are multiple fields of the same name
-        [PSCustomObject]
+        [Switch]
         $filterFieldsById,
 
         [String]

--- a/JiraPS/Public/Set-JiraIssue.ps1
+++ b/JiraPS/Public/Set-JiraIssue.ps1
@@ -47,6 +47,10 @@ function Set-JiraIssue {
         [PSCustomObject]
         $Fields,
 
+        #this is to fix case when there are multiple fields of the same name
+        [PSCustomObject]
+        $filterFieldsById,
+
         [String]
         $AddComment,
 
@@ -162,7 +166,7 @@ function Set-JiraIssue {
                     $name = $_key
                     $value = $Fields.$_key
 
-                    $field = Get-JiraField -Field $name -Credential $Credential -ErrorAction Stop
+                    $field = Get-JiraField -Field $name -Credential $Credential -filterById:$filterFieldsById -ErrorAction Stop
 
                     # For some reason, this was coming through as a hashtable instead of a String,
                     # which was causing ConvertTo-Json to crash later.


### PR DESCRIPTION
<!-- markdownlint-disable MD002 -->
<!-- markdownlint-disable MD041 -->
### Description

This is a fix for a situation I have encountered, where someone created a field with a duplicated name, which then caused Set-JiraIssue to be unable to set a value for previously existing field, since Get-JiraField returned two values, while only one of the fields were present in the issue I was updating, resulting in "Field 'xxx' cannot be set. It is not on the appropriate screen, or unknown." error. Added switches to Get-JiraField and Set-JiraIssue that allow user to call the fields directly by their id's, which allows to bypass this issue.
### Motivation and Context

Fixes issue with updating field value in an issue, in a case when multiple fields of the same name exist, but are not present in this issue.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] My code follows the code style of this project.
- [ ] I have added Pester Tests that describe what my changes should do.
- [ ] I have updated the documentation accordingly.
