### PR TITLE
Add support for Jira 9+ CreateMeta handling

### DIFF
--- a/JiraPS/Private/ConvertTo-JiraCreateMetaField.ps1
+++ b/JiraPS/Private/ConvertTo-JiraCreateMetaField.ps1
@@ -14,95 +14,63 @@ function ConvertTo-JiraCreateMetaField {
             $fieldList = $null
 
             If ($null -ne $i.values) {
-                $fieldList = $i.values
+                $fieldList = $i.values | ForEach-Object {
+                    @{
+                        Name = $_.fieldId
+                        Value = $_
+                    }
+                }
             }
             Elseif ($null -ne $i.projects.issuetypes.fields) {
 
+                $fields = $i.projects.issuetypes.fields
+                $fieldNames = (Get-Member -InputObject $fields -MemberType '*Property').Name
+
+                $fieldList = $fieldNames | ForEach-Object {
+                    @{
+                        Name = $_
+                        Value = $fields.$_
+                    }
+                }
             }
             Else {
                 Write-Error -Exception ([System.ArgumentException]::new("Input data does not match a known CreateMeta payload.", "InputObject"))
             }
 
-            if ($null -ne $i.values) {
+            $FieldList | ForEach-Object {
+                $item = $_.Value
 
-                $i.values | ForEach-Object {
-                    $item = $_
-
-                    $props = @{
-                        'Id'              = $item.fieldId
-                        'Name'            = $item.name
-                        'HasDefaultValue' = [System.Convert]::ToBoolean($item.hasDefaultValue)
-                        'Required'        = [System.Convert]::ToBoolean($item.required)
-                        'Schema'          = $item.schema
-                        'Operations'      = $item.operations
-                    }
-
-                    if ($item.allowedValues) {
-                        $props.AllowedValues = $item.allowedValues
-                    }
-
-                    if ($item.autoCompleteUrl) {
-                        $props.AutoCompleteUrl = $item.autoCompleteUrl
-                    }
-
-                    foreach ($extraProperty in (Get-Member -InputObject $item -MemberType NoteProperty).Name) {
-                        if ($null -eq $props.$extraProperty) {
-                            $props.$extraProperty = $item.$extraProperty
-                        }
-                    }
-
-                    $result = New-Object -TypeName PSObject -Property $props
-                    $result.PSObject.TypeNames.Insert(0, 'JiraPS.CreateMetaField')
-                    $result | Add-Member -MemberType ScriptMethod -Name "ToString" -Force -Value {
-                        Write-Output "$($this.Name)"
-                    }
-
-                    Write-Output $result
+                $props = @{
+                    'Id'              = $_.Name
+                    'Name'            = $item.name
+                    'HasDefaultValue' = [System.Convert]::ToBoolean($item.hasDefaultValue)
+                    'Required'        = [System.Convert]::ToBoolean($item.required)
+                    'Schema'          = $item.schema
+                    'Operations'      = $item.operations
                 }
 
-            }
-            else {
-
-                $fields = $i.projects.issuetypes.fields
-                $fieldNames = (Get-Member -InputObject $fields -MemberType '*Property').Name
-                foreach ($f in $fieldNames) {
-
-
-                    $item = $fields.$f
-
-                    $props = @{
-                        'Id'              = $f
-                        'Name'            = $item.name
-                        'HasDefaultValue' = [System.Convert]::ToBoolean($item.hasDefaultValue)
-                        'Required'        = [System.Convert]::ToBoolean($item.required)
-                        'Schema'          = $item.schema
-                        'Operations'      = $item.operations
-                    }
-
-                    if ($item.allowedValues) {
-                        $props.AllowedValues = $item.allowedValues
-                    }
-
-                    if ($item.autoCompleteUrl) {
-                        $props.AutoCompleteUrl = $item.autoCompleteUrl
-                    }
-
-                    foreach ($extraProperty in (Get-Member -InputObject $item -MemberType NoteProperty).Name) {
-                        if ($null -eq $props.$extraProperty) {
-                            $props.$extraProperty = $item.$extraProperty
-                        }
-                    }
-
-                    $result = New-Object -TypeName PSObject -Property $props
-                    $result.PSObject.TypeNames.Insert(0, 'JiraPS.CreateMetaField')
-                    $result | Add-Member -MemberType ScriptMethod -Name "ToString" -Force -Value {
-                        Write-Output "$($this.Name)"
-                    }
-
-                    Write-Output $result
+                if ($item.allowedValues) {
+                    $props.AllowedValues = $item.allowedValues
                 }
-            }
 
+                if ($item.autoCompleteUrl) {
+                    $props.AutoCompleteUrl = $item.autoCompleteUrl
+                }
+
+                foreach ($extraProperty in (Get-Member -InputObject $item -MemberType NoteProperty).Name) {
+                    if ($null -eq $props.$extraProperty) {
+                        $props.$extraProperty = $item.$extraProperty
+                    }
+                }
+
+                $result = New-Object -TypeName PSObject -Property $props
+                $result.PSObject.TypeNames.Insert(0, 'JiraPS.CreateMetaField')
+                $result | Add-Member -MemberType ScriptMethod -Name "ToString" -Force -Value {
+                    Write-Output "$($this.Name)"
+                }
+
+                Write-Output $result
+            }
         }
     }
 }

