### PR TITLE
Unify Label parameter names to singular form in `New-`/`Set-JiraIssue`

### DIFF
--- a/JiraPS/Public/New-JiraIssue.ps1
+++ b/JiraPS/Public/New-JiraIssue.ps1
@@ -29,8 +29,9 @@ function New-JiraIssue {
         $Reporter,
 
         [Parameter( ValueFromPipelineByPropertyName )]
+        [Alias("Labels")]
         [String[]]
-        $Labels,
+        $Label,
 
         [Parameter( ValueFromPipelineByPropertyName )]
         [String]
@@ -105,9 +106,9 @@ function New-JiraIssue {
             $requestBody["parent"] = @{"key" = $Parent}
         }
 
-        if ($Labels) {
+        if ($Label) {
             $requestBody["labels"] = [System.Collections.ArrayList]@()
-            foreach ($item in $Labels) {
+            foreach ($item in $Label) {
                 $null = $requestBody["labels"].Add($item)
             }
         }

--- a/JiraPS/Public/Set-JiraIssue.ps1
+++ b/JiraPS/Public/Set-JiraIssue.ps1
@@ -41,6 +41,7 @@ function Set-JiraIssue {
         [Object]
         $Assignee,
 
+        [Alias("Labels")]
         [String[]]
         $Label,
 

--- a/Tests/Functions/New-JiraIssue.Unit.Tests.ps1
+++ b/Tests/Functions/New-JiraIssue.Unit.Tests.ps1
@@ -134,7 +134,7 @@ Describe "New-JiraIssue" -Tag 'Unit' {
             defParam $command 'Summary'
             defParam $command 'Description'
             defParam $command 'Reporter'
-            defParam $command 'Labels'
+            defParam $command 'Label'
             defParam $command 'Fields'
             defParam $command 'Credential'
         }

--- a/docs/en-US/commands/New-JiraIssue.md
+++ b/docs/en-US/commands/New-JiraIssue.md
@@ -17,7 +17,7 @@ Creates a new issue in JIRA
 
 ```powershell
 New-JiraIssue [-Project] <String> [-IssueType] <String> [-Summary] <String> [[-Priority] <Int32>]
- [[-Description] <String>] [[-Reporter] <String>] [[-Labels] <String[]>] [[-Components] <String[]>] [[-Parent] <String>]
+ [[-Description] <String>] [[-Reporter] <String>] [[-Label] <String[]>] [[-Components] <String[]>] [[-Parent] <String>]
  [[-FixVersion] <String[]>] [[-Fields] <PSCustomObject>] [[-Credential] <PSCredential>] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
@@ -192,7 +192,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Labels
+### -Label
 
 List of labels which will be added to the issue.
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 -->
<!-- markdownlint-disable MD041 -->
<!-- Provide a general summary of your changes in the Title above -->

### Description

<!-- Describe your changes in detail -->

This PR aligns the naming convention for label parameters between `New-JiraIssue` and `Set-JiraIssue`.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here as follows: -->
<!-- closes #1, closes #2, ... -->

Resolves #521.

`New-JiraIssue` takes `-Labels`, whereas `Set-JiraIssue` takes `-Label`. This PR updates both to be `-Label` with `-Labels` as an alias for backwards compatibility.

### Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have added Pester Tests that describe what my changes should do.
- [x] I have updated the documentation accordingly.
