### PR TITLE
Enable creation of ApplicationData folder if it doesn't exist yet

### DIFF
--- a/JiraPS/JiraPS.psm1
+++ b/JiraPS/JiraPS.psm1
@@ -23,7 +23,7 @@ if (!("System.Net.Http" -as [Type])) {
 #endregion Dependencies
 
 #region Configuration
-$script:serverConfig = ("{0}/AtlassianPS/JiraPS/server_config" -f [Environment]::GetFolderPath('ApplicationData'))
+$script:serverConfig = ("{0}/AtlassianPS/JiraPS/server_config" -f [Environment]::GetFolderPath('ApplicationData', 'Create'))
 
 if (-not (Test-Path $script:serverConfig)) {
     $null = New-Item -Path $script:serverConfig -ItemType File -Force


### PR DESCRIPTION
<!-- markdownlint-disable MD002 -->
<!-- markdownlint-disable MD041 -->
<!-- Provide a general summary of your changes in the Title above -->

### Description

<!-- Describe your changes in detail -->
This PR allows the .NET runtime to create the ApplicationData folder for us, even if it doesn't exist yet.

### Motivation and Context

This occurs frequently in serverless environments, where variables like `XDG_CONFIG_DIR` may be set to non-standard values.

Not providing this flag to `GetFolderPath` causes it to return an empty string if the folder doesn't exist.

Fixes #512.

### Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have added Pester Tests that describe what my changes should do.
- [ ] I have updated the documentation accordingly.
