### PR TITLE
Improve performance of `New-`/`Set-JiraIssue` on instances with large quantities of fields

### DIFF
--- a/JiraPS/Public/New-JiraIssue.ps1
+++ b/JiraPS/Public/New-JiraIssue.ps1
@@ -135,13 +135,13 @@ function New-JiraIssue {
                 # The Fields hashtable supports both name- and ID-based lookup for custom fields, so we have to search both.
                 if ($AvailableFieldsById.ContainsKey($name)) {
                     $field = $AvailableFieldsById[$name][0]
-                    Write-Debug "[$($MyInvocation.MyCommand.Name)] $name appears to be a field ID"
+                    Write-Debug "[$($MyInvocation.MyCommand.Name)] [$name] appears to be a field ID"
                 } elseif ($AvailableFieldsById.ContainsKey("customfield_$name")) {
                     $field = $AvailableFieldsById["customfield_$name"][0]
-                    Write-Debug "[$($MyInvocation.MyCommand.Name)] $name appears to be a numerical field ID (customfield_$name)"
+                    Write-Debug "[$($MyInvocation.MyCommand.Name)] [$name] appears to be a numerical field ID (customfield_$name)"
                 } elseif ($AvailableFieldsByName.ContainsKey($name) -and $AvailableFieldsByName[$name].Count -eq 1) {
                     $field = $AvailableFieldsByName[$name][0]
-                    Write-Debug "[$($MyInvocation.MyCommand.Name)] $name appears to be a human-readable field name ($($field.ID))"
+                    Write-Debug "[$($MyInvocation.MyCommand.Name)] [$name] appears to be a human-readable field name ($($field.ID))"
                 } elseif ($AvailableFieldsByName.ContainsKey($name)) {
                     # Jira does not prevent multiple custom fields with the same name, so we have to ensure
                     # any name references are unambiguous.

--- a/JiraPS/Public/New-JiraIssue.ps1
+++ b/JiraPS/Public/New-JiraIssue.ps1
@@ -114,28 +114,61 @@ function New-JiraIssue {
             }
         }
 
-        Write-Debug "[$($MyInvocation.MyCommand.Name)] Resolving `$Fields"
-        foreach ($_key in $Fields.Keys) {
-            $name = $_key
-            $value = $Fields.$_key
+        If ($Fields) {
 
-            if ($field = Get-JiraField -Field $name -Credential $Credential -Debug:$false) {
-                # For some reason, this was coming through as a hashtable instead of a String,
-                # which was causing ConvertTo-Json to crash later.
-                # Not sure why, but this forces $id to be a String and not a hashtable.
+            Write-Debug "[$($MyInvocation.MyCommand.Name)] Enumerating fields for server"
+
+            # Fetch all available fields ahead-of-time to avoid repeated API calls in the upcoming loop.
+            # Eventually, this may be better to extract from CreateMeta.
+            $AvailableFields = Get-JiraField -Credential $Credential -ErrorAction Stop -Debug:$false
+
+            $AvailableFieldsById = $AvailableFields | Group-Object -Property Id -AsHashTable -AsString
+            $AvailableFieldsByName = $AvailableFields | Group-Object -Property Name -AsHashTable -AsString
+
+
+            Write-Debug "[$($MyInvocation.MyCommand.Name)] Resolving `$Fields"
+
+            foreach ($_key in $Fields.Keys) {
+
+                $name = $_key
+                $value = $Fields.$_key
+                # The Fields hashtable supports both name- and ID-based lookup for custom fields, so we have to search both.
+                if ($AvailableFieldsById.ContainsKey($name)) {
+                    $field = $AvailableFieldsById[$name][0]
+                    Write-Debug "[$($MyInvocation.MyCommand.Name)] $name appears to be a field ID"
+                } elseif ($AvailableFieldsById.ContainsKey("customfield_$name")) {
+                    $field = $AvailableFieldsById["customfield_$name"][0]
+                    Write-Debug "[$($MyInvocation.MyCommand.Name)] $name appears to be a numerical field ID (customfield_$name)"
+                } elseif ($AvailableFieldsByName.ContainsKey($name) -and $AvailableFieldsByName[$name].Count -eq 1) {
+                    $field = $AvailableFieldsByName[$name][0]
+                    Write-Debug "[$($MyInvocation.MyCommand.Name)] $name appears to be a human-readable field name ($($field.ID))"
+                } elseif ($AvailableFieldsByName.ContainsKey($name)) {
+                    # Jira does not prevent multiple custom fields with the same name, so we have to ensure
+                    # any name references are unambiguous.
+
+                    # More than one value in $AvailableFieldsByName (i.e. .Count -gt 1) indicates two duplicate custom fields.
+                    $exception = ([System.ArgumentException]"Ambiguously Referenced Parameter")
+                    $errorId = 'ParameterValue.AmbiguousParameter'
+                    $errorCategory = 'InvalidArgument'
+                    $errorTarget = $Fields
+                    $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
+                    $errorItem.ErrorDetails = "Field name [$name] in -Fields hashtable ambiguously refers to more than one field. Use Get-JiraField for more information, or specify the custom field by its ID."
+                    $PSCmdlet.ThrowTerminatingError($errorItem)
+                } else {
+                    $exception = ([System.ArgumentException]"Invalid value for Parameter")
+                    $errorId = 'ParameterValue.InvalidFields'
+                    $errorCategory = 'InvalidArgument'
+                    $errorTarget = $Fields
+                    $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
+                    $errorItem.ErrorDetails = "Unable to identify field [$name] from -Fields hashtable. Use Get-JiraField for more information."
+                    $PSCmdlet.ThrowTerminatingError($errorItem)
+                }
+
                 $id = $field.Id
                 $requestBody["$id"] = $value
             }
-            else {
-                $exception = ([System.ArgumentException]"Invalid value for Parameter")
-                $errorId = 'ParameterValue.InvalidFields'
-                $errorCategory = 'InvalidArgument'
-                $errorTarget = $Fields
-                $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
-                $errorItem.ErrorDetails = "Unable to identify field [$name] from -Fields hashtable. Use Get-JiraField for more information."
-                $PSCmdlet.ThrowTerminatingError($errorItem)
-            }
         }
+
 
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Validating fields with metadata"
         foreach ($c in $createmeta) {

--- a/JiraPS/Public/Set-JiraIssue.ps1
+++ b/JiraPS/Public/Set-JiraIssue.ps1
@@ -171,17 +171,20 @@ function Set-JiraIssue {
                 Write-Debug "[$($MyInvocation.MyCommand.Name)] Resolving `$Fields"
                 foreach ($_key in $Fields.Keys) {
 
+                    $name = $_key
+                    $value = $Fields.$_key
+
                     # The Fields hashtable supports both name- and ID-based lookup for custom fields, so we have to search both.
-                    if ($AvailableFieldsById.ContainsKey($_key)) {
-                        $field = $AvailableFieldsById[$_key][0]
-                        Write-Debug "[$($MyInvocation.MyCommand.Name)] $_key appears to be a field ID"
-                    } elseif ($AvailableFieldsById.ContainsKey("customfield_$_key")) {
-                        $field = $AvailableFieldsById["customfield_$_key"][0]
-                        Write-Debug "[$($MyInvocation.MyCommand.Name)] $_key appears to be a numerical field ID (customfield_$_key)"
-                    } elseif ($AvailableFieldsByName.ContainsKey($_key) -and $AvailableFieldsByName[$_key].Count -eq 1) {
-                        $field = $AvailableFieldsByName[$_key][0]
-                        Write-Debug "[$($MyInvocation.MyCommand.Name)] $_key appears to be a human-readable field name ($($field.ID))"
-                    } elseif ($AvailableFieldsByName.ContainsKey($_key)) {
+                    if ($AvailableFieldsById.ContainsKey($name)) {
+                        $field = $AvailableFieldsById[$name][0]
+                        Write-Debug "[$($MyInvocation.MyCommand.Name)] [$name] appears to be a field ID"
+                    } elseif ($AvailableFieldsById.ContainsKey("customfield_$name")) {
+                        $field = $AvailableFieldsById["customfield_$name"][0]
+                        Write-Debug "[$($MyInvocation.MyCommand.Name)] [$name] appears to be a numerical field ID (customfield_$name)"
+                    } elseif ($AvailableFieldsByName.ContainsKey($name) -and $AvailableFieldsByName[$name].Count -eq 1) {
+                        $field = $AvailableFieldsByName[$name][0]
+                        Write-Debug "[$($MyInvocation.MyCommand.Name)] [$name] appears to be a human-readable field name ($($field.ID))"
+                    } elseif ($AvailableFieldsByName.ContainsKey($name)) {
                         # Jira does not prevent multiple custom fields with the same name, so we have to ensure
                         # any name references are unambiguous.
 

--- a/JiraPS/Public/Set-JiraIssue.ps1
+++ b/JiraPS/Public/Set-JiraIssue.ps1
@@ -159,9 +159,11 @@ function Set-JiraIssue {
 
             if ($Fields) {
 
+                Write-Debug "[$($MyInvocation.MyCommand.Name)] Enumerating fields defined on the server"
+
                 # Fetch all available fields ahead-of-time to avoid repeated API calls in the upcoming loop.
                 # Eventually, this may be better to extract from EditMeta.
-                $AvailableFields = Get-JiraField -Credential $Credential -ErrorAction Stop
+                $AvailableFields = Get-JiraField -Credential $Credential -ErrorAction Stop -Debug:$false
 
                 $AvailableFieldsById = $AvailableFields | Group-Object -Property Id -AsHashTable -AsString
                 $AvailableFieldsByName = $AvailableFields | Group-Object -Property Name -AsHashTable -AsString

--- a/JiraPS/Public/Set-JiraIssue.ps1
+++ b/JiraPS/Public/Set-JiraIssue.ps1
@@ -156,17 +156,51 @@ function Set-JiraIssue {
                 )
             }
 
+
             if ($Fields) {
+
+                # Fetch all available fields ahead-of-time to avoid repeated API calls in the upcoming loop.
+                # Eventually, this may be better to extract from EditMeta.
+                $AvailableFields = Get-JiraField -Credential $Credential -ErrorAction Stop
+
+                $AvailableFieldsById = $AvailableFields | Group-Object -Property Id -AsHashTable -AsString
+                $AvailableFieldsByName = $AvailableFields | Group-Object -Property Name -AsHashTable -AsString
+
                 Write-Debug "[$($MyInvocation.MyCommand.Name)] Resolving `$Fields"
                 foreach ($_key in $Fields.Keys) {
-                    $name = $_key
-                    $value = $Fields.$_key
 
-                    $field = Get-JiraField -Field $name -Credential $Credential -ErrorAction Stop
+                    # The Fields hashtable supports both name- and ID-based lookup for custom fields, so we have to search both.
+                    if ($AvailableFieldsById.ContainsKey($_key)) {
+                        $field = $AvailableFieldsById[$_key][0]
+                        Write-Debug "[$($MyInvocation.MyCommand.Name)] $_key appears to be a field ID"
+                    } elseif ($AvailableFieldsById.ContainsKey("customfield_$_key")) {
+                        $field = $AvailableFieldsById["customfield_$_key"][0]
+                        Write-Debug "[$($MyInvocation.MyCommand.Name)] $_key appears to be a numerical field ID (customfield_$_key)"
+                    } elseif ($AvailableFieldsByName.ContainsKey($_key) -and $AvailableFieldsByName[$_key].Count -eq 1) {
+                        $field = $AvailableFieldsByName[$_key][0]
+                        Write-Debug "[$($MyInvocation.MyCommand.Name)] $_key appears to be a human-readable field name ($($field.ID))"
+                    } elseif ($AvailableFieldsByName.ContainsKey($_key)) {
+                        # Jira does not prevent multiple custom fields with the same name, so we have to ensure
+                        # any name references are unambiguous.
 
-                    # For some reason, this was coming through as a hashtable instead of a String,
-                    # which was causing ConvertTo-Json to crash later.
-                    # Not sure why, but this forces $id to be a String and not a hashtable.
+                        # More than one value in $AvailableFieldsByName (i.e. .Count -gt 1) indicates two duplicate custom fields.
+                        $exception = ([System.ArgumentException]"Ambiguously Referenced Parameter")
+                        $errorId = 'ParameterValue.AmbiguousParameter'
+                        $errorCategory = 'InvalidArgument'
+                        $errorTarget = $Fields
+                        $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
+                        $errorItem.ErrorDetails = "Field name [$name] in -Fields hashtable ambiguously refers to more than one field. Use Get-JiraField for more information, or specify the custom field by its ID."
+                        $PSCmdlet.ThrowTerminatingError($errorItem)
+                    } else {
+                        $exception = ([System.ArgumentException]"Invalid value for Parameter")
+                        $errorId = 'ParameterValue.InvalidFields'
+                        $errorCategory = 'InvalidArgument'
+                        $errorTarget = $Fields
+                        $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
+                        $errorItem.ErrorDetails = "Unable to identify field [$name] from -Fields hashtable. Use Get-JiraField for more information."
+                        $PSCmdlet.ThrowTerminatingError($errorItem)
+                    }
+
                     $id = [string]$field.Id
                     $issueProps.update[$id] = @(@{ 'set' = $value })
                 }

--- a/Tests/Functions/New-JiraIssue.Unit.Tests.ps1
+++ b/Tests/Functions/New-JiraIssue.Unit.Tests.ps1
@@ -81,7 +81,20 @@ Describe "New-JiraIssue" -Tag 'Unit' {
 
         # This one needs to be able to output multiple objects
         Mock Get-JiraField {
-            $Field | % {
+
+            $(If ($null -eq $Field) {
+                @(
+                    'Project'
+                    'IssueType'
+                    'Priority'
+                    'Summary'
+                    'Description'
+                    'Reporter'
+                    'CustomField'
+                )
+            } Else {
+                $Field
+            }) | % {
                 $object = [PSCustomObject] @{
                     'Id' = $_
                 }

--- a/Tests/Functions/Set-JiraIssue.Unit.Tests.ps1
+++ b/Tests/Functions/Set-JiraIssue.Unit.Tests.ps1
@@ -172,12 +172,6 @@ Describe "Set-JiraIssue" -Tag 'Unit' {
             }
 
             It "Updates custom fields if provided to the -Fields parameter" {
-                Mock Get-JiraField {
-                    [PSCustomObject] @{
-                        'Name' = $Field
-                        'ID'   = $Field
-                    }
-                }
                 { Set-JiraIssue -Issue TEST-001 -Fields @{'customfield_12345' = 'foo'; 'customfield_67890' = 'bar'; 'customfield_111222' = @(@{'value' = 'foobar'})} } | Should Not Throw
                 Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Put' -and $URI -like "$jiraServer/rest/api/*/issue/12345" -and $Body -like '*customfield_12345*set*foo*' }
                 Assert-MockCalled -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -Scope It -ParameterFilter { $Method -eq 'Put' -and $URI -like "$jiraServer/rest/api/*/issue/12345" -and $Body -like '*customfield_67890*set*bar*' }

--- a/Tests/Functions/Set-JiraIssue.Unit.Tests.ps1
+++ b/Tests/Functions/Set-JiraIssue.Unit.Tests.ps1
@@ -58,6 +58,32 @@ Describe "Set-JiraIssue" -Tag 'Unit' {
             return $object
         }
 
+        Mock Get-JiraField {
+
+            $(If ($null -eq $Field) {
+                @(
+                    'Project'
+                    'IssueType'
+                    'Priority'
+                    'Summary'
+                    'Description'
+                    'Reporter'
+                    'CustomField'
+                    'customfield_12345'
+                    'customfield_67890'
+                    'customfield_111222'
+                )
+            } Else {
+                $Field
+            }) | % {
+                $object = [PSCustomObject] @{
+                    'Id' = $_
+                }
+                $object.PSObject.TypeNames.Insert(0, 'JiraPS.Field')
+                $object
+            }
+        }
+
         Mock Resolve-JiraIssueObject -ModuleName JiraPS {
             Get-JiraIssue -Key $Issue
         }
@@ -73,7 +99,7 @@ Describe "Set-JiraIssue" -Tag 'Unit' {
         # actually try to query a JIRA instance
         Mock Invoke-JiraMethod {
             ShowMockInfo 'Invoke-JiraMethod' 'Method', 'Uri'
-            throw "Unidentified call to Invoke-JiraMethod"
+            throw "Unidentified call ($Method $Uri) to Invoke-JiraMethod"
         }
 
         Context "Sanity checking" {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 -->
<!-- markdownlint-disable MD041 -->
<!-- Provide a general summary of your changes in the Title above -->

### Description

<!-- Describe your changes in detail -->

This PR adjusts the functionality of `New-JiraIssue` and `Set-JiraIssue` to only call `Get-JiraField` once (if `-Fields` is set) instead of once per entry in the `-Fields` hashtable.

Additionally, both cmdlets will resolve numerical IDs for custom fields if users specify fields in that way (i.e. `-Fields @{12345 = $foo}` is equivalent to `-Fields @{customfield_12345 = $foo}`)

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here as follows: -->
<!-- closes #1, closes #2, ... -->

`Get-JiraField` takes a `-Name` parameter, however the underlying API call is not filtered by name. This means that every field in the instance (visible to the current user) is retrieved for each key in `-Fields`. This means network traffic/CPU usage/time spent scales quadratically in practice (linear to the number of CFs in the API call and the number of CFs in the instance).

By moving `Get-JiraField` out of this loop (thus only calling it once), we can cache field data instead of hammering Jira's API for it.

Closes #515.

#### Improvement Areas
We currently query the whole instance's fields which, on larger (or poorly-organized) instances, may:
* Be very large
* Include duplicate fields used in different contexts than the user's

Using the CreateMeta and EditMeta endpoints (with `Get-JiraIssueCreateMetadata` and `Get-JiraIssueEditMetadata`) would reduce response size and limit fields to ones that are actually relevant to the current project/issue context.

### Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have added Pester Tests that describe what my changes should do.
- [ ] I have updated the documentation accordingly.