--- a/JiraPS/Private/ConvertTo-JiraCreateMetaField.ps1
+++ b/JiraPS/Private/ConvertTo-JiraCreateMetaField.ps1
@@ -14,6 +14,8 @@ function ConvertTo-JiraCreateMetaField {
             $fieldList = $null
 
             If ($null -ne $i.values) {
+                Write-Debug "[$($MyInvocation.MyCommand.Name)] Input appears to be from Jira 9+ CreateMeta"
+
                 $fieldList = $i.values | ForEach-Object {
                     @{
                         Name = $_.fieldId
@@ -22,6 +24,7 @@ function ConvertTo-JiraCreateMetaField {
                 }
             }
             Elseif ($null -ne $i.projects.issuetypes.fields) {
+                Write-Debug "[$($MyInvocation.MyCommand.Name)] Input appears to be from Jira 8 (or below) CreateMeta"
 
                 $fields = $i.projects.issuetypes.fields
                 $fieldNames = (Get-Member -InputObject $fields -MemberType '*Property').Name

--- a/JiraPS/Private/ConvertTo-JiraCreateMetaField.ps1
+++ b/JiraPS/Private/ConvertTo-JiraCreateMetaField.ps1
@@ -10,42 +10,99 @@ function ConvertTo-JiraCreateMetaField {
         foreach ($i in $InputObject) {
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Converting `$InputObject to custom object"
 
-            $fields = $i.projects.issuetypes.fields
-            $fieldNames = (Get-Member -InputObject $fields -MemberType '*Property').Name
-            foreach ($f in $fieldNames) {
-                $item = $fields.$f
 
-                $props = @{
-                    'Id'              = $f
-                    'Name'            = $item.name
-                    'HasDefaultValue' = [System.Convert]::ToBoolean($item.hasDefaultValue)
-                    'Required'        = [System.Convert]::ToBoolean($item.required)
-                    'Schema'          = $item.schema
-                    'Operations'      = $item.operations
-                }
+            $fieldList = $null
 
-                if ($item.allowedValues) {
-                    $props.AllowedValues = $item.allowedValues
-                }
-
-                if ($item.autoCompleteUrl) {
-                    $props.AutoCompleteUrl = $item.autoCompleteUrl
-                }
-
-                foreach ($extraProperty in (Get-Member -InputObject $item -MemberType NoteProperty).Name) {
-                    if ($null -eq $props.$extraProperty) {
-                        $props.$extraProperty = $item.$extraProperty
-                    }
-                }
-
-                $result = New-Object -TypeName PSObject -Property $props
-                $result.PSObject.TypeNames.Insert(0, 'JiraPS.CreateMetaField')
-                $result | Add-Member -MemberType ScriptMethod -Name "ToString" -Force -Value {
-                    Write-Output "$($this.Name)"
-                }
-
-                Write-Output $result
+            If ($null -ne $i.values) {
+                $fieldList = $i.values
             }
+            Elseif ($null -ne $i.projects.issuetypes.fields) {
+
+            }
+            Else {
+                Write-Error -Exception ([System.ArgumentException]::new("Input data does not match a known CreateMeta payload.", "InputObject"))
+            }
+
+            if ($null -ne $i.values) {
+
+                $i.values | ForEach-Object {
+                    $item = $_
+
+                    $props = @{
+                        'Id'              = $item.fieldId
+                        'Name'            = $item.name
+                        'HasDefaultValue' = [System.Convert]::ToBoolean($item.hasDefaultValue)
+                        'Required'        = [System.Convert]::ToBoolean($item.required)
+                        'Schema'          = $item.schema
+                        'Operations'      = $item.operations
+                    }
+
+                    if ($item.allowedValues) {
+                        $props.AllowedValues = $item.allowedValues
+                    }
+
+                    if ($item.autoCompleteUrl) {
+                        $props.AutoCompleteUrl = $item.autoCompleteUrl
+                    }
+
+                    foreach ($extraProperty in (Get-Member -InputObject $item -MemberType NoteProperty).Name) {
+                        if ($null -eq $props.$extraProperty) {
+                            $props.$extraProperty = $item.$extraProperty
+                        }
+                    }
+
+                    $result = New-Object -TypeName PSObject -Property $props
+                    $result.PSObject.TypeNames.Insert(0, 'JiraPS.CreateMetaField')
+                    $result | Add-Member -MemberType ScriptMethod -Name "ToString" -Force -Value {
+                        Write-Output "$($this.Name)"
+                    }
+
+                    Write-Output $result
+                }
+
+            }
+            else {
+
+                $fields = $i.projects.issuetypes.fields
+                $fieldNames = (Get-Member -InputObject $fields -MemberType '*Property').Name
+                foreach ($f in $fieldNames) {
+
+
+                    $item = $fields.$f
+
+                    $props = @{
+                        'Id'              = $f
+                        'Name'            = $item.name
+                        'HasDefaultValue' = [System.Convert]::ToBoolean($item.hasDefaultValue)
+                        'Required'        = [System.Convert]::ToBoolean($item.required)
+                        'Schema'          = $item.schema
+                        'Operations'      = $item.operations
+                    }
+
+                    if ($item.allowedValues) {
+                        $props.AllowedValues = $item.allowedValues
+                    }
+
+                    if ($item.autoCompleteUrl) {
+                        $props.AutoCompleteUrl = $item.autoCompleteUrl
+                    }
+
+                    foreach ($extraProperty in (Get-Member -InputObject $item -MemberType NoteProperty).Name) {
+                        if ($null -eq $props.$extraProperty) {
+                            $props.$extraProperty = $item.$extraProperty
+                        }
+                    }
+
+                    $result = New-Object -TypeName PSObject -Property $props
+                    $result.PSObject.TypeNames.Insert(0, 'JiraPS.CreateMetaField')
+                    $result | Add-Member -MemberType ScriptMethod -Name "ToString" -Force -Value {
+                        Write-Output "$($this.Name)"
+                    }
+
+                    Write-Output $result
+                }
+            }
+
         }
     }
 }

--- a/JiraPS/Public/Get-JiraIssueCreateMetadata.ps1
+++ b/JiraPS/Public/Get-JiraIssueCreateMetadata.ps1
@@ -22,7 +22,16 @@ function Get-JiraIssueCreateMetadata {
 
         $server = Get-JiraConfigServer -ErrorAction Stop
 
-        $resourceURi = "$server/rest/api/2/issue/createmeta?projectIds={0}&issuetypeIds={1}&expand=projects.issuetypes.fields"
+        $JiraVersion = Get-JiraServerInfo -ErrorAction Stop
+
+        # Beginning with Jira 9, the old instance-level CreateMeta endpoint is no longer available.
+        # Instead, CreateMeta is inherently scoped to project and issue type.
+        If ($JiraVersion.Version -gt [System.version](9.0.0)) {
+            $resourceURi = "$server/rest/api/2/issue/createmeta/{0}/issuetypes/{1}"
+        } Else {
+            $resourceURi = "$server/rest/api/2/issue/createmeta?projectIds={0}&issuetypeIds={1}&expand=projects.issuetypes.fields"
+        }
+
     }
 
     process {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 -->
<!-- markdownlint-disable MD041 -->
<!-- Provide a general summary of your changes in the Title above -->

### Description

<!-- Describe your changes in detail -->

This PR adjusts `Get-JiraIssueCreateMetadata` and `ConvertTo-JiraCreateMetaField` to support Jira 9, where CreateMeta changes have prevented creation of issues.

In Jira 9 and above, the instance-level CreateMeta endpoint [was removed from the REST API](https://confluence.atlassian.com/jiracore/createmeta-rest-endpoint-to-be-removed-975040986.html). The only CreateMeta option available is the one specific to project/issue types.

JiraPS already handles this limitation as `Get-JiraIssueCreateMetadata` is scoped to an individual project/issuetype, but what's missing is support for the new:
* API endpoint
* Response format (see below)

#### New response format
In Jira 8 and below, the "old" CreateMeta endpoint returned a collection of projects, those projects' issue types, and those issue types' fields.

The `.projects.issuetypes.fields` property was a KVP/dictionary type where:
* Key names were field IDs: `assignee`, `reporter`, `customfield_10101`
* Values were another dictionary with those fields' relevant configurations: `fieldID` (...yeah, again), `name`, `required`, etc.

In Jira 9+, the new CreateMeta endpoint returns a paginated array of objects matching the values from Jira 8. Field IDs are still included in the array of response objects, but are no longer being used as the key in a key/value pair.

To accommodate this, `ConvertTo-JiraCreateMetaField` packs both forms of responses into an array of hashtables, where:
* `Name` is the field ID.
* `Value` is the field's configuration object.

Then performs the same value-conversion process for both response shapes.

#### Areas of uncertainty
* `Get-JiraIssueCreateMetadata` uses `Write-DebugMessage`, whereas `ConvertTo-JiraCreateMetaField` uses just `Write-Debug`. Which do we want to use here?
* Jira 8.4 has the same "new" CreateMeta endpoint as Jira 9. Do we want to move the "bar" for old/new CreateMeta endpoints further back in Jira's historical versions?
* The Jira 9+ CreateMeta endpoint appears to be paginated. `Get-JiraIssueCreateMetadata` does not currently attempt pagination.
  * Do we just need to add `-Paging` to the call to `Invoke-JiraMethod` for this?
  * Given that Jira 8 does not support paging this response, how do we feel about _not_ marking `Get-JiraIssueCreateMetadata` as supporting paging? I feel like marking the cmdlet as SupportsPaging but then throwing if we're on Jira 8 is not helpful for end-users.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here as follows: -->
<!-- closes #1, closes #2, ... -->

Closes #461, #469, #473, and #498, 

### Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have added Pester Tests that describe what my changes should do.
- [x] I have updated the documentation accordingly.
