### PR TITLE
fix: enforce UTF-8 with BOM for PowerShell v5 compatibility

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,7 @@ insert_final_newline = true
 
 [*.{md,ps1,psm1,psd1,psc1,ps1xml,clixml}]
 end_of_line = crlf
+charset = utf-8-bom
 
 
 [*.{yml,yaml}]

--- a/JiraPS.build.ps1
+++ b/JiraPS.build.ps1
@@ -118,8 +118,8 @@ Task CompileModule {
         $compiled += "`r`n"
     }
 
-    Set-Content -LiteralPath $targetFile -Value $compiled -Encoding UTF8 -Force
-    Remove-Utf8Bom -Path $targetFile
+    $utf8Bom = [System.Text.UTF8Encoding]::new($true)
+    [System.IO.File]::WriteAllText($targetFile, $compiled, $utf8Bom)
 
     "Private", "Public" | ForEach-Object { Remove-Item -Path "$env:BHBuildOutput/$env:BHProjectName/$_" -Recurse -Force }
 }

--- a/JiraPS/JiraPS.psd1
+++ b/JiraPS/JiraPS.psd1
@@ -1,4 +1,4 @@
-@{
+﻿@{
 
     # Script module or binary module file associated with this manifest.
     RootModule        = 'JiraPS.psm1'

--- a/JiraPS/JiraPS.psm1
+++ b/JiraPS/JiraPS.psm1
@@ -1,4 +1,4 @@
-#region Dependencies
+﻿#region Dependencies
 # Load the ConfluencePS namespace from C#
 # if (!("" -as [Type])) {
 #     Add-Type -Path (Join-Path $PSScriptRoot JiraPS.Types.cs) -ReferencedAssemblies Microsoft.CSharp, Microsoft.PowerShell.Commands.Utility, System.Management.Automation

--- a/JiraPS/Private/Convert-Result.ps1
+++ b/JiraPS/Private/Convert-Result.ps1
@@ -1,4 +1,4 @@
-function Convert-Result {
+﻿function Convert-Result {
     [CmdletBinding()]
     param(
         [Parameter( ValueFromPipeline )]

--- a/JiraPS/Private/ConvertFrom-Json.ps1
+++ b/JiraPS/Private/ConvertFrom-Json.ps1
@@ -1,4 +1,4 @@
-if ($PSVersionTable.PSVersion.Major -lt 6) {
+﻿if ($PSVersionTable.PSVersion.Major -lt 6) {
     function ConvertFrom-Json {
         <#
     .SYNOPSIS

--- a/JiraPS/Private/ConvertFrom-URLEncoded.ps1
+++ b/JiraPS/Private/ConvertFrom-URLEncoded.ps1
@@ -1,4 +1,4 @@
-function ConvertFrom-URLEncoded {
+﻿function ConvertFrom-URLEncoded {
     <#
     .SYNOPSIS
         Decode a URL encoded string

--- a/JiraPS/Private/ConvertTo-GetParameter.ps1
+++ b/JiraPS/Private/ConvertTo-GetParameter.ps1
@@ -1,4 +1,4 @@
-function ConvertTo-GetParameter {
+﻿function ConvertTo-GetParameter {
     <#
     .SYNOPSIS
     Generate the GET parameter string for an URL from a hashtable

--- a/JiraPS/Private/ConvertTo-JiraAttachment.ps1
+++ b/JiraPS/Private/ConvertTo-JiraAttachment.ps1
@@ -1,4 +1,4 @@
-function ConvertTo-JiraAttachment {
+﻿function ConvertTo-JiraAttachment {
     [CmdletBinding()]
     param(
         [Parameter( ValueFromPipeline )]

--- a/JiraPS/Private/ConvertTo-JiraComment.ps1
+++ b/JiraPS/Private/ConvertTo-JiraComment.ps1
@@ -1,4 +1,4 @@
-function ConvertTo-JiraComment {
+﻿function ConvertTo-JiraComment {
     [CmdletBinding()]
     param(
         [Parameter( ValueFromPipeline )]

--- a/JiraPS/Private/ConvertTo-JiraComponent.ps1
+++ b/JiraPS/Private/ConvertTo-JiraComponent.ps1
@@ -1,4 +1,4 @@
-function ConvertTo-JiraComponent {
+﻿function ConvertTo-JiraComponent {
     [CmdletBinding()]
     param(
         [Parameter( ValueFromPipeline )]

--- a/JiraPS/Private/ConvertTo-JiraCreateMetaField.ps1
+++ b/JiraPS/Private/ConvertTo-JiraCreateMetaField.ps1
@@ -1,4 +1,4 @@
-function ConvertTo-JiraCreateMetaField {
+﻿function ConvertTo-JiraCreateMetaField {
     [CmdletBinding()]
     param(
         [Parameter( ValueFromPipeline )]

--- a/JiraPS/Private/ConvertTo-JiraEditMetaField.ps1
+++ b/JiraPS/Private/ConvertTo-JiraEditMetaField.ps1
@@ -1,4 +1,4 @@
-function ConvertTo-JiraEditMetaField {
+﻿function ConvertTo-JiraEditMetaField {
     [CmdletBinding()]
     param(
         [Parameter( ValueFromPipeline )]

--- a/JiraPS/Private/ConvertTo-JiraField.ps1
+++ b/JiraPS/Private/ConvertTo-JiraField.ps1
@@ -1,4 +1,4 @@
-function ConvertTo-JiraField {
+﻿function ConvertTo-JiraField {
     [CmdletBinding()]
     param(
         [Parameter( ValueFromPipeline )]

--- a/JiraPS/Private/ConvertTo-JiraFilter.ps1
+++ b/JiraPS/Private/ConvertTo-JiraFilter.ps1
@@ -1,4 +1,4 @@
-function ConvertTo-JiraFilter {
+﻿function ConvertTo-JiraFilter {
     [CmdletBinding()]
     param(
         [Parameter( ValueFromPipeline )]

--- a/JiraPS/Private/ConvertTo-JiraFilterPermission.ps1
+++ b/JiraPS/Private/ConvertTo-JiraFilterPermission.ps1
@@ -1,4 +1,4 @@
-function ConvertTo-JiraFilterPermission {
+﻿function ConvertTo-JiraFilterPermission {
     [CmdletBinding()]
     param(
         [Parameter( ValueFromPipeline )]

--- a/JiraPS/Private/ConvertTo-JiraGroup.ps1
+++ b/JiraPS/Private/ConvertTo-JiraGroup.ps1
@@ -1,4 +1,4 @@
-function ConvertTo-JiraGroup {
+﻿function ConvertTo-JiraGroup {
     [CmdletBinding()]
     param(
         [Parameter( ValueFromPipeline )]

--- a/JiraPS/Private/ConvertTo-JiraIssue.ps1
+++ b/JiraPS/Private/ConvertTo-JiraIssue.ps1
@@ -1,4 +1,4 @@
-function ConvertTo-JiraIssue {
+﻿function ConvertTo-JiraIssue {
     [CmdletBinding()]
     param(
         [Parameter( ValueFromPipeline )]

--- a/JiraPS/Private/ConvertTo-JiraIssueLink.ps1
+++ b/JiraPS/Private/ConvertTo-JiraIssueLink.ps1
@@ -1,4 +1,4 @@
-function ConvertTo-JiraIssueLink {
+﻿function ConvertTo-JiraIssueLink {
     [CmdletBinding()]
     param(
         [Parameter( ValueFromPipeline )]

--- a/JiraPS/Private/ConvertTo-JiraIssueLinkType.ps1
+++ b/JiraPS/Private/ConvertTo-JiraIssueLinkType.ps1
@@ -1,4 +1,4 @@
-function ConvertTo-JiraIssueLinkType {
+﻿function ConvertTo-JiraIssueLinkType {
     [CmdletBinding()]
     param(
         [Parameter( ValueFromPipeline )]

--- a/JiraPS/Private/ConvertTo-JiraIssueType.ps1
+++ b/JiraPS/Private/ConvertTo-JiraIssueType.ps1
@@ -1,4 +1,4 @@
-function ConvertTo-JiraIssueType {
+﻿function ConvertTo-JiraIssueType {
     [CmdletBinding()]
     param(
         [Parameter( ValueFromPipeline )]

--- a/JiraPS/Private/ConvertTo-JiraLink.ps1
+++ b/JiraPS/Private/ConvertTo-JiraLink.ps1
@@ -1,4 +1,4 @@
-function ConvertTo-JiraLink {
+﻿function ConvertTo-JiraLink {
     [CmdletBinding()]
     param(
         [Parameter( ValueFromPipeline )]

--- a/JiraPS/Private/ConvertTo-JiraPriority.ps1
+++ b/JiraPS/Private/ConvertTo-JiraPriority.ps1
@@ -1,4 +1,4 @@
-function ConvertTo-JiraPriority {
+﻿function ConvertTo-JiraPriority {
     [CmdletBinding()]
     param(
         [Parameter( ValueFromPipeline )]

--- a/JiraPS/Private/ConvertTo-JiraProject.ps1
+++ b/JiraPS/Private/ConvertTo-JiraProject.ps1
@@ -1,4 +1,4 @@
-function ConvertTo-JiraProject {
+﻿function ConvertTo-JiraProject {
     [CmdletBinding()]
     param(
         [Parameter( ValueFromPipeline )]

--- a/JiraPS/Private/ConvertTo-JiraProjectRole.ps1
+++ b/JiraPS/Private/ConvertTo-JiraProjectRole.ps1
@@ -1,4 +1,4 @@
-function ConvertTo-JiraProjectRole {
+﻿function ConvertTo-JiraProjectRole {
     [CmdletBinding()]
     param(
         [Parameter( ValueFromPipeline )]

--- a/JiraPS/Private/ConvertTo-JiraServerInfo.ps1
+++ b/JiraPS/Private/ConvertTo-JiraServerInfo.ps1
@@ -1,4 +1,4 @@
-function ConvertTo-JiraServerInfo {
+﻿function ConvertTo-JiraServerInfo {
     [CmdletBinding()]
     param(
         [Parameter( ValueFromPipeline )]

--- a/JiraPS/Private/ConvertTo-JiraSession.ps1
+++ b/JiraPS/Private/ConvertTo-JiraSession.ps1
@@ -1,4 +1,4 @@
-function ConvertTo-JiraSession {
+﻿function ConvertTo-JiraSession {
     [CmdletBinding()]
     param(
         [Parameter( Mandatory )]

--- a/JiraPS/Private/ConvertTo-JiraStatus.ps1
+++ b/JiraPS/Private/ConvertTo-JiraStatus.ps1
@@ -1,4 +1,4 @@
-function ConvertTo-JiraStatus {
+﻿function ConvertTo-JiraStatus {
     [CmdletBinding()]
     param(
         [Parameter( ValueFromPipeline )]

--- a/JiraPS/Private/ConvertTo-JiraTransition.ps1
+++ b/JiraPS/Private/ConvertTo-JiraTransition.ps1
@@ -1,4 +1,4 @@
-function ConvertTo-JiraTransition {
+﻿function ConvertTo-JiraTransition {
     [CmdletBinding()]
     param(
         [Parameter( ValueFromPipeline )]

--- a/JiraPS/Private/ConvertTo-JiraUser.ps1
+++ b/JiraPS/Private/ConvertTo-JiraUser.ps1
@@ -1,4 +1,4 @@
-function ConvertTo-JiraUser {
+﻿function ConvertTo-JiraUser {
     [CmdletBinding()]
     param(
         [Parameter( ValueFromPipeline )]

--- a/JiraPS/Private/ConvertTo-JiraVersion.ps1
+++ b/JiraPS/Private/ConvertTo-JiraVersion.ps1
@@ -1,4 +1,4 @@
-function ConvertTo-JiraVersion {
+﻿function ConvertTo-JiraVersion {
     [CmdletBinding()]
     param(
         [Parameter( ValueFromPipeline )]

--- a/JiraPS/Private/ConvertTo-JiraWorklogitem.ps1
+++ b/JiraPS/Private/ConvertTo-JiraWorklogitem.ps1
@@ -1,4 +1,4 @@
-function ConvertTo-JiraWorklogItem {
+﻿function ConvertTo-JiraWorklogItem {
     [CmdletBinding()]
     param(
         [Parameter( ValueFromPipeline )]

--- a/JiraPS/Private/ConvertTo-ParameterHash.ps1
+++ b/JiraPS/Private/ConvertTo-ParameterHash.ps1
@@ -1,4 +1,4 @@
-function ConvertTo-ParameterHash {
+﻿function ConvertTo-ParameterHash {
     [CmdletBinding( DefaultParameterSetName = 'ByString' )]
     param (
         # URI from which to use the query

--- a/JiraPS/Private/ConvertTo-URLEncoded.ps1
+++ b/JiraPS/Private/ConvertTo-URLEncoded.ps1
@@ -1,4 +1,4 @@
-function ConvertTo-URLEncoded {
+﻿function ConvertTo-URLEncoded {
     <#
     .SYNOPSIS
         Encode a string into URL (eg: %20 instead of " ")

--- a/JiraPS/Private/Expand-Result.ps1
+++ b/JiraPS/Private/Expand-Result.ps1
@@ -1,4 +1,4 @@
-function Expand-Result {
+﻿function Expand-Result {
     [CmdletBinding()]
     param(
         [Parameter( Mandatory, ValueFromPipeline )]

--- a/JiraPS/Private/Invoke-PaginatedRequest.ps1
+++ b/JiraPS/Private/Invoke-PaginatedRequest.ps1
@@ -1,4 +1,4 @@
-function Invoke-PaginatedRequest {
+﻿function Invoke-PaginatedRequest {
     [CmdletBinding(SupportsPaging)]
     param(
         [Parameter( Mandatory )]

--- a/JiraPS/Private/Invoke-WebRequest.ps1
+++ b/JiraPS/Private/Invoke-WebRequest.ps1
@@ -1,4 +1,4 @@
-function Invoke-WebRequest {
+﻿function Invoke-WebRequest {
     # For Version up to 5.1
     <#
     .ForwardHelpTargetName

--- a/JiraPS/Private/Join-Hashtable.ps1
+++ b/JiraPS/Private/Join-Hashtable.ps1
@@ -1,4 +1,4 @@
-function Join-Hashtable {
+﻿function Join-Hashtable {
     <#
 	.SYNOPSIS
 		Combines multiple hashtables into a single table.

--- a/JiraPS/Private/Resolve-DefaultParameterValue.ps1
+++ b/JiraPS/Private/Resolve-DefaultParameterValue.ps1
@@ -1,4 +1,4 @@
-function Resolve-DefaultParameterValue {
+﻿function Resolve-DefaultParameterValue {
     <#
 	.SYNOPSIS
 		Used to filter and process default parameter values.

--- a/JiraPS/Private/Resolve-ErrorWebResponse.ps1
+++ b/JiraPS/Private/Resolve-ErrorWebResponse.ps1
@@ -1,4 +1,4 @@
-function Resolve-ErrorWebResponse {
+﻿function Resolve-ErrorWebResponse {
     [CmdletBinding()]
     param (
         $Exception,

--- a/JiraPS/Private/Resolve-FilePath.ps1
+++ b/JiraPS/Private/Resolve-FilePath.ps1
@@ -1,4 +1,4 @@
-function Resolve-FilePath {
+﻿function Resolve-FilePath {
     <#
     .SYNOPSIS
         Resolve a path to it's full path

--- a/JiraPS/Private/Resolve-FullPath.ps1
+++ b/JiraPS/Private/Resolve-FullPath.ps1
@@ -1,4 +1,4 @@
-function Resolve-FullPath {
+﻿function Resolve-FullPath {
     [CmdletBinding()]
     param (
         # Path to be resolved.

--- a/JiraPS/Private/Resolve-JiraError.ps1
+++ b/JiraPS/Private/Resolve-JiraError.ps1
@@ -1,4 +1,4 @@
-function Resolve-JiraError {
+﻿function Resolve-JiraError {
     [CmdletBinding()]
     param(
         [Parameter( ValueFromPipeline )]

--- a/JiraPS/Private/Resolve-JiraIssueObject.ps1
+++ b/JiraPS/Private/Resolve-JiraIssueObject.ps1
@@ -1,4 +1,4 @@
-function Resolve-JiraIssueObject {
+﻿function Resolve-JiraIssueObject {
     <#
       #ToDo:CustomClass
       Once we have custom classes, this will no longer be necessary

--- a/JiraPS/Private/Resolve-JiraUser.ps1
+++ b/JiraPS/Private/Resolve-JiraUser.ps1
@@ -1,4 +1,4 @@
-function Resolve-JiraUser {
+﻿function Resolve-JiraUser {
     <#
       #ToDo:CustomClass
       Once we have custom classes, this will no longer be necessary

--- a/JiraPS/Private/Set-TlsLevel.ps1
+++ b/JiraPS/Private/Set-TlsLevel.ps1
@@ -1,4 +1,4 @@
-function Set-TlsLevel {
+﻿function Set-TlsLevel {
     [CmdletBinding( SupportsShouldProcess = $false )]
     [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseShouldProcessForStateChangingFunctions', '')]
     param (

--- a/JiraPS/Private/Test-JiraCloudServer.ps1
+++ b/JiraPS/Private/Test-JiraCloudServer.ps1
@@ -1,4 +1,4 @@
-function Test-JiraCloudServer {
+﻿function Test-JiraCloudServer {
     [CmdletBinding()]
     [OutputType([System.Boolean])]
     param(

--- a/JiraPS/Private/Test-ServerResponse.ps1
+++ b/JiraPS/Private/Test-ServerResponse.ps1
@@ -1,4 +1,4 @@
-function Test-ServerResponse {
+﻿function Test-ServerResponse {
     [CmdletBinding()]
     <#
         .SYNOPSIS

--- a/JiraPS/Private/ThrowError.ps1
+++ b/JiraPS/Private/ThrowError.ps1
@@ -1,4 +1,4 @@
-function ThrowError {
+﻿function ThrowError {
     <#
     .SYNOPSIS
         Utility to throw a terminating errorrecord

--- a/JiraPS/Private/Write-DebugMessage.ps1
+++ b/JiraPS/Private/Write-DebugMessage.ps1
@@ -1,4 +1,4 @@
-function Write-DebugMessage {
+﻿function Write-DebugMessage {
     [CmdletBinding()]
     param(
         [Parameter( ValueFromPipeline )]

--- a/JiraPS/Private/WriteError.ps1
+++ b/JiraPS/Private/WriteError.ps1
@@ -1,4 +1,4 @@
-function WriteError {
+﻿function WriteError {
     <#
     .SYNOPSIS
         Utility to write an errorrecord to the errstd

--- a/JiraPS/Public/Add-JiraFilterPermission.ps1
+++ b/JiraPS/Public/Add-JiraFilterPermission.ps1
@@ -1,4 +1,4 @@
-function Add-JiraFilterPermission {
+﻿function Add-JiraFilterPermission {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( SupportsShouldProcess, DefaultParameterSetName = 'ByInputObject' )]
     # [OutputType( [JiraPS.FilterPermission] )]

--- a/JiraPS/Public/Add-JiraGroupMember.ps1
+++ b/JiraPS/Public/Add-JiraGroupMember.ps1
@@ -1,4 +1,4 @@
-function Add-JiraGroupMember {
+﻿function Add-JiraGroupMember {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( SupportsShouldProcess )]
     param(

--- a/JiraPS/Public/Add-JiraIssueAttachment.ps1
+++ b/JiraPS/Public/Add-JiraIssueAttachment.ps1
@@ -1,4 +1,4 @@
-function Add-JiraIssueAttachment {
+﻿function Add-JiraIssueAttachment {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( SupportsShouldProcess )]
     param(

--- a/JiraPS/Public/Add-JiraIssueComment.ps1
+++ b/JiraPS/Public/Add-JiraIssueComment.ps1
@@ -1,4 +1,4 @@
-function Add-JiraIssueComment {
+﻿function Add-JiraIssueComment {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( SupportsShouldProcess )]
     param(

--- a/JiraPS/Public/Add-JiraIssueLink.ps1
+++ b/JiraPS/Public/Add-JiraIssueLink.ps1
@@ -1,4 +1,4 @@
-function Add-JiraIssueLink {
+﻿function Add-JiraIssueLink {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( SupportsShouldProcess )]
     param(

--- a/JiraPS/Public/Add-JiraIssueWatcher.ps1
+++ b/JiraPS/Public/Add-JiraIssueWatcher.ps1
@@ -1,4 +1,4 @@
-function Add-JiraIssueWatcher {
+﻿function Add-JiraIssueWatcher {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( SupportsShouldProcess )]
     param(

--- a/JiraPS/Public/Add-JiraIssueWorklog.ps1
+++ b/JiraPS/Public/Add-JiraIssueWorklog.ps1
@@ -1,4 +1,4 @@
-function Add-JiraIssueWorklog {
+﻿function Add-JiraIssueWorklog {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( SupportsShouldProcess )]
     param(

--- a/JiraPS/Public/Find-JiraFilter.ps1
+++ b/JiraPS/Public/Find-JiraFilter.ps1
@@ -1,4 +1,4 @@
-function Find-JiraFilter {
+﻿function Find-JiraFilter {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( DefaultParameterSetName = 'ByAccountId', SupportsPaging )]
     param(

--- a/JiraPS/Public/Format-Jira.ps1
+++ b/JiraPS/Public/Format-Jira.ps1
@@ -1,4 +1,4 @@
-function Format-Jira {
+﻿function Format-Jira {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding()]
     [OutputType([System.String])]

--- a/JiraPS/Public/Get-JiraComponent.ps1
+++ b/JiraPS/Public/Get-JiraComponent.ps1
@@ -1,4 +1,4 @@
-function Get-JiraComponent {
+﻿function Get-JiraComponent {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding(DefaultParameterSetName = 'ByID')]
     param(

--- a/JiraPS/Public/Get-JiraConfigServer.ps1
+++ b/JiraPS/Public/Get-JiraConfigServer.ps1
@@ -1,4 +1,4 @@
-function Get-JiraConfigServer {
+﻿function Get-JiraConfigServer {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding()]
     [OutputType([System.String])]

--- a/JiraPS/Public/Get-JiraField.ps1
+++ b/JiraPS/Public/Get-JiraField.ps1
@@ -1,4 +1,4 @@
-function Get-JiraField {
+﻿function Get-JiraField {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( DefaultParameterSetName = '_All' )]
     param(

--- a/JiraPS/Public/Get-JiraFilter.ps1
+++ b/JiraPS/Public/Get-JiraFilter.ps1
@@ -1,4 +1,4 @@
-function Get-JiraFilter {
+﻿function Get-JiraFilter {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding(DefaultParameterSetName = 'ByFilterID')]
     param(

--- a/JiraPS/Public/Get-JiraFilterPermission.ps1
+++ b/JiraPS/Public/Get-JiraFilterPermission.ps1
@@ -1,4 +1,4 @@
-function Get-JiraFilterPermission {
+﻿function Get-JiraFilterPermission {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( DefaultParameterSetName = 'ById' )]
     # [OutputType( [JiraPS.FilterPermission] )]

--- a/JiraPS/Public/Get-JiraGroup.ps1
+++ b/JiraPS/Public/Get-JiraGroup.ps1
@@ -1,4 +1,4 @@
-function Get-JiraGroup {
+﻿function Get-JiraGroup {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding()]
     param(

--- a/JiraPS/Public/Get-JiraGroupMember.ps1
+++ b/JiraPS/Public/Get-JiraGroupMember.ps1
@@ -1,4 +1,4 @@
-function Get-JiraGroupMember {
+﻿function Get-JiraGroupMember {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( SupportsPaging )]
     param(

--- a/JiraPS/Public/Get-JiraIssue.ps1
+++ b/JiraPS/Public/Get-JiraIssue.ps1
@@ -1,4 +1,4 @@
-function Get-JiraIssue {
+﻿function Get-JiraIssue {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( SupportsPaging, DefaultParameterSetName = 'ByIssueKey' )]
     param(

--- a/JiraPS/Public/Get-JiraIssueAttachment.ps1
+++ b/JiraPS/Public/Get-JiraIssueAttachment.ps1
@@ -1,4 +1,4 @@
-function Get-JiraIssueAttachment {
+﻿function Get-JiraIssueAttachment {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding()]
     param(

--- a/JiraPS/Public/Get-JiraIssueAttachmentFile.ps1
+++ b/JiraPS/Public/Get-JiraIssueAttachmentFile.ps1
@@ -1,4 +1,4 @@
-function Get-JiraIssueAttachmentFile {
+﻿function Get-JiraIssueAttachmentFile {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding()]
     [OutputType([Bool])]

--- a/JiraPS/Public/Get-JiraIssueComment.ps1
+++ b/JiraPS/Public/Get-JiraIssueComment.ps1
@@ -1,4 +1,4 @@
-function Get-JiraIssueComment {
+﻿function Get-JiraIssueComment {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding()]
     param(

--- a/JiraPS/Public/Get-JiraIssueCreateMetadata.ps1
+++ b/JiraPS/Public/Get-JiraIssueCreateMetadata.ps1
@@ -1,4 +1,4 @@
-function Get-JiraIssueCreateMetadata {
+﻿function Get-JiraIssueCreateMetadata {
     # .ExternalHelp ..\JiraPS-help.xml
     [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseSingularNouns', '')]
     [CmdletBinding()]

--- a/JiraPS/Public/Get-JiraIssueEditMetadata.ps1
+++ b/JiraPS/Public/Get-JiraIssueEditMetadata.ps1
@@ -1,4 +1,4 @@
-function Get-JiraIssueEditMetadata {
+﻿function Get-JiraIssueEditMetadata {
     # .ExternalHelp ..\JiraPS-help.xml
     [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseSingularNouns', '')]
     [CmdletBinding()]

--- a/JiraPS/Public/Get-JiraIssueLink.ps1
+++ b/JiraPS/Public/Get-JiraIssueLink.ps1
@@ -1,4 +1,4 @@
-function Get-JiraIssueLink {
+﻿function Get-JiraIssueLink {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding()]
     param(

--- a/JiraPS/Public/Get-JiraIssueLinkType.ps1
+++ b/JiraPS/Public/Get-JiraIssueLinkType.ps1
@@ -1,4 +1,4 @@
-function Get-JiraIssueLinkType {
+﻿function Get-JiraIssueLinkType {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding(DefaultParameterSetName = '_All')]
     param(

--- a/JiraPS/Public/Get-JiraIssueType.ps1
+++ b/JiraPS/Public/Get-JiraIssueType.ps1
@@ -1,4 +1,4 @@
-function Get-JiraIssueType {
+﻿function Get-JiraIssueType {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( DefaultParameterSetName = '_All' )]
     param(

--- a/JiraPS/Public/Get-JiraIssueWatcher.ps1
+++ b/JiraPS/Public/Get-JiraIssueWatcher.ps1
@@ -1,4 +1,4 @@
-function Get-JiraIssueWatcher {
+﻿function Get-JiraIssueWatcher {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding()]
     param(

--- a/JiraPS/Public/Get-JiraIssueWorklog.ps1
+++ b/JiraPS/Public/Get-JiraIssueWorklog.ps1
@@ -1,4 +1,4 @@
-function Get-JiraIssueWorklog {
+﻿function Get-JiraIssueWorklog {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding()]
     param(

--- a/JiraPS/Public/Get-JiraPriority.ps1
+++ b/JiraPS/Public/Get-JiraPriority.ps1
@@ -1,4 +1,4 @@
-function Get-JiraPriority {
+﻿function Get-JiraPriority {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( DefaultParameterSetName = '_All' )]
     param(

--- a/JiraPS/Public/Get-JiraProject.ps1
+++ b/JiraPS/Public/Get-JiraProject.ps1
@@ -1,4 +1,4 @@
-function Get-JiraProject {
+﻿function Get-JiraProject {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( DefaultParameterSetName = '_All' )]
     param(

--- a/JiraPS/Public/Get-JiraRemoteLink.ps1
+++ b/JiraPS/Public/Get-JiraRemoteLink.ps1
@@ -1,4 +1,4 @@
-function Get-JiraRemoteLink {
+﻿function Get-JiraRemoteLink {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding()]
     param(

--- a/JiraPS/Public/Get-JiraServerInformation.ps1
+++ b/JiraPS/Public/Get-JiraServerInformation.ps1
@@ -1,4 +1,4 @@
-function Get-JiraServerInformation {
+﻿function Get-JiraServerInformation {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding()]
     param(

--- a/JiraPS/Public/Get-JiraSession.ps1
+++ b/JiraPS/Public/Get-JiraSession.ps1
@@ -1,4 +1,4 @@
-function Get-JiraSession {
+﻿function Get-JiraSession {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding()]
     param()

--- a/JiraPS/Public/Get-JiraUser.ps1
+++ b/JiraPS/Public/Get-JiraUser.ps1
@@ -1,4 +1,4 @@
-function Get-JiraUser {
+﻿function Get-JiraUser {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( DefaultParameterSetName = 'Self' )]
     param(

--- a/JiraPS/Public/Get-JiraVersion.ps1
+++ b/JiraPS/Public/Get-JiraVersion.ps1
@@ -1,4 +1,4 @@
-function Get-JiraVersion {
+﻿function Get-JiraVersion {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( SupportsPaging, DefaultParameterSetName = 'byId' )]
     param(

--- a/JiraPS/Public/Invoke-JiraIssueTransition.ps1
+++ b/JiraPS/Public/Invoke-JiraIssueTransition.ps1
@@ -1,4 +1,4 @@
-function Invoke-JiraIssueTransition {
+﻿function Invoke-JiraIssueTransition {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding()]
     param(

--- a/JiraPS/Public/Invoke-JiraMethod.ps1
+++ b/JiraPS/Public/Invoke-JiraMethod.ps1
@@ -1,4 +1,4 @@
-function Invoke-JiraMethod {
+﻿function Invoke-JiraMethod {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( SupportsPaging )]
     param(

--- a/JiraPS/Public/Move-JiraVersion.ps1
+++ b/JiraPS/Public/Move-JiraVersion.ps1
@@ -1,4 +1,4 @@
-function Move-JiraVersion {
+﻿function Move-JiraVersion {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( DefaultParameterSetName = 'ByAfter' )]
     param(

--- a/JiraPS/Public/New-JiraFilter.ps1
+++ b/JiraPS/Public/New-JiraFilter.ps1
@@ -1,4 +1,4 @@
-function New-JiraFilter {
+﻿function New-JiraFilter {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( SupportsShouldProcess )]
     param(

--- a/JiraPS/Public/New-JiraGroup.ps1
+++ b/JiraPS/Public/New-JiraGroup.ps1
@@ -1,4 +1,4 @@
-function New-JiraGroup {
+﻿function New-JiraGroup {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( SupportsShouldProcess )]
     param(

--- a/JiraPS/Public/New-JiraIssue.ps1
+++ b/JiraPS/Public/New-JiraIssue.ps1
@@ -1,4 +1,4 @@
-function New-JiraIssue {
+﻿function New-JiraIssue {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( SupportsShouldProcess )]
     param(

--- a/JiraPS/Public/New-JiraSession.ps1
+++ b/JiraPS/Public/New-JiraSession.ps1
@@ -1,4 +1,4 @@
-function New-JiraSession {
+﻿function New-JiraSession {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding()]
     [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseShouldProcessForStateChangingFunctions', '')]

--- a/JiraPS/Public/New-JiraUser.ps1
+++ b/JiraPS/Public/New-JiraUser.ps1
@@ -1,4 +1,4 @@
-function New-JiraUser {
+﻿function New-JiraUser {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( SupportsShouldProcess )]
     param(

--- a/JiraPS/Public/New-JiraVersion.ps1
+++ b/JiraPS/Public/New-JiraVersion.ps1
@@ -1,4 +1,4 @@
-function New-JiraVersion {
+﻿function New-JiraVersion {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( SupportsShouldProcess, DefaultParameterSetName = 'byObject' )]
     param(

--- a/JiraPS/Public/Remove-JiraFilter.ps1
+++ b/JiraPS/Public/Remove-JiraFilter.ps1
@@ -1,4 +1,4 @@
-function Remove-JiraFilter {
+﻿function Remove-JiraFilter {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( ConfirmImpact = "Medium", SupportsShouldProcess, DefaultParameterSetName = 'ByInputObject' )]
     param(

--- a/JiraPS/Public/Remove-JiraFilterPermission.ps1
+++ b/JiraPS/Public/Remove-JiraFilterPermission.ps1
@@ -1,4 +1,4 @@
-function Remove-JiraFilterPermission {
+﻿function Remove-JiraFilterPermission {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( SupportsShouldProcess, DefaultParameterSetName = 'ByFilterId' )]
     param(

--- a/JiraPS/Public/Remove-JiraGroup.ps1
+++ b/JiraPS/Public/Remove-JiraGroup.ps1
@@ -1,4 +1,4 @@
-function Remove-JiraGroup {
+﻿function Remove-JiraGroup {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( SupportsShouldProcess, ConfirmImpact = 'High' )]
     param(

--- a/JiraPS/Public/Remove-JiraGroupMember.ps1
+++ b/JiraPS/Public/Remove-JiraGroupMember.ps1
@@ -1,4 +1,4 @@
-function Remove-JiraGroupMember {
+﻿function Remove-JiraGroupMember {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( SupportsShouldProcess, ConfirmImpact = 'High' )]
     param(

--- a/JiraPS/Public/Remove-JiraIssue.ps1
+++ b/JiraPS/Public/Remove-JiraIssue.ps1
@@ -1,4 +1,4 @@
-function Remove-JiraIssue {
+﻿function Remove-JiraIssue {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding(
         ConfirmImpact = 'High',

--- a/JiraPS/Public/Remove-JiraIssueAttachment.ps1
+++ b/JiraPS/Public/Remove-JiraIssueAttachment.ps1
@@ -1,4 +1,4 @@
-function Remove-JiraIssueAttachment {
+﻿function Remove-JiraIssueAttachment {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( ConfirmImpact = 'High', SupportsShouldProcess, DefaultParameterSetName = 'byId' )]
     param(

--- a/JiraPS/Public/Remove-JiraIssueLink.ps1
+++ b/JiraPS/Public/Remove-JiraIssueLink.ps1
@@ -1,4 +1,4 @@
-function Remove-JiraIssueLink {
+﻿function Remove-JiraIssueLink {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( SupportsShouldProcess, ConfirmImpact = 'Medium' )]
     param(

--- a/JiraPS/Public/Remove-JiraIssueWatcher.ps1
+++ b/JiraPS/Public/Remove-JiraIssueWatcher.ps1
@@ -1,4 +1,4 @@
-function Remove-JiraIssueWatcher {
+﻿function Remove-JiraIssueWatcher {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( SupportsShouldProcess )]
     param(

--- a/JiraPS/Public/Remove-JiraRemoteLink.ps1
+++ b/JiraPS/Public/Remove-JiraRemoteLink.ps1
@@ -1,4 +1,4 @@
-function Remove-JiraRemoteLink {
+﻿function Remove-JiraRemoteLink {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( ConfirmImpact = 'High', SupportsShouldProcess )]
     param(

--- a/JiraPS/Public/Remove-JiraSession.ps1
+++ b/JiraPS/Public/Remove-JiraSession.ps1
@@ -1,4 +1,4 @@
-function Remove-JiraSession {
+﻿function Remove-JiraSession {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding()]
     [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseShouldProcessForStateChangingFunctions', '')]

--- a/JiraPS/Public/Remove-JiraUser.ps1
+++ b/JiraPS/Public/Remove-JiraUser.ps1
@@ -1,4 +1,4 @@
-function Remove-JiraUser {
+﻿function Remove-JiraUser {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( ConfirmImpact = 'High', SupportsShouldProcess )]
     param(

--- a/JiraPS/Public/Remove-JiraVersion.ps1
+++ b/JiraPS/Public/Remove-JiraVersion.ps1
@@ -1,4 +1,4 @@
-function Remove-JiraVersion {
+﻿function Remove-JiraVersion {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( ConfirmImpact = 'High', SupportsShouldProcess )]
     param(

--- a/JiraPS/Public/Set-JiraConfigServer.ps1
+++ b/JiraPS/Public/Set-JiraConfigServer.ps1
@@ -1,4 +1,4 @@
-function Set-JiraConfigServer {
+﻿function Set-JiraConfigServer {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding()]
     [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseShouldProcessForStateChangingFunctions', '')]

--- a/JiraPS/Public/Set-JiraFilter.ps1
+++ b/JiraPS/Public/Set-JiraFilter.ps1
@@ -1,4 +1,4 @@
-function Set-JiraFilter {
+﻿function Set-JiraFilter {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( SupportsShouldProcess )]
     param(

--- a/JiraPS/Public/Set-JiraIssue.ps1
+++ b/JiraPS/Public/Set-JiraIssue.ps1
@@ -1,4 +1,4 @@
-function Set-JiraIssue {
+﻿function Set-JiraIssue {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( SupportsShouldProcess )]
     param(

--- a/JiraPS/Public/Set-JiraIssueLabel.ps1
+++ b/JiraPS/Public/Set-JiraIssueLabel.ps1
@@ -1,4 +1,4 @@
-function Set-JiraIssueLabel {
+﻿function Set-JiraIssueLabel {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( SupportsShouldProcess, DefaultParameterSetName = 'ReplaceLabels' )]
     param(

--- a/JiraPS/Public/Set-JiraUser.ps1
+++ b/JiraPS/Public/Set-JiraUser.ps1
@@ -1,4 +1,4 @@
-function Set-JiraUser {
+﻿function Set-JiraUser {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( SupportsShouldProcess, DefaultParameterSetName = 'ByNamedParameters' )]
     param(

--- a/JiraPS/Public/Set-JiraVersion.ps1
+++ b/JiraPS/Public/Set-JiraVersion.ps1
@@ -1,4 +1,4 @@
-function Set-JiraVersion {
+﻿function Set-JiraVersion {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding( SupportsShouldProcess )]
     param(

--- a/Tests/Build.Tests.ps1
+++ b/Tests/Build.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 Describe "Validation of build environment" -Tag Unit {
     BeforeAll {
@@ -7,6 +7,18 @@ Describe "Validation of build environment" -Tag Unit {
         Initialize-TestEnvironment
         $script:moduleToTest = Resolve-ModuleSource
         $script:moduleRoot = Resolve-ProjectRoot
+    }
+
+    Context "Compiled module" {
+        It "has a UTF-8 BOM on the compiled .psm1" {
+            $modulePath = Split-Path $moduleToTest -Parent
+            $psm1Path = Join-Path $modulePath "$((Get-Item $modulePath).Name).psm1"
+            $bytes = [System.IO.File]::ReadAllBytes($psm1Path)
+            $bytes.Count | Should -BeGreaterThan 3
+            $bytes[0] | Should -Be 0xEF
+            $bytes[1] | Should -Be 0xBB
+            $bytes[2] | Should -Be 0xBF
+        }
     }
 
     Context "CHANGELOG" {

--- a/Tests/Examples.Tests.ps1
+++ b/Tests/Examples.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertFrom-Json.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertFrom-Json.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertFrom-URLEncoded.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertFrom-URLEncoded.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraAttachment.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraAttachment.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraComment.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraComment.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraComponent.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraComponent.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraCreateMetaField.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraCreateMetaField.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraEditMetaField.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraEditMetaField.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraField.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraField.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraFilter.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraFilter.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraFilterPermission.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraFilterPermission.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraGroup.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraGroup.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraIssue.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraIssue.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraIssueLink.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraIssueLink.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraIssueLinkType.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraIssueLinkType.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraIssueType.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraIssueType.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraLink.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraLink.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraPriority.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraPriority.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraProject.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraProject.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraProjectRole.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraProjectRole.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraServerInfo.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraServerInfo.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraSession.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraSession.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraStatus.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraStatus.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraTransition.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraTransition.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraUser.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraUser.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraVersion.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraVersion.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraWorklogitem.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraWorklogitem.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-URLEncoded.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-URLEncoded.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/Test-ServerResponse.Unit.Tests.ps1
+++ b/Tests/Functions/Private/Test-ServerResponse.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Add-JiraFilterPermission.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Add-JiraFilterPermission.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Add-JiraGroupMember.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Add-JiraGroupMember.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Add-JiraIssueAttachment.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Add-JiraIssueAttachment.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "")]
 param()
 

--- a/Tests/Functions/Public/Add-JiraIssueComment.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Add-JiraIssueComment.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Add-JiraIssueLink.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Add-JiraIssueLink.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Add-JiraIssueWatcher.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Add-JiraIssueWatcher.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Add-JiraIssueWorklog.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Add-JiraIssueWorklog.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Find-JiraFilter.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Find-JiraFilter.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Format-Jira.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Format-Jira.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraComponent.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraComponent.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraConfigServer.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraConfigServer.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraField.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraField.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraFilter.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraFilter.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraFilterPermission.unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraFilterPermission.unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraGroup.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraGroup.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraGroupMember.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraGroupMember.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraIssue.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraIssue.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraIssueAttachment.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraIssueAttachment.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraIssueAttachmentFile.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraIssueAttachmentFile.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraIssueComment.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraIssueComment.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraIssueCreateMetadata.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraIssueCreateMetadata.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraIssueEditMetadata.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraIssueEditMetadata.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraIssueLink.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraIssueLink.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraIssueLinkType.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraIssueLinkType.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraIssueType.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraIssueType.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraIssueWatcher.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraIssueWatcher.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraIssueWorklog.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraIssueWorklog.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraPriority.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraPriority.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraProject.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraProject.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraRemoteLink.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraRemoteLink.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraServerInformation.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraServerInformation.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraSession.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraSession.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraUser.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraUser.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraVersion.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraVersion.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Invoke-JiraIssueTransition.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Invoke-JiraIssueTransition.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Invoke-JiraMethod.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Invoke-JiraMethod.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "")]
 param()

--- a/Tests/Functions/Public/Move-JiraVersion.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Move-JiraVersion.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/New-JiraFilter.Unit.Tests.ps1
+++ b/Tests/Functions/Public/New-JiraFilter.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/New-JiraGroup.Unit.Tests.ps1
+++ b/Tests/Functions/Public/New-JiraGroup.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/New-JiraIssue.Unit.Tests.ps1
+++ b/Tests/Functions/Public/New-JiraIssue.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/New-JiraSession.Unit.Tests.ps1
+++ b/Tests/Functions/Public/New-JiraSession.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/New-JiraUser.Unit.Tests.ps1
+++ b/Tests/Functions/Public/New-JiraUser.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/New-JiraVersion.Unit.Tests.ps1
+++ b/Tests/Functions/Public/New-JiraVersion.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 param()
 

--- a/Tests/Functions/Public/Remove-JiraFilter.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Remove-JiraFilter.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Remove-JiraFilterPermission.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Remove-JiraFilterPermission.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Remove-JiraGroup.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Remove-JiraGroup.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Remove-JiraGroupMember.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Remove-JiraGroupMember.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Remove-JiraIssue.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Remove-JiraIssue.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Remove-JiraIssueAttachment.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Remove-JiraIssueAttachment.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Remove-JiraIssueLink.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Remove-JiraIssueLink.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Remove-JiraIssueWatcher.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Remove-JiraIssueWatcher.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Remove-JiraRemoteLink.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Remove-JiraRemoteLink.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Remove-JiraSession.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Remove-JiraSession.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 Describe "Remove-JiraSession" -Tag 'Unit' {
 

--- a/Tests/Functions/Public/Remove-JiraUser.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Remove-JiraUser.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Remove-JiraVersion.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Remove-JiraVersion.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Resolve-JiraError.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Resolve-JiraError.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Set-JiraConfigServer.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Set-JiraConfigServer.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Set-JiraFilter.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Set-JiraFilter.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Set-JiraIssue.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Set-JiraIssue.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Set-JiraIssueLabel.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Set-JiraIssueLabel.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Set-JiraUser.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Set-JiraUser.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Set-JiraVersion.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Set-JiraVersion.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Help.Tests.ps1
+++ b/Tests/Help.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/Helpers/TestTools.ps1"

--- a/Tests/Helpers/Get-FileEncoding.ps1
+++ b/Tests/Helpers/Get-FileEncoding.ps1
@@ -1,4 +1,4 @@
-function Get-FileEncoding {
+﻿function Get-FileEncoding {
     <#
     .SYNOPSIS
         Attempt to determine a file type based on a BOM or file header.

--- a/Tests/Helpers/Shared.ps1
+++ b/Tests/Helpers/Shared.ps1
@@ -1,4 +1,4 @@
-# THIS FILE IS DEPRECATED. PLEASE DO NOT MAKE ANY CHANGES HERE.
+﻿# THIS FILE IS DEPRECATED. PLEASE DO NOT MAKE ANY CHANGES HERE.
 # TODO: Migrate any useful functions to ./Tests/Helpers/TestTools.ps1
 
 #Requires -Modules Pester

--- a/Tests/JiraPS.Integration.Tests.old.ps1
+++ b/Tests/JiraPS.Integration.Tests.old.ps1
@@ -1,4 +1,4 @@
-# Describe 'Load Module' -Tag 'Integration' {
+﻿# Describe 'Load Module' -Tag 'Integration' {
 #     # ARRANGE
 #     Remove-Module JiraPS -Force -ErrorAction SilentlyContinue
 

--- a/Tests/JiraPS.Tests.ps1
+++ b/Tests/JiraPS.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/Helpers/TestTools.ps1"

--- a/Tests/PSScriptAnalyzer.Tests.ps1
+++ b/Tests/PSScriptAnalyzer.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 #requires -modules PSScriptAnalyzer
 
 Describe "PSScriptAnalyzer Tests" -Tag "Unit" {

--- a/Tests/Project.Tests.ps1
+++ b/Tests/Project.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/Helpers/TestTools.ps1"

--- a/Tests/Style.Tests.ps1
+++ b/Tests/Style.Tests.ps1
@@ -1,4 +1,4 @@
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 Describe "Style rules" -Tag "Unit" {
     BeforeAll {
@@ -45,18 +45,18 @@ Describe "Style rules" -Tag "Unit" {
         }
     }
 
-    It "uses UTF-8 for code files" {
+    It "uses UTF-8 with BOM for code files" {
         $badFiles = @(
             foreach ($file in $codeFiles) {
                 $encoding = Get-FileEncoding -Path $file.FullName
-                if ($encoding -and $encoding.encoding -ne "UTF8") {
+                if ($encoding -and $encoding.encoding -ne "UTF8-BOM") {
                     $file.FullName
                 }
             }
         )
 
         if ($badFiles.Count -gt 0) {
-            throw "The following files are not encoded with UTF-8 (no BOM):`n  $($badFiles -join "`n  ")"
+            throw "The following files are not encoded with UTF-8 BOM (required for PS v5 compatibility):`n  $($badFiles -join "`n  ")"
         }
     }
 

--- a/Tools/BuildTools.psm1
+++ b/Tools/BuildTools.psm1
@@ -1,4 +1,4 @@
-#requires -Modules @{ModuleName='PowerShellGet';ModuleVersion='1.6.0'}
+﻿#requires -Modules @{ModuleName='PowerShellGet';ModuleVersion='1.6.0'}
 
 function Assert-True {
     [CmdletBinding( DefaultParameterSetName = 'ByBool' )]

--- a/Tools/build.requirements.psd1
+++ b/Tools/build.requirements.psd1
@@ -1,4 +1,4 @@
-@(
+﻿@(
     @{ ModuleName = "InvokeBuild"; RequiredVersion = "5.14.22" }
     @{ ModuleName = "BuildHelpers"; RequiredVersion = "2.0.16" }
     @{ ModuleName = "Metadata"; RequiredVersion = "1.5.7" }

--- a/Tools/setup.ps1
+++ b/Tools/setup.ps1
@@ -1,4 +1,4 @@
-#requires -Module PowerShellGet
+﻿#requires -Module PowerShellGet
 
 [CmdletBinding()]
 param()


### PR DESCRIPTION
## Summary

- Enforce UTF-8 with BOM across all PowerShell source and test files to ensure PowerShell v5 on Windows parses them correctly (v5 treats BOM-less UTF-8 as Windows-1252, corrupting non-ASCII characters and causing parse errors)
- Update `.editorconfig` with `charset = utf-8-bom` for PS file types
- Update build script to write compiled `.psm1` with BOM instead of stripping it via `Remove-Utf8Bom`
- Update `Style.Tests.ps1` to require `UTF8-BOM` encoding on all code files
- Add `Build.Tests.ps1` assertion that the compiled `.psm1` starts with the BOM signature (`EF BB BF`)
- Re-save all 213 `.ps1`/`.psm1`/`.psd1` files with BOM

## Context

This was discovered when non-ASCII characters (em-dashes `—`) in `Write-Debug` strings caused the compiled module to fail parsing on PS v5 CI. The byte `0x94` (part of UTF-8 encoded `—`) is interpreted as `"` (right double quote) in Windows-1252, prematurely terminating strings and breaking the parser.

## Test plan

- [x] `Invoke-Build .` passes locally (3338/3338, only pre-existing `test.ps1` PSScriptAnalyzer warning)
- [ ] CI passes on both PowerShell v5 (Windows) and v7 (all platforms)
- [ ] `Build.Tests.ps1` "has a UTF-8 BOM on the compiled .psm1" test passes
- [ ] `Style.Tests.ps1` "uses UTF-8 with BOM for code files" test passes

Made with [Cursor](https://cursor.com)