### PR TITLE
feat(adf): add Atlassian Document Format conversion for Jira Cloud

### DIFF
--- a/.github/instructions/jira-api-compatibility.instructions.md
+++ b/.github/instructions/jira-api-compatibility.instructions.md
@@ -28,9 +28,12 @@ Affected: `Get-JiraUser`, `Set-JiraUser`, `Remove-JiraUser`, `New-JiraIssue`
 - Data Center: these fields are plain strings or wiki markup
 - Sending ADF to DC produces garbled content or API errors
 - Reading DC plain strings through ADF conversion is wasteful
-- `ConvertTo-AtlassianDocumentFormat` must only be used for Cloud
-- `ConvertFrom-AtlassianDocumentFormat` must only be used for Cloud
+- `ConvertTo-AtlassianDocumentFormat` (alias `ConvertTo-ADF`) must only be used for Cloud
+- `ConvertFrom-AtlassianDocumentFormat` (alias `ConvertFrom-ADF`) must only be used for Cloud
   (though the function gracefully handles strings as a fallback)
+- Both functions are public so users can convert ADF manually when using
+  `Invoke-JiraMethod` against Cloud v3 endpoints — JiraPS's built-in
+  read/write commands don't cover every API surface
 
 ## Search Endpoint
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Change Log
 
+## v2.16.0-beta2 - unreleased
+
+### Added
+
+- Added `ConvertFrom-AtlassianDocumentFormat` public function (alias `ConvertFrom-ADF`) — converts ADF objects (Jira Cloud v3) to Markdown; plain strings (Data Center) are passed through unchanged. Supports headings, bold/italic/strikethrough/code/links, bullet/ordered/task lists, tables, code fences, blockquotes, panels, mentions, emoji, and date nodes
+- Added `ConvertTo-AtlassianDocumentFormat` public function (alias `ConvertTo-ADF`) — converts Markdown to ADF for writing descriptions and comments on Jira Cloud v3. Supports all symmetric constructs: headings, inline marks, fenced code blocks, blockquotes, tables, task/bullet/ordered lists, block images
+- Added `Tests/Fixtures/adf.sample.json` + `Tests/Fixtures/adf.sample.md` — reference fixtures covering every ADF node type, used by unit tests
+- Added nested list support (2 levels) for both `ConvertTo-ADF` and `ConvertFrom-ADF` — indented bullet/ordered lists are now parsed and rendered correctly
+- Added combined inline mark support (`***bold italic***`, `**_nested_**`, `_**reverse**_`) — produces ADF text nodes with multiple marks
+- Added hard break support — trailing double-spaces in Markdown are converted to `hardBreak` ADF nodes and back
+
+### Fixed
+
+- Fixed `ConvertTo-JiraComment` and `ConvertTo-JiraIssue` to pass `Body` and `Description` through `ConvertFrom-AtlassianDocumentFormat` — Jira Cloud API v3 returns ADF objects instead of plain strings; without conversion, fields contained raw `PSCustomObject` data instead of readable text
+- Fixed table separator regex in `ConvertTo-ADF` to handle compact separators without spaces (`|---|---|`)
+- Fixed `inlineCard` rendering in `ConvertFrom-ADF` to produce `<url>` instead of redundant `[url](url)`
+
 ## v2.16.0-beta - 2026-04-06
 
 ### Added

--- a/JiraPS/Private/ConvertTo-JiraComment.ps1
+++ b/JiraPS/Private/ConvertTo-JiraComment.ps1
@@ -12,7 +12,7 @@
 
             $props = @{
                 'ID'         = $i.id
-                'Body'       = $i.body
+                'Body'       = ConvertFrom-AtlassianDocumentFormat -InputObject $i.body
                 'Visibility' = $i.visibility
                 'RestUrl'    = $i.self
             }

--- a/JiraPS/Private/ConvertTo-JiraIssue.ps1
+++ b/JiraPS/Private/ConvertTo-JiraIssue.ps1
@@ -32,7 +32,7 @@
                 'HttpUrl'     = $http
                 'RestUrl'     = $i.self
                 'Summary'     = $i.fields.summary
-                'Description' = $i.fields.description
+                'Description' = ConvertFrom-AtlassianDocumentFormat -InputObject $i.fields.description
                 'Status'      = $i.fields.status.name
             }
 

--- a/JiraPS/Public/ConvertFrom-AtlassianDocumentFormat.ps1
+++ b/JiraPS/Public/ConvertFrom-AtlassianDocumentFormat.ps1
@@ -1,0 +1,258 @@
+function ConvertFrom-AtlassianDocumentFormat {
+    # .ExternalHelp ..\JiraPS-help.xml
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(ValueFromPipeline)]
+        [Object]$InputObject
+    )
+
+    begin {
+        Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
+    }
+
+    process {
+        Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] PSBoundParameters: $($PSBoundParameters | Out-String)"
+
+        if ($null -eq $InputObject) {
+            Write-Debug "[$($MyInvocation.MyCommand.Name)] InputObject is `$null — returning `$null"
+            return $null
+        }
+
+        # Resolve the ADF 'type' field for both PSCustomObject (API JSON) and hashtable (round-trip)
+        $docType = $null
+        if ($InputObject -is [hashtable]) {
+            $docType = $InputObject['type']
+        }
+        elseif ($InputObject.PSObject.Properties['type']) {
+            $docType = $InputObject.type
+        }
+
+        # Data Center, API v2 and non-ADF objects
+        if ($docType -ne 'doc') {
+            Write-Debug "[$($MyInvocation.MyCommand.Name)] Input is not ADF (type='$docType') — returning as string"
+            return $InputObject.ToString()
+        }
+
+        Write-Debug "[$($MyInvocation.MyCommand.Name)] ADF document with $($InputObject.content.Count) top-level node(s)"
+
+        $rawBlocks = foreach ($node in $InputObject.content) {
+            ConvertFrom-AdfBlock -Node $node
+        }
+
+        $formattedBlocks = $rawBlocks | Where-Object { $null -ne $_ -and '' -ne $_ }
+        return ($formattedBlocks -join "`n`n" |
+                ForEach-Object { $_.TrimEnd() })
+    }
+
+    end {
+        Write-Verbose "[$($MyInvocation.MyCommand.Name)] Complete"
+    }
+}
+
+New-Alias -Name "ConvertFrom-ADF" -Value "ConvertFrom-AtlassianDocumentFormat" -ErrorAction SilentlyContinue
+
+# ---------------------------------------------------------------------------
+# Block-level renderers
+# ---------------------------------------------------------------------------
+
+function script:ConvertFrom-AdfBlock {
+    param($Node)
+    switch ($Node.type) {
+        'heading' {
+            $hashes = '#' * [int]$Node.attrs.level
+            return "$hashes $(ConvertFrom-AdfInline $Node.content)"
+        }
+        'paragraph' {
+            if (-not $Node.content) { return $null }
+            return ConvertFrom-AdfInline $Node.content
+        }
+        'bulletList' {
+            return ConvertFrom-AdfList -Node $Node -ListType 'bullet' -IndentLevel 0
+        }
+        'orderedList' {
+            return ConvertFrom-AdfList -Node $Node -ListType 'ordered' -IndentLevel 0
+        }
+        'taskList' {
+            return ($Node.content |
+                    ForEach-Object {
+                        $box = if ($_.attrs -and $_.attrs.state -eq 'DONE') { '[x]' } else { '[ ]' }
+                        "* $box $(ConvertFrom-AdfInline $_.content)"
+                    }) -join "`n"
+        }
+        'decisionList' {
+            return ($Node.content |
+                    ForEach-Object {
+                        ConvertFrom-AdfInline $_.content
+                    }) -join "`n"
+        }
+        'blockquote' {
+            return ($Node.content |
+                    ForEach-Object {
+                        "> $((ConvertFrom-AdfBlock $_).Trim())"
+                    }) -join "`n"
+        }
+        'codeBlock' {
+            $lang = if ($Node.attrs -and $Node.attrs.language) { $Node.attrs.language } else { '' }
+            $code = ConvertFrom-AdfInline $Node.content
+            return "``````$lang`n$code`n``````"
+        }
+        'panel' {
+            return ConvertFrom-AdfContent $Node.content
+        }
+        'mediaSingle' {
+            $media = $Node.content | Where-Object { $_.type -eq 'media' } | Select-Object -First 1
+            if ($media -and $media.attrs.url) {
+                $alt = if ($media.attrs -and $media.attrs.alt) { $media.attrs.alt } else { 'image' }
+                return "![$alt]($($media.attrs.url))"
+            }
+            return $null
+        }
+        'table' {
+            return ConvertFrom-AdfTable $Node
+        }
+        default {
+            $nodeContent = if ($Node -is [hashtable]) { $Node['content'] }
+            elseif ($Node.PSObject.Properties['content']) { $Node.content }
+            else { $null }
+            if ($nodeContent) {
+                return ConvertFrom-AdfContent $nodeContent
+            }
+            return $null
+        }
+    }
+}
+
+function script:ConvertFrom-AdfContent {
+    param($Nodes)
+    if (-not $Nodes) { return '' }
+    ($Nodes |
+        ForEach-Object { ConvertFrom-AdfBlock $_ } |
+        Where-Object { $null -ne $_ }) -join "`n"
+}
+
+# ---------------------------------------------------------------------------
+# Inline renderers
+# ---------------------------------------------------------------------------
+
+function script:ConvertFrom-AdfInline {
+    param($Nodes)
+    if (-not $Nodes) { return '' }
+    -join ($Nodes | ForEach-Object { ConvertFrom-AdfInlineNode $_ })
+}
+
+function script:ConvertFrom-AdfInlineNode {
+    param($Node)
+    switch ($Node.type) {
+        'text' {
+            $t = $Node.text
+            if (-not $Node.marks) { return $t }
+
+            $link = $Node.marks | Where-Object { $_.type -eq 'link' } | Select-Object -First 1
+            $strong = $Node.marks | Where-Object { $_.type -eq 'strong' }
+            $em = $Node.marks | Where-Object { $_.type -eq 'em' }
+            $strike = $Node.marks | Where-Object { $_.type -eq 'strike' }
+            $code = $Node.marks | Where-Object { $_.type -eq 'code' }
+
+            if ($link) { return "[$t]($($link.attrs.href))" }
+            if ($code) { return "``$t``" }
+            if ($strike) { $t = "~~$t~~" }
+            if ($strong) { $t = "**$t**" }
+            if ($em) { $t = "_${t}_" }
+            return $t
+        }
+        'hardBreak' { return "  `n" }
+        'mention' { return $Node.attrs.text }
+        'emoji' { return $Node.attrs.text }
+        'inlineCard' {
+            return "<$($Node.attrs.url)>"
+        }
+        'date' {
+            $ts = [long]$Node.attrs.timestamp
+            return [System.DateTimeOffset]::FromUnixTimeMilliseconds($ts).UtcDateTime.ToString('yyyy-MM-dd')
+        }
+        default {
+            $nodeContent = if ($Node -is [hashtable]) { $Node['content'] }
+            elseif ($Node.PSObject.Properties['content']) { $Node.content }
+            else { $null }
+            if ($nodeContent) {
+                return ConvertFrom-AdfInline $nodeContent
+            }
+            return ''
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Table renderer
+# ---------------------------------------------------------------------------
+
+function script:ConvertFrom-AdfTable {
+    param($Node)
+    $lines = [System.Collections.Generic.List[string]]::new()
+    $separatorInserted = $false
+    foreach ($row in ($Node.content | Where-Object { $_.type -eq 'tableRow' })) {
+        $cells = @($row.content |
+                ForEach-Object {
+                    (ConvertFrom-AdfContent $_.content).Trim()
+                })
+
+        # Skip rows where every cell is empty (trailing blank rows from Jira editor)
+        if ($separatorInserted -and -not ($cells | Where-Object { $_ -ne '' })) { continue }
+
+        $lines.Add("| $($cells -join ' | ') |")
+
+        $isHeaderRow = ($row.content | Where-Object { $_.type -eq 'tableHeader' }) -as [bool]
+        if ($isHeaderRow -and -not $separatorInserted) {
+            $sep = @($cells | ForEach-Object { '-' * [Math]::Max(3, $_.Length) })
+            $lines.Add("| $($sep -join ' | ') |")
+            $separatorInserted = $true
+        }
+    }
+    $lines -join "`n"
+}
+
+# ---------------------------------------------------------------------------
+# List renderer with nesting support
+# ---------------------------------------------------------------------------
+
+function script:ConvertFrom-AdfList {
+    param(
+        $Node,
+        [ValidateSet('bullet', 'ordered')]
+        [string]$ListType,
+        [int]$IndentLevel
+    )
+
+    $indent = '  ' * $IndentLevel
+    $lines = [System.Collections.Generic.List[string]]::new()
+    $n = if ($Node.attrs -and $Node.attrs.order) { [int]$Node.attrs.order } else { 1 }
+
+    foreach ($item in $Node.content) {
+        # Render the paragraph content of this list item
+        $paragraphContent = $item.content | Where-Object { $_.type -eq 'paragraph' } | Select-Object -First 1
+        $itemText = if ($paragraphContent) { (ConvertFrom-AdfInline $paragraphContent.content).Trim() } else { '' }
+
+        if ($ListType -eq 'bullet') {
+            $lines.Add("$indent* $itemText")
+        }
+        else {
+            $lines.Add("$indent$n. $itemText")
+            $n++
+        }
+
+        # Check for nested lists in this list item's content
+        foreach ($child in $item.content) {
+            if ($child.type -eq 'bulletList') {
+                $nestedLines = ConvertFrom-AdfList -Node $child -ListType 'bullet' -IndentLevel ($IndentLevel + 1)
+                $lines.Add($nestedLines)
+            }
+            elseif ($child.type -eq 'orderedList') {
+                $nestedLines = ConvertFrom-AdfList -Node $child -ListType 'ordered' -IndentLevel ($IndentLevel + 1)
+                $lines.Add($nestedLines)
+            }
+        }
+    }
+
+    $lines -join "`n"
+}

--- a/JiraPS/Public/ConvertFrom-AtlassianDocumentFormat.ps1
+++ b/JiraPS/Public/ConvertFrom-AtlassianDocumentFormat.ps1
@@ -1,4 +1,4 @@
-function ConvertFrom-AtlassianDocumentFormat {
+﻿function ConvertFrom-AtlassianDocumentFormat {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding()]
     [OutputType([string])]

--- a/JiraPS/Public/ConvertTo-AtlassianDocumentFormat.ps1
+++ b/JiraPS/Public/ConvertTo-AtlassianDocumentFormat.ps1
@@ -1,4 +1,4 @@
-function ConvertTo-AtlassianDocumentFormat {
+﻿function ConvertTo-AtlassianDocumentFormat {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding()]
     param(

--- a/JiraPS/Public/ConvertTo-AtlassianDocumentFormat.ps1
+++ b/JiraPS/Public/ConvertTo-AtlassianDocumentFormat.ps1
@@ -1,0 +1,382 @@
+function ConvertTo-AtlassianDocumentFormat {
+    # .ExternalHelp ..\JiraPS-help.xml
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [AllowEmptyString()]
+        [string]$Markdown
+    )
+
+    begin {
+        Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
+    }
+
+    process {
+        Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] PSBoundParameters: $($PSBoundParameters | Out-String)"
+
+        if ([string]::IsNullOrWhiteSpace($Markdown)) {
+            Write-Debug "[$($MyInvocation.MyCommand.Name)] Input is empty or whitespace — returning empty ADF doc"
+            return @{ version = 1; type = 'doc'; content = @() }
+        }
+
+        $lines = @($Markdown -split "`r?`n")
+        Write-Debug "[$($MyInvocation.MyCommand.Name)] Parsing $($lines.Count) line(s) of Markdown"
+        $content = @(ConvertTo-AdfContent -Lines $lines)
+
+        Write-Debug "[$($MyInvocation.MyCommand.Name)] Produced $($content.Count) top-level ADF node(s)"
+        @{ version = 1; type = 'doc'; content = $content }
+    }
+
+    end {
+        Write-Verbose "[$($MyInvocation.MyCommand.Name)] Complete"
+    }
+}
+
+New-Alias -Name "ConvertTo-ADF" -Value "ConvertTo-AtlassianDocumentFormat" -ErrorAction SilentlyContinue
+
+# ---------------------------------------------------------------------------
+# Block-level parser
+# ---------------------------------------------------------------------------
+
+function script:ConvertTo-AdfContent {
+    param([string[]]$Lines)
+
+    $nodes = [System.Collections.Generic.List[hashtable]]::new()
+    $i = 0
+
+    while ($i -lt $Lines.Count) {
+        $line = $Lines[$i]
+
+        # ── Heading ──────────────────────────────────────────────────────────
+        if ($line -match '^(#{1,6})\s+(.+)$') {
+            $nodes.Add(@{
+                    type    = 'heading'
+                    attrs   = @{ level = $matches[1].Length }
+                    content = @(ConvertTo-AdfInline $matches[2])
+                })
+            $i++
+            continue
+        }
+
+        # ── Fenced code block ────────────────────────────────────────────────
+        if ($line -match '^```(\w*)$') {
+            $lang = $matches[1]
+            $codeLines = [System.Collections.Generic.List[string]]::new()
+            $i++
+            while ($i -lt $Lines.Count -and $Lines[$i] -notmatch '^```+$') {
+                $codeLines.Add($Lines[$i])
+                $i++
+            }
+            $i++ # skip closing ```
+            $nodes.Add(@{
+                    type    = 'codeBlock'
+                    attrs   = @{ language = $lang }
+                    content = @(@{ type = 'text'; text = ($codeLines -join "`n") })
+                })
+            continue
+        }
+
+        # ── Block image ───────────────────────────────────────────────────────
+        if ($line -match '^!\[(?<alt>[^\]]*)\]\((?<url>[^\)]+)\)\s*$') {
+            $nodes.Add(@{
+                    type    = 'mediaSingle'
+                    attrs   = @{ layout = 'align-start' }
+                    content = @(@{
+                            type  = 'media'
+                            attrs = @{ type = 'external'; url = $matches['url']; alt = $matches['alt'] }
+                        })
+                })
+            $i++
+            continue
+        }
+
+        # ── Blockquote ────────────────────────────────────────────────────────
+        if ($line -match '^>\s*(.*)$') {
+            $quoteParas = [System.Collections.Generic.List[hashtable]]::new()
+            while ($i -lt $Lines.Count -and $Lines[$i] -match '^>\s*(.*)$') {
+                $quoteParas.Add(@{
+                        type    = 'paragraph'
+                        content = @(ConvertTo-AdfInline $matches[1])
+                    })
+                $i++
+            }
+            $nodes.Add(@{ type = 'blockquote'; content = @($quoteParas) })
+            continue
+        }
+
+        # ── Table ─────────────────────────────────────────────────────────────
+        if ($line -match '^\|') {
+            $tableLines = [System.Collections.Generic.List[string]]::new()
+            while ($i -lt $Lines.Count -and $Lines[$i] -match '^\|') {
+                $tableLines.Add($Lines[$i])
+                $i++
+            }
+            $tableNode = ConvertTo-AdfTable -TableLines $tableLines
+            if ($tableNode) { $nodes.Add($tableNode) }
+            continue
+        }
+
+        # ── Task list (must be tested before bullet list) ────────────────────
+        if ($line -match '^\*\s+\[[ x]\]\s') {
+            $taskItems = [System.Collections.Generic.List[hashtable]]::new()
+            while ($i -lt $Lines.Count -and $Lines[$i] -match '^\*\s+\[([ x])\]\s+(.+)$') {
+                $state = if ($matches[1] -eq 'x') { 'DONE' } else { 'TODO' }
+                $taskItems.Add(@{
+                        type    = 'taskItem'
+                        content = @(ConvertTo-AdfInline $matches[2])
+                        attrs   = @{ localId = [guid]::NewGuid().ToString(); state = $state }
+                    })
+                $i++
+            }
+            $nodes.Add(@{
+                    type    = 'taskList'
+                    content = @($taskItems)
+                    attrs   = @{ localId = [guid]::NewGuid().ToString() }
+                })
+            continue
+        }
+
+        # ── Bullet list (with 2-level nesting support) ─────────────────────────
+        if ($line -match '^\*\s+(?!\[[ x]\])(.+)$') {
+            $listResult = ConvertTo-AdfList -Lines $Lines -StartIndex $i -ListType 'bullet' -IndentLevel 0
+            $nodes.Add($listResult.Node)
+            $i = $listResult.NextIndex
+            continue
+        }
+
+        # ── Ordered list (with 2-level nesting support) ────────────────────────
+        if ($line -match '^\d+\.\s+(.+)$') {
+            $listResult = ConvertTo-AdfList -Lines $Lines -StartIndex $i -ListType 'ordered' -IndentLevel 0
+            $nodes.Add($listResult.Node)
+            $i = $listResult.NextIndex
+            continue
+        }
+
+        # ── Empty line ────────────────────────────────────────────────────────
+        if ([string]::IsNullOrWhiteSpace($line)) {
+            $i++
+            continue
+        }
+
+        # ── Paragraph (default) ───────────────────────────────────────────────
+        # Handle hard breaks: lines ending with two spaces continue into the next line
+        $paraContent = [System.Collections.Generic.List[hashtable]]::new()
+        while ($i -lt $Lines.Count) {
+            $currentLine = $Lines[$i]
+            # Skip if we hit a blank line (end of paragraph)
+            if ([string]::IsNullOrWhiteSpace($currentLine)) { break }
+            # Skip if we hit a block-level element
+            if ($currentLine -match '^(#{1,6}\s|```|!\[|>\s*|\||\*\s|\d+\.\s)') { break }
+
+            $endsWithHardBreak = $currentLine -match '  $'
+            $trimmedLine = $currentLine -replace '  $', ''
+
+            foreach ($inlineNode in (ConvertTo-AdfInline $trimmedLine)) {
+                $paraContent.Add($inlineNode)
+            }
+            $i++
+
+            if ($endsWithHardBreak -and $i -lt $Lines.Count -and -not [string]::IsNullOrWhiteSpace($Lines[$i])) {
+                $paraContent.Add(@{ type = 'hardBreak' })
+            }
+            else {
+                break
+            }
+        }
+        if ($paraContent.Count -gt 0) {
+            $nodes.Add(@{
+                    type    = 'paragraph'
+                    content = @($paraContent)
+                })
+        }
+    }
+
+    $nodes.ToArray()
+}
+
+# ---------------------------------------------------------------------------
+# Inline parser
+# ---------------------------------------------------------------------------
+
+function script:ConvertTo-AdfInline {
+    param([string]$Text)
+
+    if ([string]::IsNullOrEmpty($Text)) { return }
+
+    $nodes = [System.Collections.Generic.List[hashtable]]::new()
+
+    # Combined regex (single-quoted — no PS escape processing on backticks)
+    # Priority order: combined marks → link → bold → italic → strikethrough → code
+    # biText = ***bold italic*** (3 asterisks)
+    # beText = **_bold italic_** (bold wrapping italic)
+    # ebText = _**bold italic**_ (italic wrapping bold)
+    $pattern = '\*\*\*(?<biText>[^\*\n]+)\*\*\*|\*\*_(?<beText>[^_\n]+)_\*\*|_\*\*(?<ebText>[^\*\n]+)\*\*_|\[(?<lText>[^\]]+)\]\((?<lUrl>[^\)]+)\)|\*\*(?<bText>[^\*\n]+)\*\*|_(?<eText>[^_\n]+)_|~~(?<sText>[^~\n]+)~~|`(?<cText>[^`\n]+)`'
+
+    $lastEnd = 0
+    foreach ($m in [regex]::Matches($Text, $pattern)) {
+        # Plain text before this match
+        if ($m.Index -gt $lastEnd) {
+            $nodes.Add(@{ type = 'text'; text = $Text.Substring($lastEnd, $m.Index - $lastEnd) })
+        }
+
+        if ($m.Groups['biText'].Success) {
+            # ***bold italic*** - combined strong + em
+            $nodes.Add(@{ type = 'text'; text = $m.Groups['biText'].Value; marks = @(@{ type = 'strong' }, @{ type = 'em' }) })
+        }
+        elseif ($m.Groups['beText'].Success) {
+            # **_bold italic_** - combined strong + em
+            $nodes.Add(@{ type = 'text'; text = $m.Groups['beText'].Value; marks = @(@{ type = 'strong' }, @{ type = 'em' }) })
+        }
+        elseif ($m.Groups['ebText'].Success) {
+            # _**bold italic**_ - combined em + strong
+            $nodes.Add(@{ type = 'text'; text = $m.Groups['ebText'].Value; marks = @(@{ type = 'em' }, @{ type = 'strong' }) })
+        }
+        elseif ($m.Groups['lText'].Success) {
+            $nodes.Add(@{
+                    type  = 'text'
+                    text  = $m.Groups['lText'].Value
+                    marks = @(@{ type = 'link'; attrs = @{ href = $m.Groups['lUrl'].Value } })
+                })
+        }
+        elseif ($m.Groups['bText'].Success) {
+            $nodes.Add(@{ type = 'text'; text = $m.Groups['bText'].Value; marks = @(@{ type = 'strong' }) })
+        }
+        elseif ($m.Groups['eText'].Success) {
+            $nodes.Add(@{ type = 'text'; text = $m.Groups['eText'].Value; marks = @(@{ type = 'em' }) })
+        }
+        elseif ($m.Groups['sText'].Success) {
+            $nodes.Add(@{ type = 'text'; text = $m.Groups['sText'].Value; marks = @(@{ type = 'strike' }) })
+        }
+        elseif ($m.Groups['cText'].Success) {
+            $nodes.Add(@{ type = 'text'; text = $m.Groups['cText'].Value; marks = @(@{ type = 'code' }) })
+        }
+
+        $lastEnd = $m.Index + $m.Length
+    }
+
+    # Remaining plain text
+    if ($lastEnd -lt $Text.Length) {
+        $nodes.Add(@{ type = 'text'; text = $Text.Substring($lastEnd) })
+    }
+
+    $nodes.ToArray()
+}
+
+# ---------------------------------------------------------------------------
+# Table parser
+# ---------------------------------------------------------------------------
+
+function script:ConvertTo-AdfTable {
+    param([System.Collections.Generic.List[string]]$TableLines)
+
+    if ($TableLines.Count -lt 2) { return $null }
+
+    $tableRows = [System.Collections.Generic.List[hashtable]]::new()
+    $isHeader = $true
+
+    foreach ($tLine in $TableLines) {
+        # Skip separator rows: | --- | :---: | ---: | (with or without spaces)
+        if ($tLine -match '^\|[-:\s|]+\|$') { continue }
+
+        # Split on | and trim — the leading/trailing | produce empty strings, filter those out
+        $cells = @($tLine -split '\|' |
+                Where-Object { $_ -ne '' } |
+                ForEach-Object { $_.Trim() })
+
+        $cellType = if ($isHeader) { 'tableHeader' } else { 'tableCell' }
+        $cellNodes = @($cells |
+                ForEach-Object {
+                    @{
+                        type    = $cellType
+                        attrs   = @{}
+                        content = @(@{
+                                type    = 'paragraph'
+                                content = @(ConvertTo-AdfInline $_)
+                            })
+                    }
+                })
+
+        $tableRows.Add(@{ type = 'tableRow'; content = $cellNodes })
+        $isHeader = $false
+    }
+
+    if ($tableRows.Count -eq 0) { return $null }
+
+    @{
+        type    = 'table'
+        attrs   = @{ isNumberColumnEnabled = $false; layout = 'align-start'; localId = [guid]::NewGuid().ToString() }
+        content = @($tableRows)
+    }
+}
+
+# ---------------------------------------------------------------------------
+# List parser with 2-level nesting support
+# ---------------------------------------------------------------------------
+
+function script:ConvertTo-AdfList {
+    param(
+        [string[]]$Lines,
+        [int]$StartIndex,
+        [ValidateSet('bullet', 'ordered')]
+        [string]$ListType,
+        [int]$IndentLevel
+    )
+
+    $listItems = [System.Collections.Generic.List[hashtable]]::new()
+    $i = $StartIndex
+
+    # Indentation pattern for current level (each level = 2 spaces)
+    $indentSpaces = ' ' * ($IndentLevel * 2)
+    if ($ListType -eq 'bullet') {
+        $itemPattern = "^$indentSpaces\*\s+(?!\[[ x]\])(.+)$"
+    }
+    else {
+        $itemPattern = "^$indentSpaces\d+\.\s+(.+)$"
+    }
+
+    # Pattern to detect nested items (one level deeper)
+    $nestedIndent = ' ' * (($IndentLevel + 1) * 2)
+    $nestedBulletPattern = "^$nestedIndent\*\s+"
+    $nestedOrderedPattern = "^$nestedIndent\d+\.\s+"
+
+    while ($i -lt $Lines.Count -and $Lines[$i] -match $itemPattern) {
+        $itemText = $matches[1]
+        $itemContent = [System.Collections.Generic.List[hashtable]]::new()
+        $itemContent.Add(@{
+                type    = 'paragraph'
+                content = @(ConvertTo-AdfInline $itemText)
+            })
+        $i++
+
+        # Check for nested list (only if we haven't reached max depth of 2)
+        if ($IndentLevel -lt 1 -and $i -lt $Lines.Count) {
+            if ($Lines[$i] -match $nestedBulletPattern) {
+                $nestedResult = ConvertTo-AdfList -Lines $Lines -StartIndex $i -ListType 'bullet' -IndentLevel ($IndentLevel + 1)
+                $itemContent.Add($nestedResult.Node)
+                $i = $nestedResult.NextIndex
+            }
+            elseif ($Lines[$i] -match $nestedOrderedPattern) {
+                $nestedResult = ConvertTo-AdfList -Lines $Lines -StartIndex $i -ListType 'ordered' -IndentLevel ($IndentLevel + 1)
+                $itemContent.Add($nestedResult.Node)
+                $i = $nestedResult.NextIndex
+            }
+        }
+
+        $listItems.Add(@{
+                type    = 'listItem'
+                content = @($itemContent)
+            })
+    }
+
+    $listNode = if ($ListType -eq 'bullet') {
+        @{ type = 'bulletList'; content = @($listItems) }
+    }
+    else {
+        @{ type = 'orderedList'; attrs = @{ order = 1 }; content = @($listItems) }
+    }
+
+    @{
+        Node      = $listNode
+        NextIndex = $i
+    }
+}

--- a/Tests/Fixtures/adf.sample.json
+++ b/Tests/Fixtures/adf.sample.json
@@ -1,0 +1,669 @@
+{
+  "type": "doc",
+  "version": 1,
+  "content": [
+    {
+      "type": "heading",
+      "attrs": {
+        "level": 1
+      },
+      "content": [
+        {
+          "type": "text",
+          "text": "Header 1"
+        }
+      ]
+    },
+    {
+      "type": "heading",
+      "attrs": {
+        "level": 2
+      },
+      "content": [
+        {
+          "type": "text",
+          "text": "Header 2"
+        }
+      ]
+    },
+    {
+      "type": "heading",
+      "attrs": {
+        "level": 3
+      },
+      "content": [
+        {
+          "type": "text",
+          "text": "Header 3"
+        }
+      ]
+    },
+    {
+      "type": "heading",
+      "attrs": {
+        "level": 4
+      },
+      "content": [
+        {
+          "type": "text",
+          "text": "Header 4"
+        }
+      ]
+    },
+    {
+      "type": "heading",
+      "attrs": {
+        "level": 5
+      },
+      "content": [
+        {
+          "type": "text",
+          "text": "Header 5"
+        }
+      ]
+    },
+    {
+      "type": "heading",
+      "attrs": {
+        "level": 6
+      },
+      "content": [
+        {
+          "type": "text",
+          "text": "Header 6"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "content": [
+        {
+          "type": "text",
+          "text": "Normal text. Including "
+        },
+        {
+          "type": "text",
+          "text": "BOLD",
+          "marks": [
+            {
+              "type": "strong"
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "text": ", "
+        },
+        {
+          "type": "text",
+          "text": "italic,",
+          "marks": [
+            {
+              "type": "em"
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "text": " "
+        },
+        {
+          "type": "text",
+          "text": "underscored",
+          "marks": [
+            {
+              "type": "underline"
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "text": ", "
+        },
+        {
+          "type": "text",
+          "text": "struked out",
+          "marks": [
+            {
+              "type": "strike"
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "text": ", "
+        },
+        {
+          "type": "text",
+          "text": "code",
+          "marks": [
+            {
+              "type": "code"
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "text": ", "
+        },
+        {
+          "type": "text",
+          "text": "subscript",
+          "marks": [
+            {
+              "attrs": {
+                "type": "sub"
+              },
+              "type": "subsup"
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "text": " and "
+        },
+        {
+          "type": "text",
+          "text": "superscript",
+          "marks": [
+            {
+              "attrs": {
+                "type": "sup"
+              },
+              "type": "subsup"
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "text": "."
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "content": [
+        {
+          "type": "text",
+          "text": "Normal text. Including "
+        },
+        {
+          "type": "text",
+          "text": "blue",
+          "marks": [
+            {
+              "type": "textColor",
+              "attrs": {
+                "color": "#0747a6"
+              }
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "text": ", "
+        },
+        {
+          "type": "text",
+          "text": "red",
+          "marks": [
+            {
+              "type": "textColor",
+              "attrs": {
+                "color": "#ff5630"
+              }
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "text": " and "
+        },
+        {
+          "type": "text",
+          "text": "yellow",
+          "marks": [
+            {
+              "type": "textColor",
+              "attrs": {
+                "color": "#fff0b3"
+              }
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "text": "."
+        }
+      ]
+    },
+    {
+      "type": "bulletList",
+      "content": [
+        {
+          "type": "listItem",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [
+                {
+                  "type": "text",
+                  "text": "unordered"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "listItem",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [
+                {
+                  "type": "text",
+                  "text": "bullet"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "listItem",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [
+                {
+                  "type": "text",
+                  "text": "list"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "orderedList",
+      "attrs": {
+        "order": 1
+      },
+      "content": [
+        {
+          "type": "listItem",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [
+                {
+                  "type": "text",
+                  "text": "ordered"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "listItem",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [
+                {
+                  "type": "text",
+                  "text": "bullet list"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "taskList",
+      "content": [
+        {
+          "type": "taskItem",
+          "content": [
+            {
+              "type": "text",
+              "text": "Action Item"
+            }
+          ],
+          "attrs": {
+            "localId": "06b2a700-93dd-4293-a7ea-43e6a5a885da",
+            "state": "TODO"
+          }
+        }
+      ],
+      "attrs": {
+        "localId": "5a2a7a3d-6c9f-4069-ab3c-b5569d7a2e1f"
+      }
+    },
+    {
+      "type": "paragraph",
+      "content": [
+        {
+          "type": "text",
+          "text": "link",
+          "marks": [
+            {
+              "type": "link",
+              "attrs": {
+                "href": "https://github.com/atlassianps"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "mediaSingle",
+      "attrs": {
+        "width": 250,
+        "widthType": "pixel",
+        "layout": "align-start"
+      },
+      "content": [
+        {
+          "type": "media",
+          "attrs": {
+            "type": "external",
+            "url": "https://camo.githubusercontent.com/3f9366e78be7286a8a8554c7c5fb19567a4acd2f504e109525ccf91003f1a85a/68747470733a2f2f61746c61737369616e70732e6f72672f6173736574732f696d672f41746c61737369616e50532e706e67",
+            "alt": "alt text",
+            "height": 128,
+            "width": 128
+          }
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "content": [
+        {
+          "type": "text",
+          "text": "Mention: "
+        },
+        {
+          "type": "mention",
+          "attrs": {
+            "id": "557058:15b2a9f1-1893-42b3-a6b5-ab899c878d00",
+            "text": "@Oliver Lipkau",
+            "accessLevel": "",
+            "localId": "7398a245-20db-4358-973d-a4f13e6907a7"
+          }
+        },
+        {
+          "type": "text",
+          "text": " "
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "content": [
+        {
+          "type": "emoji",
+          "attrs": {
+            "shortName": ":smiley:",
+            "id": "1f603",
+            "text": "😃"
+          }
+        },
+        {
+          "type": "text",
+          "text": " "
+        },
+        {
+          "type": "emoji",
+          "attrs": {
+            "shortName": ":sweat_smile:",
+            "id": "1f605",
+            "text": "😅"
+          }
+        },
+        {
+          "type": "text",
+          "text": " "
+        }
+      ]
+    },
+    {
+      "type": "table",
+      "attrs": {
+        "isNumberColumnEnabled": false,
+        "layout": "align-start",
+        "localId": "d27c4fcb-173e-46d7-8237-9a08b9f1ea7c"
+      },
+      "content": [
+        {
+          "type": "tableRow",
+          "content": [
+            {
+              "type": "tableHeader",
+              "attrs": {},
+              "content": [
+                {
+                  "type": "paragraph",
+                  "content": [
+                    {
+                      "type": "text",
+                      "text": "Table",
+                      "marks": [
+                        {
+                          "type": "strong"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "tableHeader",
+              "attrs": {},
+              "content": [
+                {
+                  "type": "paragraph",
+                  "content": [
+                    {
+                      "type": "text",
+                      "text": "with",
+                      "marks": [
+                        {
+                          "type": "strong"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "tableHeader",
+              "attrs": {},
+              "content": [
+                {
+                  "type": "paragraph",
+                  "content": [
+                    {
+                      "type": "text",
+                      "text": "header",
+                      "marks": [
+                        {
+                          "type": "strong"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "tableRow",
+          "content": [
+            {
+              "type": "tableCell",
+              "attrs": {},
+              "content": [
+                {
+                  "type": "paragraph",
+                  "content": [
+                    {
+                      "type": "text",
+                      "text": "lorem"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "tableCell",
+              "attrs": {},
+              "content": [
+                {
+                  "type": "paragraph",
+                  "content": [
+                    {
+                      "type": "text",
+                      "text": "ipsum"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "tableCell",
+              "attrs": {},
+              "content": [
+                {
+                  "type": "paragraph",
+                  "content": [
+                    {
+                      "type": "text",
+                      "text": "dolor"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "tableRow",
+          "content": [
+            {
+              "type": "tableCell",
+              "attrs": {},
+              "content": [
+                {
+                  "type": "paragraph"
+                }
+              ]
+            },
+            {
+              "type": "tableCell",
+              "attrs": {},
+              "content": [
+                {
+                  "type": "paragraph"
+                }
+              ]
+            },
+            {
+              "type": "tableCell",
+              "attrs": {},
+              "content": [
+                {
+                  "type": "paragraph"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "codeBlock",
+      "attrs": {
+        "language": "python"
+      },
+      "content": [
+        {
+          "type": "text",
+          "text": "import os\n\nprint(os.path('.'))"
+        }
+      ]
+    },
+    {
+      "type": "panel",
+      "content": [
+        {
+          "type": "paragraph",
+          "content": [
+            {
+              "type": "text",
+              "text": "info widget"
+            }
+          ]
+        }
+      ],
+      "attrs": {
+        "panelType": "info"
+      }
+    },
+    {
+      "type": "blockquote",
+      "content": [
+        {
+          "type": "paragraph",
+          "content": [
+            {
+              "type": "text",
+              "text": "quote"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "decisionList",
+      "content": [
+        {
+          "type": "decisionItem",
+          "content": [
+            {
+              "type": "text",
+              "text": "decision"
+            }
+          ],
+          "attrs": {
+            "localId": "c4ae6d64-fc6c-475c-84f8-e074706ccb3f",
+            "state": "DECIDED"
+          }
+        }
+      ],
+      "attrs": {
+        "localId": "332e524c-ac3a-413b-b6c2-542b5f2d1bab"
+      }
+    },
+    {
+      "type": "paragraph",
+      "content": [
+        {
+          "type": "date",
+          "attrs": {
+            "timestamp": "1775952000000"
+          }
+        },
+        {
+          "type": "text",
+          "text": " "
+        }
+      ]
+    }
+  ]
+}

--- a/Tests/Fixtures/adf.sample.md
+++ b/Tests/Fixtures/adf.sample.md
@@ -1,0 +1,48 @@
+# Header 1
+
+## Header 2
+
+### Header 3
+
+#### Header 4
+
+##### Header 5
+
+###### Header 6
+
+Normal text. Including **BOLD**, _italic_, underscored, ~~struked out~~, `code`, subscript and superscript.
+
+Normal text. Including blue, red and yellow.
+
+* unordered
+* bullet
+* list
+
+1. ordered
+2. bullet list
+
+* [ ] Action Item
+
+[link](https://github.com/atlassianps)
+
+![alt text](https://atlassianps.org/assets/img/AtlassianPS.png)
+
+Mention: @Oliver Lipkau
+
+| Table | with  | header |
+| ----- | ----- | ------ |
+| lorem | ipsum | dolor  |
+
+```python
+import os
+
+print(os.path('.'))
+```
+
+info widget
+
+> quote
+
+decision
+
+2026-04-12

--- a/Tests/Functions/Private/ConvertTo-JiraComment.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraComment.Unit.Tests.ps1
@@ -110,5 +110,56 @@ InModuleScope JiraPS {
                 }
             }
         }
+
+        Context "Jira Cloud — ADF body" {
+            BeforeAll {
+                # On Jira Cloud (API v3), comment body is returned as ADF JSON
+                $adfCommentJson = @"
+{
+    "self": "$jiraServer/rest/api/3/issue/41701/comment/90731",
+    "id": "90731",
+    "author": {
+        "self": "$jiraServer/rest/api/3/user?accountId=abc123",
+        "accountId": "abc123",
+        "displayName": "$jiraUserDisplayName",
+        "active": true,
+        "avatarUrls": {}
+    },
+    "body": {
+        "type": "doc",
+        "version": 1,
+        "content": [
+            {
+                "type": "paragraph",
+                "content": [
+                    { "type": "text", "text": "ADF comment body" }
+                ]
+            }
+        ]
+    },
+    "updateAuthor": {
+        "self": "$jiraServer/rest/api/3/user?accountId=abc123",
+        "accountId": "abc123",
+        "displayName": "$jiraUserDisplayName",
+        "active": true,
+        "avatarUrls": {}
+    },
+    "created": "2015-05-01T16:24:38.000-0500",
+    "updated": "2015-05-01T16:24:38.000-0500"
+}
+"@
+                $script:adfCommentObject = ConvertFrom-Json -InputObject $adfCommentJson
+                $script:adfResult = ConvertTo-JiraComment -InputObject $adfCommentObject
+            }
+
+            It "extracts plain text from an ADF body" {
+                $adfResult.Body | Should -Be "ADF comment body"
+            }
+
+            It "Body is a plain string, not a PSCustomObject" {
+                $adfResult.Body | Should -BeOfType [string]
+            }
+        }
     }
 }
+

--- a/Tests/Functions/Public/ConvertFrom-AtlassianDocumentFormat.Unit.Tests.ps1
+++ b/Tests/Functions/Public/ConvertFrom-AtlassianDocumentFormat.Unit.Tests.ps1
@@ -1,0 +1,509 @@
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+
+BeforeDiscovery {
+    . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+
+    Initialize-TestEnvironment
+    $script:moduleToTest = Resolve-ModuleSource
+
+    Import-Module $script:moduleToTest -Force -ErrorAction Stop
+}
+
+InModuleScope JiraPS {
+    Describe "ConvertFrom-AtlassianDocumentFormat" -Tag 'Unit' {
+        BeforeAll {
+            . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+
+            #region Inline ADF fixtures ────────────────────────────────────
+
+            $script:adfPlainParagraph = ConvertFrom-Json @'
+{ "type": "doc", "version": 1, "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "Hello world" }] }] }
+'@
+            $script:adfMultiParagraph = ConvertFrom-Json @'
+{
+  "type": "doc", "version": 1,
+  "content": [
+    { "type": "paragraph", "content": [{ "type": "text", "text": "First" }] },
+    { "type": "paragraph", "content": [{ "type": "text", "text": "Second" }] }
+  ]
+}
+'@
+
+            $script:adfHeadings = ConvertFrom-Json @'
+{
+  "type": "doc", "version": 1,
+  "content": [
+    { "type": "heading", "attrs": { "level": 1 }, "content": [{ "type": "text", "text": "Header 1" }] },
+    { "type": "heading", "attrs": { "level": 2 }, "content": [{ "type": "text", "text": "Header 2" }] },
+    { "type": "heading", "attrs": { "level": 6 }, "content": [{ "type": "text", "text": "Header 6" }] }
+  ]
+}
+'@
+
+            $script:adfInlineMarks = ConvertFrom-Json @'
+{
+  "type": "doc", "version": 1,
+  "content": [{
+    "type": "paragraph",
+    "content": [
+      { "type": "text", "text": "plain " },
+      { "type": "text", "text": "BOLD", "marks": [{ "type": "strong" }] },
+      { "type": "text", "text": " " },
+      { "type": "text", "text": "italic", "marks": [{ "type": "em" }] },
+      { "type": "text", "text": " " },
+      { "type": "text", "text": "struck", "marks": [{ "type": "strike" }] },
+      { "type": "text", "text": " " },
+      { "type": "text", "text": "code", "marks": [{ "type": "code" }] },
+      { "type": "text", "text": " " },
+      { "type": "text", "text": "underlined", "marks": [{ "type": "underline" }] }
+    ]
+  }]
+}
+'@
+
+            $script:adfLink = ConvertFrom-Json @'
+{
+  "type": "doc", "version": 1,
+  "content": [{
+    "type": "paragraph",
+    "content": [
+      { "type": "text", "text": "click", "marks": [{ "type": "link", "attrs": { "href": "https://example.com" } }] }
+    ]
+  }]
+}
+'@
+
+            $script:adfLists = ConvertFrom-Json @'
+{
+  "type": "doc", "version": 1,
+  "content": [
+    {
+      "type": "bulletList",
+      "content": [
+        { "type": "listItem", "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "alpha" }] }] },
+        { "type": "listItem", "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "beta" }] }] }
+      ]
+    },
+    {
+      "type": "orderedList", "attrs": { "order": 1 },
+      "content": [
+        { "type": "listItem", "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "first" }] }] },
+        { "type": "listItem", "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "second" }] }] }
+      ]
+    },
+    {
+      "type": "taskList", "attrs": { "localId": "t1" },
+      "content": [
+        { "type": "taskItem", "attrs": { "localId": "i1", "state": "TODO" }, "content": [{ "type": "text", "text": "do this" }] },
+        { "type": "taskItem", "attrs": { "localId": "i2", "state": "DONE" }, "content": [{ "type": "text", "text": "done that" }] }
+      ]
+    }
+  ]
+}
+'@
+
+            $script:adfBlocks = ConvertFrom-Json @'
+{
+  "type": "doc", "version": 1,
+  "content": [
+    { "type": "codeBlock", "attrs": { "language": "python" }, "content": [{ "type": "text", "text": "print(42)" }] },
+    { "type": "blockquote", "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "quoted" }] }] },
+    {
+      "type": "panel", "attrs": { "panelType": "info" },
+      "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "info panel" }] }]
+    }
+  ]
+}
+'@
+
+            $script:adfTable = ConvertFrom-Json @'
+{
+  "type": "doc", "version": 1,
+  "content": [{
+    "type": "table",
+    "attrs": { "isNumberColumnEnabled": false, "layout": "align-start" },
+    "content": [
+      {
+        "type": "tableRow",
+        "content": [
+          { "type": "tableHeader", "attrs": {}, "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "Name" }] }] },
+          { "type": "tableHeader", "attrs": {}, "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "Value" }] }] }
+        ]
+      },
+      {
+        "type": "tableRow",
+        "content": [
+          { "type": "tableCell", "attrs": {}, "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "foo" }] }] },
+          { "type": "tableCell", "attrs": {}, "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "bar" }] }] }
+        ]
+      }
+    ]
+  }]
+}
+'@
+
+            $script:adfSpecialInline = ConvertFrom-Json @'
+{
+  "type": "doc", "version": 1,
+  "content": [{
+    "type": "paragraph",
+    "content": [
+      { "type": "mention", "attrs": { "id": "abc", "text": "@Oliver Lipkau", "accessLevel": "" } },
+      { "type": "text", "text": " " },
+      { "type": "emoji", "attrs": { "shortName": ":smiley:", "id": "1f603", "text": "\ud83d\ude03" } },
+      { "type": "text", "text": " " },
+      { "type": "date", "attrs": { "timestamp": "1775952000000" } }
+    ]
+  }]
+}
+'@
+
+            $script:adfColoredText = ConvertFrom-Json @'
+{
+  "type": "doc", "version": 1,
+  "content": [{
+    "type": "paragraph",
+    "content": [
+      { "type": "text", "text": "blue", "marks": [{ "type": "textColor", "attrs": { "color": "#0747a6" } }] },
+      { "type": "text", "text": " and " },
+      { "type": "text", "text": "red", "marks": [{ "type": "textColor", "attrs": { "color": "#ff5630" } }] }
+    ]
+  }]
+}
+'@
+
+            $script:adfSubSup = ConvertFrom-Json @'
+{
+  "type": "doc", "version": 1,
+  "content": [{
+    "type": "paragraph",
+    "content": [
+      { "type": "text", "text": "H" },
+      { "type": "text", "text": "2", "marks": [{ "type": "subsup", "attrs": { "type": "sub" } }] },
+      { "type": "text", "text": "O" }
+    ]
+  }]
+}
+'@
+
+            $script:adfImage = ConvertFrom-Json @'
+{
+  "type": "doc", "version": 1,
+  "content": [{
+    "type": "mediaSingle", "attrs": { "layout": "align-start" },
+    "content": [{
+      "type": "media",
+      "attrs": { "type": "external", "url": "https://example.com/image.png", "alt": "logo" }
+    }]
+  }]
+}
+'@
+
+            $script:adfDecisionList = ConvertFrom-Json @'
+{
+  "type": "doc", "version": 1,
+  "content": [{
+    "type": "decisionList", "attrs": { "localId": "d1" },
+    "content": [
+      { "type": "decisionItem", "attrs": { "localId": "i1", "state": "DECIDED" }, "content": [{ "type": "text", "text": "accepted" }] }
+    ]
+  }]
+}
+'@
+            #endregion
+        }
+
+        Context "Smoke test — real Jira Cloud ADF" {
+            BeforeAll {
+                $adfJson = Get-Content -Raw "$PSScriptRoot/../../Fixtures/adf.sample.json"
+                $script:fullAdf = ConvertFrom-Json $adfJson
+                $script:fullResult = ConvertFrom-AtlassianDocumentFormat -InputObject $fullAdf
+            }
+
+            It "returns a non-empty string" {
+                $fullResult | Should -Not -BeNullOrEmpty
+                $fullResult | Should -BeOfType [string]
+            }
+
+            It "contains Markdown heading markers" {
+                $fullResult | Should -Match '(?m)^# '
+                $fullResult | Should -Match '(?m)^###### '
+            }
+
+            It "contains bold and strikethrough markers" {
+                $fullResult | Should -Match '\*\*.+\*\*'
+                $fullResult | Should -Match '~~.+~~'
+            }
+
+            It "contains bullet and ordered list markers" {
+                $fullResult | Should -Match '(?m)^\* '
+                $fullResult | Should -Match '(?m)^\d+\. '
+            }
+
+            It "contains a code fence" {
+                $fullResult | Should -Match '(?m)^```\w+$'
+            }
+
+            It "contains a blockquote marker" {
+                $fullResult | Should -Match '(?m)^> '
+            }
+
+            It "contains table pipe delimiters" {
+                $fullResult | Should -Match '(?m)^\|.+\|$'
+            }
+        }
+
+        Context "Input handling" {
+            It "returns a plain string unchanged" {
+                ConvertFrom-AtlassianDocumentFormat -InputObject "plain text" | Should -Be "plain text"
+            }
+
+            It "returns an empty string unchanged" {
+                ConvertFrom-AtlassianDocumentFormat -InputObject "" | Should -Be ""
+            }
+
+            It "returns null for null input" {
+                ConvertFrom-AtlassianDocumentFormat -InputObject $null | Should -BeNullOrEmpty
+            }
+
+            It "always returns a [string] for ADF input" {
+                ConvertFrom-AtlassianDocumentFormat -InputObject $adfPlainParagraph | Should -BeOfType [string]
+            }
+        }
+
+        Context "Basic structure" {
+            It "extracts text from a single paragraph" {
+                ConvertFrom-AtlassianDocumentFormat -InputObject $adfPlainParagraph | Should -Be "Hello world"
+            }
+
+            It "separates multiple paragraphs with a blank line" {
+                $result = ConvertFrom-AtlassianDocumentFormat -InputObject $adfMultiParagraph
+                $result | Should -Be "First`n`nSecond"
+            }
+        }
+
+        Context "Headings" {
+            BeforeAll { $script:h = ConvertFrom-AtlassianDocumentFormat -InputObject $adfHeadings }
+
+            It "renders H1 with a single hash" {
+                $h | Should -Match '(?m)^# Header 1$'
+            }
+
+            It "renders H2 with two hashes" {
+                $h | Should -Match '(?m)^## Header 2$'
+            }
+
+            It "renders H6 with six hashes" {
+                $h | Should -Match '(?m)^###### Header 6$'
+            }
+        }
+
+        Context "Inline marks" {
+            BeforeAll { $script:inl = ConvertFrom-AtlassianDocumentFormat -InputObject $adfInlineMarks }
+
+            It "renders strong mark as **text**" {
+                $inl | Should -Match '\*\*BOLD\*\*'
+            }
+
+            It "renders em mark as _text_" {
+                $inl | Should -Match '_italic_'
+            }
+
+            It "renders strike mark as ~~text~~" {
+                $inl | Should -Match '~~struck~~'
+            }
+
+            It 'renders code mark as `text`' {
+                $inl | Should -Match '`code`'
+            }
+
+            It "renders underline as plain text (no HTML tag)" {
+                $inl | Should -Match '\bunderlined\b'
+                $inl | Should -Not -Match '<u>'
+            }
+        }
+
+        Context "Unsupported marks (graceful fallback)" {
+            It "renders textColor-marked text as plain text" {
+                $result = ConvertFrom-AtlassianDocumentFormat -InputObject $adfColoredText
+                $result | Should -Be 'blue and red'
+            }
+
+            It "renders subscript as plain text" {
+                $result = ConvertFrom-AtlassianDocumentFormat -InputObject $adfSubSup
+                $result | Should -Be 'H2O'
+            }
+        }
+
+        Context "Links" {
+            It 'renders a link mark as [text](url)' {
+                $result = ConvertFrom-AtlassianDocumentFormat -InputObject $adfLink
+                $result | Should -Be '[click](https://example.com)'
+            }
+        }
+
+        Context "Lists" {
+            BeforeAll { $script:lst = ConvertFrom-AtlassianDocumentFormat -InputObject $adfLists }
+
+            It "renders bullet list items with * prefix" {
+                $lst | Should -Match '(?m)^\* alpha$'
+                $lst | Should -Match '(?m)^\* beta$'
+            }
+
+            It "renders ordered list items with sequential N. prefix" {
+                $lst | Should -Match '(?m)^1\. first$'
+                $lst | Should -Match '(?m)^2\. second$'
+            }
+
+            It "renders unchecked task items as '* [ ] text'" {
+                $lst | Should -Match '(?m)^\* \[ \] do this$'
+            }
+
+            It "renders checked task items as '* [x] text'" {
+                $lst | Should -Match '(?m)^\* \[x\] done that$'
+            }
+        }
+
+        Context "Block types" {
+            BeforeAll { $script:blk = ConvertFrom-AtlassianDocumentFormat -InputObject $adfBlocks }
+
+            It "renders code block with opening and closing fences" {
+                $blk | Should -Match '(?m)^```python$'
+                $blk | Should -Match 'print\(42\)'
+                $blk | Should -Match '(?m)^```$'
+            }
+
+            It "renders blockquote lines with > prefix" {
+                $blk | Should -Match '(?m)^> quoted$'
+            }
+
+            It "renders panel content as plain text (no wrapper)" {
+                $blk | Should -Match '\binfo panel\b'
+            }
+        }
+
+        Context "Table" {
+            BeforeAll {
+                $script:tbl = ConvertFrom-AtlassianDocumentFormat -InputObject $adfTable
+                $script:tblLines = $tbl -split "`n"
+            }
+
+            It "renders header row with pipe delimiters" {
+                $tblLines[0] | Should -Be '| Name | Value |'
+            }
+
+            It "renders a separator row after the header" {
+                $tblLines[1] | Should -Match '^\| -{3,} \| -{3,} \|$'
+            }
+
+            It "renders data row with pipe delimiters" {
+                $tblLines[2] | Should -Be '| foo | bar |'
+            }
+
+            It "produces exactly 3 lines (header + separator + data)" {
+                $tblLines | Should -HaveCount 3
+            }
+        }
+
+        Context "Special inline nodes" {
+            BeforeAll { $script:spc = ConvertFrom-AtlassianDocumentFormat -InputObject $adfSpecialInline }
+
+            It "renders mention using attrs.text" {
+                $spc | Should -Match '@Oliver Lipkau'
+            }
+
+            It "renders emoji using attrs.text" {
+                $spc | Should -Match ([regex]::Escape('😃'))
+            }
+
+            It "renders date as ISO 8601 string (yyyy-MM-dd)" {
+                $spc | Should -Match '\d{4}-\d{2}-\d{2}'
+            }
+        }
+
+        Context "Image (mediaSingle)" {
+            It 'renders as ![alt](url)' {
+                $result = ConvertFrom-AtlassianDocumentFormat -InputObject $adfImage
+                $result | Should -Be '![logo](https://example.com/image.png)'
+            }
+        }
+
+        Context "Decision list" {
+            It "renders decision item text" {
+                $result = ConvertFrom-AtlassianDocumentFormat -InputObject $adfDecisionList
+                $result | Should -Be 'accepted'
+            }
+        }
+
+        Context "Negative / edge cases" {
+            It "returns the string representation of a numeric input" {
+                $result = ConvertFrom-AtlassianDocumentFormat -InputObject 42
+                $result | Should -BeOfType [string]
+                $result | Should -Be "42"
+            }
+
+            It "returns empty/null for an ADF doc with empty content array" {
+                $emptyDoc = [PSCustomObject]@{ type = 'doc'; version = 1; content = @() }
+                ConvertFrom-AtlassianDocumentFormat -InputObject $emptyDoc | Should -BeNullOrEmpty
+            }
+
+            It "does not throw for an ADF doc with no content property" {
+                $noContent = [PSCustomObject]@{ type = 'doc'; version = 1 }
+                { ConvertFrom-AtlassianDocumentFormat -InputObject $noContent } | Should -Not -Throw
+            }
+
+            It "silently skips unknown node types without losing subsequent nodes" {
+                $doc = [PSCustomObject]@{
+                    type = 'doc'; version = 1
+                    content = @(
+                        [PSCustomObject]@{ type = 'unknownWidget' },
+                        [PSCustomObject]@{
+                            type    = 'paragraph'
+                            content = @([PSCustomObject]@{ type = 'text'; text = 'after unknown' })
+                        }
+                    )
+                }
+                $result = ConvertFrom-AtlassianDocumentFormat -InputObject $doc
+                $result | Should -Be 'after unknown'
+            }
+
+            It "does not throw for a heading with no content array" {
+                $doc = [PSCustomObject]@{
+                    type = 'doc'; version = 1
+                    content = @(
+                        [PSCustomObject]@{ type = 'heading'; attrs = @{ level = 1 } }
+                    )
+                }
+                { ConvertFrom-AtlassianDocumentFormat -InputObject $doc } | Should -Not -Throw
+            }
+
+            It "skips paragraphs with null content" {
+                $doc = [PSCustomObject]@{
+                    type = 'doc'; version = 1
+                    content = @(
+                        [PSCustomObject]@{ type = 'paragraph'; content = $null },
+                        [PSCustomObject]@{
+                            type    = 'paragraph'
+                            content = @([PSCustomObject]@{ type = 'text'; text = 'visible' })
+                        }
+                    )
+                }
+                $result = ConvertFrom-AtlassianDocumentFormat -InputObject $doc
+                $result | Should -Be 'visible'
+            }
+        }
+
+        Context "Pipeline support" {
+            It "accepts input from the pipeline" {
+                "hello" | ConvertFrom-AtlassianDocumentFormat | Should -Be "hello"
+            }
+
+            It "processes multiple ADF objects from the pipeline" {
+                $results = $adfPlainParagraph, "plain" | ConvertFrom-AtlassianDocumentFormat
+                $results | Should -HaveCount 2
+                $results[0] | Should -Be "Hello world"
+                $results[1] | Should -Be "plain"
+            }
+        }
+    }
+}

--- a/Tests/Functions/Public/ConvertTo-AtlassianDocumentFormat.Unit.Tests.ps1
+++ b/Tests/Functions/Public/ConvertTo-AtlassianDocumentFormat.Unit.Tests.ps1
@@ -1,0 +1,584 @@
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+
+BeforeDiscovery {
+    . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+
+    Initialize-TestEnvironment
+    $script:moduleToTest = Resolve-ModuleSource
+
+    Import-Module $script:moduleToTest -Force -ErrorAction Stop
+}
+
+InModuleScope JiraPS {
+    Describe "ConvertTo-AtlassianDocumentFormat" -Tag 'Unit' {
+        BeforeAll {
+            . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+
+            # Load the sample Markdown from the project root
+            $script:sampleMd = Get-Content -Raw "$PSScriptRoot/../../Fixtures/adf.sample.md"
+
+            # Helper: find all nodes of a given type anywhere in a doc (depth-first)
+            function script:Find-AdfNode {
+                param($Doc, [string]$Type)
+                $results = [System.Collections.Generic.List[object]]::new()
+                function recurse($node) {
+                    if ($node -is [hashtable] -and $node.type -eq $Type) { $results.Add($node) }
+                    if ($node -is [hashtable] -and $node.ContainsKey('content') -and $node.content) {
+                        foreach ($c in $node.content) { recurse $c }
+                    }
+                }
+                foreach ($n in $Doc.content) { recurse $n }
+                $results
+            }
+        }
+
+        Context "Input handling" {
+            It "returns a doc with type = 'doc' and version = 1" {
+                $result = ConvertTo-AtlassianDocumentFormat -Markdown "hello"
+                $result.type    | Should -Be "doc"
+                $result.version | Should -Be 1
+            }
+
+            It "returns an empty content array for an empty string" {
+                $result = ConvertTo-AtlassianDocumentFormat -Markdown ""
+                $result.content | Should -HaveCount 0
+            }
+
+            It "returns an empty content array for whitespace-only input" {
+                $result = ConvertTo-AtlassianDocumentFormat -Markdown "   "
+                $result.content | Should -HaveCount 0
+            }
+
+            It "accepts input from the pipeline" {
+                $result = "hello" | ConvertTo-AtlassianDocumentFormat
+                $result.type | Should -Be "doc"
+            }
+        }
+
+        Context "Headings" {
+            It "converts '<md>' to a heading node with level <level>" -TestCases @(
+                @{ level = 1; md = '# Header 1'; text = 'Header 1' }
+                @{ level = 2; md = '## Header 2'; text = 'Header 2' }
+                @{ level = 3; md = '### Header 3'; text = 'Header 3' }
+                @{ level = 4; md = '#### Header 4'; text = 'Header 4' }
+                @{ level = 5; md = '##### Header 5'; text = 'Header 5' }
+                @{ level = 6; md = '###### Header 6'; text = 'Header 6' }
+            ) {
+                $result = ConvertTo-AtlassianDocumentFormat -Markdown $md
+                $node = $result.content[0]
+                $node.type          | Should -Be "heading"
+                $node.attrs.level   | Should -Be $level
+                $node.content[0].text | Should -Be $text
+            }
+        }
+
+        Context "Paragraph" {
+            It "converts a plain text line to a paragraph node" {
+                $result = ConvertTo-AtlassianDocumentFormat -Markdown "Normal text"
+                $result.content[0].type             | Should -Be "paragraph"
+                $result.content[0].content[0].type  | Should -Be "text"
+                $result.content[0].content[0].text  | Should -Be "Normal text"
+            }
+
+            It "emits separate paragraph nodes for lines separated by a blank line" {
+                $result = ConvertTo-AtlassianDocumentFormat -Markdown "First`n`nSecond"
+                $result.content | Should -HaveCount 2
+                $result.content[0].type | Should -Be "paragraph"
+                $result.content[1].type | Should -Be "paragraph"
+            }
+        }
+
+        Context "Inline marks" {
+            It "converts **text** to a text node with 'strong' mark" {
+                $nodes = (ConvertTo-AtlassianDocumentFormat -Markdown "**bold**").content[0].content
+                $node = $nodes | Where-Object { $_.text -eq 'bold' }
+                $node.marks[0].type | Should -Be "strong"
+            }
+
+            It "converts _text_ to a text node with 'em' mark" {
+                $nodes = (ConvertTo-AtlassianDocumentFormat -Markdown "_italic_").content[0].content
+                $node = $nodes | Where-Object { $_.text -eq 'italic' }
+                $node.marks[0].type | Should -Be "em"
+            }
+
+            It "converts ~~text~~ to a text node with 'strike' mark" {
+                $nodes = (ConvertTo-AtlassianDocumentFormat -Markdown "~~struck~~").content[0].content
+                $node = $nodes | Where-Object { $_.text -eq 'struck' }
+                $node.marks[0].type | Should -Be "strike"
+            }
+
+            It "converts `text` to a text node with 'code' mark" {
+                $nodes = (ConvertTo-AtlassianDocumentFormat -Markdown '`code`').content[0].content
+                $node = $nodes | Where-Object { $_.text -eq 'code' }
+                $node.marks[0].type | Should -Be "code"
+            }
+
+            It 'converts [text](url) to a text node with a link mark' {
+                $nodes = (ConvertTo-AtlassianDocumentFormat -Markdown '[GitHub](https://github.com)').content[0].content
+                $node = $nodes | Where-Object { $_.text -eq 'GitHub' }
+                $node.marks[0].type | Should -Be "link"
+                $node.marks[0].attrs.href | Should -Be "https://github.com"
+            }
+
+            It "preserves surrounding plain text alongside marked text" {
+                $nodes = (ConvertTo-AtlassianDocumentFormat -Markdown "Plain **bold** end").content[0].content
+                ($nodes | Where-Object { $_.text -eq 'Plain ' }) | Should -Not -BeNullOrEmpty
+                ($nodes | Where-Object { $_.text -eq ' end' })   | Should -Not -BeNullOrEmpty
+            }
+
+            It "converts ***text*** to a text node with both 'strong' and 'em' marks" {
+                $nodes = (ConvertTo-AtlassianDocumentFormat -Markdown "***bold italic***").content[0].content
+                $node = $nodes | Where-Object { $_.text -eq 'bold italic' }
+                $node.marks | Should -HaveCount 2
+                ($node.marks | Where-Object { $_.type -eq 'strong' }) | Should -Not -BeNullOrEmpty
+                ($node.marks | Where-Object { $_.type -eq 'em' }) | Should -Not -BeNullOrEmpty
+            }
+
+            It "converts **_text_** to a text node with both 'strong' and 'em' marks" {
+                $nodes = (ConvertTo-AtlassianDocumentFormat -Markdown "**_nested marks_**").content[0].content
+                $node = $nodes | Where-Object { $_.text -eq 'nested marks' }
+                $node.marks | Should -HaveCount 2
+                ($node.marks | Where-Object { $_.type -eq 'strong' }) | Should -Not -BeNullOrEmpty
+                ($node.marks | Where-Object { $_.type -eq 'em' }) | Should -Not -BeNullOrEmpty
+            }
+
+            It "converts _**text**_ to a text node with both 'em' and 'strong' marks" {
+                $nodes = (ConvertTo-AtlassianDocumentFormat -Markdown "_**italic bold**_").content[0].content
+                $node = $nodes | Where-Object { $_.text -eq 'italic bold' }
+                $node.marks | Should -HaveCount 2
+                ($node.marks | Where-Object { $_.type -eq 'em' }) | Should -Not -BeNullOrEmpty
+                ($node.marks | Where-Object { $_.type -eq 'strong' }) | Should -Not -BeNullOrEmpty
+            }
+        }
+
+        Context "Bullet list" {
+            BeforeAll {
+                $script:blResult = ConvertTo-AtlassianDocumentFormat -Markdown "* unordered`n* bullet`n* list"
+            }
+
+            It "produces a bulletList node" {
+                $blResult.content[0].type | Should -Be "bulletList"
+            }
+
+            It "produces 3 listItem nodes" {
+                $blResult.content[0].content | Should -HaveCount 3
+            }
+
+            It "each listItem wraps its text in a paragraph" {
+                foreach ($item in $blResult.content[0].content) {
+                    $item.type                      | Should -Be "listItem"
+                    $item.content[0].type           | Should -Be "paragraph"
+                    $item.content[0].content[0].type | Should -Be "text"
+                }
+            }
+
+            It "listItem '<index>' has text '<text>'" -TestCases @(
+                @{ index = 0; text = 'unordered' }
+                @{ index = 1; text = 'bullet' }
+                @{ index = 2; text = 'list' }
+            ) {
+                $blResult.content[0].content[$index].content[0].content[0].text | Should -Be $text
+            }
+        }
+
+        Context "Ordered list" {
+            BeforeAll {
+                $script:olResult = ConvertTo-AtlassianDocumentFormat -Markdown "1. ordered`n2. bullet list"
+            }
+
+            It "produces an orderedList node" {
+                $olResult.content[0].type | Should -Be "orderedList"
+            }
+
+            It "sets attrs.order = 1" {
+                $olResult.content[0].attrs.order | Should -Be 1
+            }
+
+            It "produces 2 listItem nodes" {
+                $olResult.content[0].content | Should -HaveCount 2
+            }
+
+            It "listItem '<index>' has text '<text>'" -TestCases @(
+                @{ index = 0; text = 'ordered' }
+                @{ index = 1; text = 'bullet list' }
+            ) {
+                $olResult.content[0].content[$index].content[0].content[0].text | Should -Be $text
+            }
+        }
+
+        Context "Nested lists (2 levels)" {
+            BeforeAll {
+                $script:nestedBullet = ConvertTo-AtlassianDocumentFormat -Markdown "* parent`n  * nested child`n* another parent"
+                $script:nestedOrdered = ConvertTo-AtlassianDocumentFormat -Markdown "1. first`n  1. nested first`n  2. nested second`n2. second"
+                $script:mixedNested = ConvertTo-AtlassianDocumentFormat -Markdown "* bullet parent`n  1. ordered nested"
+            }
+
+            It "produces a bulletList with nested bulletList" {
+                $nestedBullet.content[0].type | Should -Be "bulletList"
+                # First item should have nested list
+                $firstItem = $nestedBullet.content[0].content[0]
+                $firstItem.content | Should -HaveCount 2
+                $firstItem.content[0].type | Should -Be "paragraph"
+                $firstItem.content[1].type | Should -Be "bulletList"
+            }
+
+            It "nested bullet list contains the child item" {
+                $nestedList = $nestedBullet.content[0].content[0].content[1]
+                $nestedList.content[0].content[0].content[0].text | Should -Be "nested child"
+            }
+
+            It "parent list has 2 items (parent items only)" {
+                $nestedBullet.content[0].content | Should -HaveCount 2
+            }
+
+            It "produces an orderedList with nested orderedList" {
+                $nestedOrdered.content[0].type | Should -Be "orderedList"
+                $firstItem = $nestedOrdered.content[0].content[0]
+                $firstItem.content | Should -HaveCount 2
+                $firstItem.content[1].type | Should -Be "orderedList"
+            }
+
+            It "nested ordered list has 2 items" {
+                $nestedList = $nestedOrdered.content[0].content[0].content[1]
+                $nestedList.content | Should -HaveCount 2
+            }
+
+            It "supports mixed nesting (bullet parent with ordered nested)" {
+                $mixedNested.content[0].type | Should -Be "bulletList"
+                $mixedNested.content[0].content[0].content[1].type | Should -Be "orderedList"
+            }
+
+            It "nested list round-trips through ConvertFrom-AtlassianDocumentFormat" {
+                $md = "* parent`n  * nested"
+                $adf = ConvertTo-AtlassianDocumentFormat -Markdown $md
+                $back = ConvertFrom-AtlassianDocumentFormat -InputObject $adf
+                $back | Should -Match '(?m)^\* parent$'
+                $back | Should -Match '(?m)^  \* nested$'
+            }
+        }
+
+        Context "Task list" {
+            BeforeAll {
+                $script:tlResult = ConvertTo-AtlassianDocumentFormat -Markdown "* [ ] todo item`n* [x] done item"
+            }
+
+            It "produces a taskList node" {
+                $tlResult.content[0].type | Should -Be "taskList"
+            }
+
+            It "sets taskList attrs.localId" {
+                $tlResult.content[0].attrs.localId | Should -Not -BeNullOrEmpty
+            }
+
+            It "sets state = TODO for an unchecked item '* [ ]'" {
+                $tlResult.content[0].content[0].attrs.state | Should -Be "TODO"
+            }
+
+            It "sets state = DONE for a checked item '* [x]'" {
+                $tlResult.content[0].content[1].attrs.state | Should -Be "DONE"
+            }
+
+            It "each taskItem has a unique localId" {
+                $ids = $tlResult.content[0].content | ForEach-Object { $_.attrs.localId }
+                $ids | Select-Object -Unique | Should -HaveCount 2
+            }
+        }
+
+        Context "Code block" {
+            BeforeAll {
+                $script:cbResult = ConvertTo-AtlassianDocumentFormat -Markdown @'
+```python
+import os
+
+print(os.path('.'))
+```
+'@
+            }
+
+            It "produces a codeBlock node" {
+                $cbResult.content[0].type | Should -Be "codeBlock"
+            }
+
+            It "sets the language attribute from the fence" {
+                $cbResult.content[0].attrs.language | Should -Be "python"
+            }
+
+            It "preserves the code content including internal newlines" {
+                $cbResult.content[0].content[0].text | Should -Match 'import os'
+                $cbResult.content[0].content[0].text | Should -Match "print\(os\.path"
+            }
+        }
+
+        Context "Blockquote" {
+            BeforeAll {
+                $script:bqResult = ConvertTo-AtlassianDocumentFormat -Markdown "> quote text"
+            }
+
+            It "produces a blockquote node" {
+                $bqResult.content[0].type | Should -Be "blockquote"
+            }
+
+            It "wraps the quoted text in a paragraph" {
+                $bqResult.content[0].content[0].type | Should -Be "paragraph"
+            }
+
+            It "contains the quoted text" {
+                $bqResult.content[0].content[0].content[0].text | Should -Be "quote text"
+            }
+        }
+
+        Context "Table" {
+            BeforeAll {
+                $script:tblResult = ConvertTo-AtlassianDocumentFormat -Markdown @'
+| Table | with | header |
+| ----- | ---- | ------ |
+| lorem | ipsum | dolor |
+'@
+            }
+
+            It "produces a table node" {
+                $tblResult.content[0].type | Should -Be "table"
+            }
+
+            It "produces 2 tableRow nodes (separator excluded)" {
+                $tblResult.content[0].content | Should -HaveCount 2
+            }
+
+            It "header row uses tableHeader cell type" {
+                $tblResult.content[0].content[0].content[0].type | Should -Be "tableHeader"
+            }
+
+            It "data row uses tableCell cell type" {
+                $tblResult.content[0].content[1].content[0].type | Should -Be "tableCell"
+            }
+
+            It "header cell '<index>' contains text '<text>'" -TestCases @(
+                @{ index = 0; text = 'Table' }
+                @{ index = 1; text = 'with' }
+                @{ index = 2; text = 'header' }
+            ) {
+                $tblResult.content[0].content[0].content[$index].content[0].content[0].text |
+                    Should -Be $text
+            }
+
+            It "data cell '<index>' contains text '<text>'" -TestCases @(
+                @{ index = 0; text = 'lorem' }
+                @{ index = 1; text = 'ipsum' }
+                @{ index = 2; text = 'dolor' }
+            ) {
+                $tblResult.content[0].content[1].content[$index].content[0].content[0].text |
+                    Should -Be $text
+            }
+        }
+
+        Context "Block image (mediaSingle)" {
+            BeforeAll {
+                $script:imgResult = ConvertTo-AtlassianDocumentFormat -Markdown "![alt text](https://example.com/img.png)"
+            }
+
+            It "produces a mediaSingle node" {
+                $imgResult.content[0].type | Should -Be "mediaSingle"
+            }
+
+            It "contains a media child with type = external" {
+                $imgResult.content[0].content[0].type              | Should -Be "media"
+                $imgResult.content[0].content[0].attrs.type        | Should -Be "external"
+            }
+
+            It "stores the image URL in attrs.url" {
+                $imgResult.content[0].content[0].attrs.url | Should -Be "https://example.com/img.png"
+            }
+
+            It "stores the alt text in attrs.alt" {
+                $imgResult.content[0].content[0].attrs.alt | Should -Be "alt text"
+            }
+        }
+
+        Context "Round-trip via ConvertFrom-AtlassianDocumentFormat" {
+            It "Markdown heading survives ADF round-trip" {
+                $md = "# Header 1"
+                $adf = ConvertTo-AtlassianDocumentFormat -Markdown $md
+                $back = ConvertFrom-AtlassianDocumentFormat -InputObject $adf
+                $back | Should -Match '(?m)^# Header 1$'
+            }
+
+            It "bold inline survives ADF round-trip" {
+                $md = "Plain **bold** end"
+                $adf = ConvertTo-AtlassianDocumentFormat -Markdown $md
+                $back = ConvertFrom-AtlassianDocumentFormat -InputObject $adf
+                $back | Should -Match '\*\*bold\*\*'
+            }
+
+            It "link survives ADF round-trip" {
+                $md = '[GitHub](https://github.com)'
+                $adf = ConvertTo-AtlassianDocumentFormat -Markdown $md
+                $back = ConvertFrom-AtlassianDocumentFormat -InputObject $adf
+                $back | Should -Be '[GitHub](https://github.com)'
+            }
+
+            It "bullet list survives ADF round-trip" {
+                $md = "* alpha`n* beta"
+                $adf = ConvertTo-AtlassianDocumentFormat -Markdown $md
+                $back = ConvertFrom-AtlassianDocumentFormat -InputObject $adf
+                $back | Should -Match '(?m)^\* alpha$'
+                $back | Should -Match '(?m)^\* beta$'
+            }
+
+            It "ordered list survives ADF round-trip" {
+                $md = "1. first`n2. second"
+                $adf = ConvertTo-AtlassianDocumentFormat -Markdown $md
+                $back = ConvertFrom-AtlassianDocumentFormat -InputObject $adf
+                $back | Should -Match '(?m)^1\. first$'
+                $back | Should -Match '(?m)^2\. second$'
+            }
+
+            It "unchecked task list item survives ADF round-trip" {
+                $md = "* [ ] do this"
+                $adf = ConvertTo-AtlassianDocumentFormat -Markdown $md
+                $back = ConvertFrom-AtlassianDocumentFormat -InputObject $adf
+                $back | Should -Match '(?m)^\* \[ \] do this$'
+            }
+
+            It "code block survives ADF round-trip" {
+                $md = @'
+```python
+print("hello")
+```
+'@
+                $adf = ConvertTo-AtlassianDocumentFormat -Markdown $md
+                $back = ConvertFrom-AtlassianDocumentFormat -InputObject $adf
+                $back | Should -Match '(?m)^```python$'
+                $back | Should -Match 'print\("hello"\)'
+                $back | Should -Match '(?m)^```$'
+            }
+
+            It "table survives ADF round-trip" {
+                $md = "| A | B |`n| -- | -- |`n| 1 | 2 |"
+                $adf = ConvertTo-AtlassianDocumentFormat -Markdown $md
+                $back = ConvertFrom-AtlassianDocumentFormat -InputObject $adf
+                $back | Should -Match '\| A \|'
+                $back | Should -Match '\| 1 \|'
+            }
+        }
+
+        Context "Sample file — all heading levels present" {
+            BeforeAll {
+                $script:sampleResult = ConvertTo-AtlassianDocumentFormat -Markdown $sampleMd
+                $script:sampleHeadings = Find-AdfNode -Doc $sampleResult -Type 'heading'
+            }
+
+            It "produces heading nodes for all 6 levels" {
+                $levels = $sampleHeadings | ForEach-Object { $_.attrs.level } | Sort-Object -Unique
+                $levels | Should -HaveCount 6
+            }
+
+            It "heading for level <level> has text 'Header <level>'" -TestCases @(
+                @{ level = 1 }; @{ level = 2 }; @{ level = 3 }
+                @{ level = 4 }; @{ level = 5 }; @{ level = 6 }
+            ) {
+                $node = $sampleHeadings | Where-Object { $_.attrs.level -eq $level } | Select-Object -First 1
+                $node | Should -Not -BeNullOrEmpty
+                $node.content[0].text | Should -Be "Header $level"
+            }
+        }
+
+        Context "Sample file — list types present" {
+            BeforeAll {
+                $script:sampleFromMd = ConvertTo-AtlassianDocumentFormat -Markdown $sampleMd
+            }
+
+            It "produces a bulletList node" {
+                (Find-AdfNode -Doc $sampleFromMd -Type 'bulletList') | Should -Not -BeNullOrEmpty
+            }
+
+            It "produces an orderedList node" {
+                (Find-AdfNode -Doc $sampleFromMd -Type 'orderedList') | Should -Not -BeNullOrEmpty
+            }
+
+            It "produces a taskList node" {
+                (Find-AdfNode -Doc $sampleFromMd -Type 'taskList') | Should -Not -BeNullOrEmpty
+            }
+        }
+
+        Context "Hard breaks (trailing double-space)" {
+            It "converts trailing double-space to a hardBreak node" {
+                # Two spaces at end of line followed by another line = hard break
+                $result = ConvertTo-AtlassianDocumentFormat -Markdown "line one  `nline two"
+                $result.content | Should -HaveCount 1
+                $result.content[0].type | Should -Be "paragraph"
+                $result.content[0].content | Should -HaveCount 3
+                $result.content[0].content[0].text | Should -Be "line one"
+                $result.content[0].content[1].type | Should -Be "hardBreak"
+                $result.content[0].content[2].text | Should -Be "line two"
+            }
+
+            It "handles multiple consecutive hard breaks" {
+                $result = ConvertTo-AtlassianDocumentFormat -Markdown "first  `nsecond  `nthird"
+                $result.content | Should -HaveCount 1
+                $result.content[0].content | Should -HaveCount 5
+                $result.content[0].content[0].text | Should -Be "first"
+                $result.content[0].content[1].type | Should -Be "hardBreak"
+                $result.content[0].content[2].text | Should -Be "second"
+                $result.content[0].content[3].type | Should -Be "hardBreak"
+                $result.content[0].content[4].text | Should -Be "third"
+            }
+
+            It "does not add hardBreak when line ends normally (no trailing spaces)" {
+                $result = ConvertTo-AtlassianDocumentFormat -Markdown "line one`n`nline two"
+                $result.content | Should -HaveCount 2
+                $result.content[0].content[0].text | Should -Be "line one"
+                $result.content[1].content[0].text | Should -Be "line two"
+            }
+
+            It "hardBreak round-trips through ConvertFrom-AtlassianDocumentFormat" {
+                $md = "line one  `nline two"
+                $adf = ConvertTo-AtlassianDocumentFormat -Markdown $md
+                $back = ConvertFrom-AtlassianDocumentFormat -InputObject $adf
+                $back | Should -Match 'line one'
+                $back | Should -Match 'line two'
+            }
+        }
+
+        Context "Negative / edge cases" {
+            It "handles an unclosed code fence without throwing" {
+                $result = ConvertTo-AtlassianDocumentFormat -Markdown "``````python`nprint('hi')"
+                $result.content[0].type | Should -Be "codeBlock"
+                $result.content[0].attrs.language | Should -Be "python"
+                $result.content[0].content[0].text | Should -Be "print('hi')"
+            }
+
+            It "handles a table with only a header row (no data)" {
+                $result = ConvertTo-AtlassianDocumentFormat -Markdown "| A | B |`n| -- | -- |"
+                $result.content[0].type | Should -Be "table"
+                $result.content[0].content | Should -HaveCount 1
+                $result.content[0].content[0].content[0].type | Should -Be "tableHeader"
+            }
+
+            It "does not produce empty paragraph nodes for multiple blank lines" {
+                $result = ConvertTo-AtlassianDocumentFormat -Markdown "First`n`n`n`nSecond"
+                $result.content | Should -HaveCount 2
+                $result.content[0].content[0].text | Should -Be "First"
+                $result.content[1].content[0].text | Should -Be "Second"
+            }
+
+            It "handles an image with empty alt text" {
+                $result = ConvertTo-AtlassianDocumentFormat -Markdown '![](https://example.com/img.png)'
+                $result.content[0].type | Should -Be "mediaSingle"
+                $result.content[0].content[0].attrs.url | Should -Be "https://example.com/img.png"
+                $result.content[0].content[0].attrs.alt | Should -Be ""
+            }
+
+            It "splits marked text correctly at word boundaries" {
+                $nodes = (ConvertTo-AtlassianDocumentFormat -Markdown "**bold**rest").content[0].content
+                ($nodes | Where-Object { $_.text -eq 'bold' }).marks[0].type | Should -Be "strong"
+                ($nodes | Where-Object { $_.text -eq 'rest' }).marks | Should -BeNullOrEmpty
+            }
+
+            It "handles input with only special characters" {
+                $result = ConvertTo-AtlassianDocumentFormat -Markdown '!@$%^&'
+                $result.content[0].type | Should -Be "paragraph"
+                $result.content[0].content[0].type | Should -Be "text"
+            }
+        }
+    }
+}

--- a/docs/en-US/commands/ConvertFrom-AtlassianDocumentFormat.md
+++ b/docs/en-US/commands/ConvertFrom-AtlassianDocumentFormat.md
@@ -1,0 +1,117 @@
+---
+external help file: JiraPS-help.xml
+Module Name: JiraPS
+online version: https://atlassianps.org/docs/JiraPS/commands/ConvertFrom-AtlassianDocumentFormat/
+locale: en-US
+schema: 2.0.0
+layout: documentation
+permalink: /docs/JiraPS/commands/ConvertFrom-AtlassianDocumentFormat/
+---
+# ConvertFrom-AtlassianDocumentFormat
+
+## SYNOPSIS
+
+Converts an Atlassian Document Format (ADF) object to Markdown.
+
+## SYNTAX
+
+```powershell
+ConvertFrom-AtlassianDocumentFormat [[-InputObject] <Object>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+Jira Cloud API v3 returns description, comments, and many custom fields as ADF JSON objects.
+This function converts ADF to Markdown, preserving headings, bold, italic, strikethrough,
+inline code, links, bullet/ordered/task lists, tables, code blocks, blockquotes, mentions,
+emoji, and dates.
+
+Plain strings (Data Center / API v2) are returned unchanged.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+$raw = Invoke-JiraMethod -Uri "$server/rest/api/3/issue/TEST-1" -Method Get
+$markdown = ConvertFrom-AtlassianDocumentFormat -InputObject $raw.fields.description
+```
+
+Converts the ADF description returned by the Jira Cloud v3 API into readable Markdown.
+
+### EXAMPLE 2
+
+```powershell
+$raw.fields.description | ConvertFrom-AtlassianDocumentFormat
+```
+
+The same conversion using pipeline input.
+
+### EXAMPLE 3
+
+```powershell
+$comments = Invoke-JiraMethod -Uri "$server/rest/api/3/issue/TEST-1/comment" -Method Get
+$comments.comments | ForEach-Object {
+    ConvertFrom-AtlassianDocumentFormat -InputObject $_.body
+}
+```
+
+Converts each ADF comment body to Markdown.
+
+## PARAMETERS
+
+### -InputObject
+
+The ADF object (PSCustomObject with type = "doc") or a plain string.
+When a plain string is provided it is returned unchanged, making the function safe
+to use regardless of whether the server returns ADF or wiki markup.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### [System.Object]
+
+An ADF document object (PSCustomObject or hashtable) or a plain string.
+
+## OUTPUTS
+
+### [System.String]
+
+A Markdown representation of the ADF input, or the original string if the input was not ADF.
+
+## NOTES
+
+This function is public because JiraPS's read commands (`Get-JiraIssue`, `Get-JiraIssueComment`)
+only convert ADF automatically when they use API v3 internally. Users who call `Invoke-JiraMethod`
+directly against Jira Cloud v3 endpoints receive raw ADF objects that need manual conversion.
+Making this function public lets users convert those responses to Markdown without reimplementing
+the logic.
+
+It is also useful for inspecting the raw ADF structure returned by the API alongside the
+converted Markdown output.
+
+Alias: `ConvertFrom-ADF`
+
+## RELATED LINKS
+
+[ConvertTo-AtlassianDocumentFormat](ConvertTo-AtlassianDocumentFormat.md)
+
+[Invoke-JiraMethod](Invoke-JiraMethod.md)
+
+[Atlassian Document Format](https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/)

--- a/docs/en-US/commands/ConvertTo-AtlassianDocumentFormat.md
+++ b/docs/en-US/commands/ConvertTo-AtlassianDocumentFormat.md
@@ -1,0 +1,125 @@
+---
+external help file: JiraPS-help.xml
+Module Name: JiraPS
+online version: https://atlassianps.org/docs/JiraPS/commands/ConvertTo-AtlassianDocumentFormat/
+locale: en-US
+schema: 2.0.0
+layout: documentation
+permalink: /docs/JiraPS/commands/ConvertTo-AtlassianDocumentFormat/
+---
+# ConvertTo-AtlassianDocumentFormat
+
+## SYNOPSIS
+
+Converts Markdown to Atlassian Document Format (ADF).
+
+## SYNTAX
+
+```powershell
+ConvertTo-AtlassianDocumentFormat [-Markdown] <String> [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+Jira Cloud API v3 requires description, comments, and similar text fields to be
+submitted as ADF JSON objects. This function parses a Markdown string and produces
+the corresponding ADF structure.
+
+Supported Markdown constructs:
+
+- **Block**: headings (# to ######), code fences, blockquotes (>), tables, bullet lists (\* item), ordered lists (1. item), task lists (\* [ ] / \* [x]), images (!\[alt\](url))
+- **Inline**: \*\*bold\*\*, \_italic\_, \~\~strike\~\~, \`code\`, \[text\](url)
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+$adf = ConvertTo-AtlassianDocumentFormat -Markdown "**Hello** world"
+$body = @{ body = $adf } | ConvertTo-Json -Depth 20
+Invoke-JiraMethod -Uri "$server/rest/api/3/issue/TEST-1/comment" -Method Post -Body $body
+```
+
+Converts a Markdown string to ADF and posts it as a comment via the Jira Cloud v3 API.
+
+### EXAMPLE 2
+
+```powershell
+$description = @"
+# Release Notes
+
+* Bug fix for login
+* New dashboard widget
+"@ | ConvertTo-AtlassianDocumentFormat
+
+$body = @{ fields = @{ description = $description } } | ConvertTo-Json -Depth 20
+Invoke-JiraMethod -Uri "$server/rest/api/3/issue/TEST-1" -Method Put -Body $body
+```
+
+Updates an issue description on Jira Cloud using Markdown converted to ADF.
+
+### EXAMPLE 3
+
+```powershell
+$adf = ConvertTo-AtlassianDocumentFormat -Markdown "**Hello** world"
+$adf | ConvertTo-Json -Depth 20
+```
+
+Inspects the ADF structure generated from a simple Markdown string.
+
+## PARAMETERS
+
+### -Markdown
+
+The Markdown string to convert to ADF.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### [System.String]
+
+A Markdown-formatted string.
+
+## OUTPUTS
+
+### [System.Collections.Hashtable]
+
+An ADF document as a hashtable with `version`, `type`, and `content` keys,
+ready to be serialized to JSON with `ConvertTo-Json -Depth 20`.
+
+## NOTES
+
+The output must be serialized with sufficient depth (`-Depth 20` or higher)
+to preserve the nested ADF structure.
+
+This function is public because JiraPS's write commands (`New-JiraIssue`, `Set-JiraIssue`,
+`Add-JiraIssueComment`) currently use API v2, which accepts plain text or wiki markup.
+Users who need to write to Jira Cloud v3 endpoints via `Invoke-JiraMethod` must supply ADF.
+Making this function public lets users convert Markdown to ADF for those calls without
+reimplementing the logic.
+
+Alias: `ConvertTo-ADF`
+
+## RELATED LINKS
+
+[ConvertFrom-AtlassianDocumentFormat](ConvertFrom-AtlassianDocumentFormat.md)
+
+[Invoke-JiraMethod](Invoke-JiraMethod.md)
+
+[Atlassian Document Format](https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/)


### PR DESCRIPTION
Add ConvertFrom-AtlassianDocumentFormat and ConvertTo-AtlassianDocumentFormat public functions for converting between ADF (Jira Cloud API v3) and Markdown.

Features:
- Headings, paragraphs, bullet/ordered/task lists (2-level nesting)
- Inline marks: bold, italic, strikethrough, code, links, combined marks
- Tables, code blocks, blockquotes, panels, images
- Mentions, emoji, dates, inlineCards, hard breaks

Integrates ADF conversion into ConvertTo-JiraIssue and ConvertTo-JiraComment so Cloud responses display readable text instead of raw ADF objects.

Includes 151 unit tests and comprehensive documentation.

Made-with: Cursor