### PR TITLE
docs: add vendor-agnostic AI instruction architecture

### DIFF
--- a/.cursor/rules/jiraps.mdc
+++ b/.cursor/rules/jiraps.mdc
@@ -1,0 +1,33 @@
+---
+description: JiraPS PowerShell module development rules
+globs: ["**/*.ps1", "**/*.psm1", "**/*.psd1"]
+---
+
+# PowerShell File Rules (Cursor)
+
+This file applies to PowerShell files. It references shared rules.
+
+**Canonical sources**:
+- Project rules: `AGENTS.md`
+- PowerShell rules: `.github/ai-context/powershell-rules.md`
+
+## Quick Reference
+
+1. **One Functionality Per Commit** — code + tests + docs + green tests
+2. **Cloud AND Data Center** — all API changes must work on both
+3. **User Identity** — `accountId` for Cloud, `username`/`name` for DC
+4. **REST calls** — always go through `Invoke-JiraMethod`
+5. **Tests required** — every function needs `.Unit.Tests.ps1`
+6. **Run tests** — `Invoke-Build -Task Build, Test` (must build first!)
+
+## File Locations
+
+| Type | Location |
+|------|----------|
+| Public functions | `JiraPS/Public/` |
+| Private functions | `JiraPS/Private/` |
+| Public tests | `Tests/Functions/Public/` |
+| Private tests | `Tests/Functions/Private/` |
+| Docs | `docs/en-US/commands/` |
+
+For full rules, read `AGENTS.md` and `.github/ai-context/powershell-rules.md`.

--- a/.github/ai-context/powershell-rules.md
+++ b/.github/ai-context/powershell-rules.md
@@ -1,0 +1,145 @@
+# PowerShell Development Rules
+
+These rules apply to all `.ps1`, `.psm1`, and `.psd1` files in JiraPS.
+
+## Jira Cloud vs Data Center Compatibility
+
+JiraPS targets both Jira Cloud and Jira Data Center. These are different
+products with different API behaviors. Any change to API endpoints, request
+bodies, or response handling MUST work on both deployment types.
+
+### User Identity (Critical)
+
+- Cloud uses `accountId` (GDPR removed `username`/`name`)
+- Data Center uses `username` / `name`
+- If a function uses `?username=` or `@{name=...}`, it only works on DC
+- If a function uses `?accountId=` or `@{accountId=...}`, it only works on Cloud
+- Correct approach: branch based on deployment type
+
+Affected functions: `Get-JiraUser`, `Set-JiraUser`, `Remove-JiraUser`,
+`New-JiraIssue` (reporter), `Set-JiraIssue` (assignee),
+`Invoke-JiraIssueTransition`, `Add-JiraGroupMember`, `Remove-JiraGroupMember`,
+`Add-JiraIssueWatcher`, `Remove-JiraIssueWatcher`, `Resolve-JiraUser`
+
+### Text Fields (ADF vs Plain Text)
+
+- Cloud v3: description, comment body use Atlassian Document Format (ADF) — JSON with `type: "doc"`
+- Data Center: these fields are plain strings or wiki markup
+- Sending ADF to DC produces garbled content or API errors
+- `ConvertTo-ADF` / `ConvertFrom-ADF` must only be used for Cloud
+
+### Search Endpoint
+
+- Cloud: `POST /rest/api/3/search/jql` (JSON body, token pagination)
+- Data Center: `GET /rest/api/2/search` (query params, offset pagination)
+- These are NOT interchangeable
+
+### API Version
+
+- Do NOT blindly swap `/rest/api/2/` to `/rest/api/3/`
+- Cloud is migrating to v3; Data Center retains full v2 support
+- Endpoint version changes must be deployment-aware
+
+### Deployment Detection
+
+- `Get-JiraServerInformation` returns `deploymentType` (`Cloud` or `Server`)
+- Use this value to branch Cloud/DC-specific logic
+
+## PowerShell Patterns
+
+### REST API Calls
+
+All HTTP calls go through `Invoke-JiraMethod`:
+
+```powershell
+$parameter = @{
+    URI    = "$($script:JiraServerUrl)/rest/api/2/issue/$IssueKey"
+    Method = "GET"
+}
+$result = Invoke-JiraMethod @parameter
+```
+
+### Type Conversion
+
+Use `ConvertTo-*` functions to transform API responses:
+
+```powershell
+$result = Invoke-JiraMethod @parameter
+ConvertTo-JiraIssue -InputObject $result
+```
+
+### Parameter Patterns
+
+```powershell
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory, ValueFromPipeline)]
+    [ValidateNotNullOrEmpty()]
+    [String]$IssueKey,
+
+    [PSCredential]
+    [System.Management.Automation.Credential()]
+    $Credential = [System.Management.Automation.PSCredential]::Empty
+)
+```
+
+### Error Handling
+
+```powershell
+try {
+    $result = Invoke-JiraMethod @params
+} catch {
+    $PSCmdlet.ThrowTerminatingError($_)
+}
+```
+
+## Testing Requirements
+
+- Every function needs a corresponding `.Unit.Tests.ps1` file
+- Use Pester 5 syntax
+- Public functions: `Tests/Functions/Public/<FunctionName>.Unit.Tests.ps1`
+- Private functions: `Tests/Functions/Private/<FunctionName>.Unit.Tests.ps1`
+- Use `.template.ps1` files as starting points
+- Tests must cover both Cloud and DC response shapes
+
+## Running Tests
+
+**IMPORTANT**: Tests run against the *built* module in `Release/`, not the source files.
+You MUST build before testing.
+
+```powershell
+# First time setup (install dependencies)
+./Tools/setup.ps1
+
+# Build AND test (standard workflow)
+Invoke-Build -Task Build, Test
+
+# Or separately:
+Invoke-Build -Task Build    # Compiles module into Release/
+Invoke-Build -Task Test     # Runs Pester tests against Release/
+```
+
+### Available Build Tasks
+
+| Task | What it does |
+|------|--------------|
+| `Clean` | Removes `Release/` and test artifacts |
+| `Build` | Compiles module into `Release/` (includes Clean) |
+| `Test` | Runs Pester tests against built module |
+| `GenerateExternalHelp` | Generates help XML from `docs/` markdown |
+
+### Common Mistakes
+
+- **Running `Invoke-Pester` directly** — Won't work; tests expect the compiled module
+- **Running `Invoke-Build -Task Test` without building** — Tests will fail or use stale code
+- **Forgetting `./Tools/setup.ps1`** — Missing dependencies (Pester, InvokeBuild, etc.)
+
+## Review Checklist
+
+When changing PowerShell files:
+
+1. Does the change work on BOTH Cloud and Data Center?
+2. If user identity is involved: is `accountId` used for Cloud and `username`/`name` for DC?
+3. If text fields are read/written: is ADF conversion conditional on deployment type?
+4. Are tests written/updated?
+5. Do tests pass? (`Invoke-Build -Task Build && Invoke-Build -Task Test`)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,28 @@
+# GitHub Copilot Instructions
+
+This file exists for GitHub Copilot global instructions.
+
+**Canonical sources**:
+- Project rules: [AGENTS.md](../AGENTS.md)
+- PowerShell rules: [ai-context/powershell-rules.md](ai-context/powershell-rules.md)
+- File-pattern rules: [instructions/](instructions/) (Copilot-specific)
+
+## Quick Reference
+
+1. **One Functionality Per Commit** — code + tests + docs + green tests
+2. **Cloud AND Data Center** — all API changes must work on both Jira deployment types
+3. **User Identity** — `accountId` for Cloud, `username`/`name` for DC
+4. **REST calls** — always go through `Invoke-JiraMethod`
+5. **Tests required** — every function needs `.Unit.Tests.ps1`
+6. **Run tests before commit** — `Invoke-Build -Task Build, Test` (must build first!)
+
+## File Locations
+
+| Type | Location |
+|------|----------|
+| Public functions | `JiraPS/Public/` |
+| Private functions | `JiraPS/Private/` |
+| Tests | `Tests/Functions/Public/` or `Tests/Functions/Private/` |
+| Docs | `docs/en-US/commands/` |
+
+For full instructions, read `AGENTS.md` and `ai-context/powershell-rules.md`.

--- a/.github/instructions/jira-api-compatibility.instructions.md
+++ b/.github/instructions/jira-api-compatibility.instructions.md
@@ -2,72 +2,18 @@
 applyTo: "**/*.ps1"
 ---
 
-# Jira Cloud vs Data Center Compatibility
+# PowerShell File Rules (GitHub Copilot)
 
-JiraPS targets both Jira Cloud and Jira Data Center. These are different
-products with different API behaviors. Any change to API endpoints, request
-bodies, or response handling MUST work on both deployment types.
+This file applies to all `.ps1` files. It references shared rules.
 
-## User Identity (Critical)
+**Canonical source**: [.github/ai-context/powershell-rules.md](../ai-context/powershell-rules.md)
 
-- Cloud uses `accountId` (GDPR removed `username`/`name`)
-- Data Center uses `username` / `name`
-- If a function uses `?username=` or `@{name=...}`, it only works on DC
-- If a function uses `?accountId=` or `@{accountId=...}`, it only works on Cloud
-- Correct approach: branch based on deployment type
+## Quick Reference
 
-Affected: `Get-JiraUser`, `Set-JiraUser`, `Remove-JiraUser`, `New-JiraIssue`
-(reporter), `Set-JiraIssue` (assignee), `Invoke-JiraIssueTransition`,
-`Add-JiraGroupMember`, `Remove-JiraGroupMember`, `Add-JiraIssueWatcher`,
-`Remove-JiraIssueWatcher`, `Resolve-JiraUser`
+1. **Cloud AND Data Center** — all changes must work on both Jira deployment types
+2. **User Identity** — `accountId` for Cloud, `username`/`name` for DC
+3. **ADF** — only use `ConvertTo-ADF`/`ConvertFrom-ADF` for Cloud
+4. **REST calls** — always go through `Invoke-JiraMethod`
+5. **Tests required** — every function needs `.Unit.Tests.ps1`
 
-## Text Fields (ADF vs Plain Text)
-
-- Cloud v3: description, comment body, and similar fields use Atlassian
-  Document Format (ADF) — a JSON structure with `type: "doc"`
-- Data Center: these fields are plain strings or wiki markup
-- Sending ADF to DC produces garbled content or API errors
-- Reading DC plain strings through ADF conversion is wasteful
-- `ConvertTo-AtlassianDocumentFormat` (alias `ConvertTo-ADF`) must only be used for Cloud
-- `ConvertFrom-AtlassianDocumentFormat` (alias `ConvertFrom-ADF`) must only be used for Cloud
-  (though the function gracefully handles strings as a fallback)
-- Both functions are public so users can convert ADF manually when using
-  `Invoke-JiraMethod` against Cloud v3 endpoints — JiraPS's built-in
-  read/write commands don't cover every API surface
-
-## Search Endpoint
-
-- Cloud: `POST /rest/api/3/search/jql` (JSON body, token pagination)
-- Data Center: `GET /rest/api/2/search` (query params, offset pagination)
-- These are NOT interchangeable — the Cloud endpoint may not exist on DC
-- `nextPageToken` pagination is Cloud-only; DC uses `startAt`/`maxResults`
-
-## API Version
-
-- Do NOT blindly swap `/rest/api/2/` to `/rest/api/3/` across all endpoints
-- Cloud is migrating to v3; Data Center retains full v2 support
-- v3 availability on DC varies by release version
-- Endpoint version changes must be deployment-aware
-
-## Deployment Detection
-
-- `Get-JiraServerInformation` returns `deploymentType` (`Cloud` or `Server`)
-- This value is mapped in `ConvertTo-JiraServerInfo` but NOT used for branching
-- Any Cloud/DC-aware logic should use this value to select behavior
-
-## Review Checklist
-
-When reviewing changes to API endpoints or REST call handling:
-
-1. Does the change work on BOTH Cloud and Data Center?
-2. If user identity is involved: is `accountId` used for Cloud and
-   `username`/`name` for DC?
-3. If text fields are read/written: is ADF conversion conditional on
-   deployment type?
-4. If search is changed: does it handle both POST/token (Cloud) and
-   GET/offset (DC) patterns?
-5. If URL version is changed to v3: are query params and body fields
-   also updated to match v3 semantics?
-6. Does the PR claim backward compatibility? Is that claim accurate
-   for BOTH deployment types?
-7. Do tests cover both Cloud and DC response shapes?
+For full rules, read `.github/ai-context/powershell-rules.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,69 @@
-# GitHub Copilot Instructions for JiraPS
+# AI Instructions for JiraPS
+
+> **This file is the single source of truth for AI coding assistants.**
+> It is read by GitHub Copilot, Cursor, Claude Code, and other AI tools.
+> Tool-specific files (e.g., `CLAUDE.md`, `.cursor/rules/`) reference this file.
+
+## AI Tool Compatibility
+
+This repository supports multiple AI coding tools without vendor lock-in:
+
+| Tool | Entry Point | References |
+|------|-------------|------------|
+| **GitHub Copilot** | `.github/copilot-instructions.md` | → `AGENTS.md`, `ai-context/` |
+| **Cursor** | `.cursor/rules/*.mdc` | → `AGENTS.md`, `ai-context/` |
+| **Claude Code** | `CLAUDE.md` | → `AGENTS.md`, `ai-context/` |
+| **Any tool** | `AGENTS.md` (this file) | Canonical project rules |
+
+### Directory Structure
+
+```
+AGENTS.md                           # Project-level rules (this file)
+CLAUDE.md                           # Claude Code entry point
+.cursor/rules/jiraps.mdc            # Cursor entry point
+.github/
+├── copilot-instructions.md         # Copilot entry point
+├── ai-context/                     # Shared context (tool-agnostic)
+│   └── powershell-rules.md         # PowerShell-specific rules
+└── instructions/                   # Copilot file-pattern rules
+    └── *.instructions.md           # Applied by file glob
+```
+
+### Editing Guidelines
+
+| To change... | Edit this file |
+|--------------|----------------|
+| Project-wide rules | `AGENTS.md` |
+| PowerShell-specific rules | `.github/ai-context/powershell-rules.md` |
+| Tool entry points | Only if adding quick-reference summaries |
+
+---
+
+## One Functionality Per Commit
+
+> **RULE**: A commit is a complete, shippable unit of work. It includes the code,
+> the tests, and the documentation — all passing. Incomplete work is not committable.
+
+### What "Complete" Means
+
+Every commit must include **all** of the following:
+
+| Component | Required | Location |
+|-----------|----------|----------|
+| **Code** | The implementation | `JiraPS/Public/` or `JiraPS/Private/` |
+| **Unit Tests** | Tests that verify the code works | `Tests/Functions/Public/` or `Tests/Functions/Private/` |
+| **Green Tests** | All tests passing | Run `Invoke-Build -Task Build, Test` |
+| **Documentation** | Updated docs for user-facing changes | `docs/en-US/commands/*.md`, `CHANGELOG.md` |
+| **Linter Clean** | No new PSScriptAnalyzer errors | Run PSScriptAnalyzer |
+
+### Enforcement
+
+- **Do not ask** if the user wants to skip tests or docs — they are part of the functionality
+- **Do not commit** until tests are green
+- **Do not treat code as "done"** if any component is missing
+- If implementing multiple functionalities, make multiple commits — one per functionality
+
+---
 
 ## Project Overview
 
@@ -16,7 +81,7 @@
 > **JiraPS targets both Jira Cloud AND Data Center.** These have different
 > APIs (accountId vs username, ADF vs plain text, different search and
 > pagination). Changes must work on both. See
-> `.github/instructions/jira-api-compatibility.instructions.md` for rules.
+> `.github/ai-context/powershell-rules.md` for detailed rules.
 
 ### Known Technical Debt
 
@@ -116,24 +181,32 @@ param(
 
 ### Build Process
 
-**Build Tasks** (via `Invoke-Build`):
+> **IMPORTANT**: Tests run against the *built* module in `Release/`, not the source files.
+> You MUST build before testing. Running `Invoke-Pester` directly will not work.
 
-1. `Clean`: Removes Release/ and test artifacts
-2. `Build`: Compiles module into Release/
-    - Copies module files
-    - Compiles all Private/Public functions into single .psm1
-    - Generates external help with PlatyPS
-    - Updates manifest with exported functions
-3. `Test`: Runs Pester tests on built module
-4. `Publish`: Publishes to PowerShell Gallery (on release tags)
-
-**Run Locally**:
+**Standard Workflow**:
 
 ```powershell
-./Tools/setup.ps1              # Install dependencies
-Invoke-Build -Task Build       # Build module
-Invoke-Build -Task Test        # Run tests
+./Tools/setup.ps1              # First time: install dependencies
+Invoke-Build -Task Build, Test # Build and test in one command
 ```
+
+**Build Tasks** (via `Invoke-Build`):
+
+| Task | What it does |
+|------|--------------|
+| `Clean` | Removes `Release/` and test artifacts |
+| `Build` | Compiles module into `Release/` (runs Clean first) |
+| `Test` | Runs Pester tests against built module |
+| `GenerateExternalHelp` | Generates help XML from `docs/` markdown |
+| `Publish` | Publishes to PowerShell Gallery (release tags only) |
+
+**Common Mistakes**:
+
+- ❌ `Invoke-Pester` directly — Tests expect the compiled module in `Release/`
+- ❌ `Invoke-Build -Task Test` without building — Uses stale or missing code
+- ❌ Forgetting `./Tools/setup.ps1` — Missing Pester, InvokeBuild, etc.
+- ✅ `Invoke-Build -Task Build, Test` — Correct: build then test
 
 ## API & REST Patterns
 
@@ -305,8 +378,7 @@ function Get-JiraExample {
 5. **Build and test**:
 
 ```powershell
-Invoke-Build -Task Build
-Invoke-Build -Task Test
+Invoke-Build -Task Build, Test
 ```
 
 ### Updating for API Changes
@@ -439,9 +511,9 @@ New-JiraIssue -Fields $fields ...
 
 ### DO:
 
+-   ✅ **Follow "One Functionality Per Commit"** — code + tests + docs + green tests = one commit
 -   ✅ Maintain backward compatibility (large user base on **both Cloud and Data Center**)
 -   ✅ Follow existing patterns (especially `Invoke-JiraMethod` → `ConvertTo-*`)
--   ✅ Write/update unit tests with Pester 5 syntax
 -   ✅ Update CHANGELOG.md for user-facing changes
 -   ✅ Generate help after adding/modifying cmdlets
 -   ✅ Test on both Windows PowerShell 5.1 and PowerShell Core 7+
@@ -452,11 +524,13 @@ New-JiraIssue -Fields $fields ...
 
 ### DON'T:
 
+-   ❌ **Commit incomplete functionality** — code without tests/docs is not committable
+-   ❌ **Commit with red tests** — all tests must pass before commit
+-   ❌ **Ask to skip any part of "One Functionality Per Commit"** — just complete it
 -   ❌ Break existing cmdlet interfaces without major version bump
 -   ❌ Add runtime dependencies (keep module pure)
 -   ❌ Bypass `Invoke-JiraMethod` for REST calls
 -   ❌ Hardcode server URLs (use `$script:JiraServerUrl`)
--   ❌ Forget to update documentation in `docs/`
 -   ❌ Mix Pester 4 and 5 syntax in same file
 -   ❌ Commit Release/ directory (build artifact)
 -   ❌ Assume Cloud-only or DC-only usage — always handle both deployment types
@@ -546,34 +620,28 @@ $result.PSObject.TypeNames.Insert(0, 'JiraPS.Issue')
 ## Example Contribution Workflow
 
 ```powershell
-# 1. Checkout and branch
-git checkout master
-git pull origin master
+# 1. Setup
+git checkout master && git pull origin master
 git checkout -b feature/my-enhancement
-
-# 2. Install dependencies
 ./Tools/setup.ps1
 
-# 3. Make changes to JiraPS/Public/*.ps1 or Private/*.ps1
+# 2. Implement ONE functionality (code + tests + docs together)
+#    - Write/modify code in JiraPS/Public/ or JiraPS/Private/
+#    - Write/update tests in Tests/Functions/
+#    - Update docs in docs/en-US/commands/ and CHANGELOG.md
 
-# 4. Update tests in Tests/Functions/*.Unit.Tests.ps1
-
-# 5. Build and test
-Invoke-Build -Task Build
-Invoke-Build -Task Test
-
-# 6. Update documentation if needed
-# Edit docs/en-US/commands/*.md
+# 3. Verify before commit (all must pass)
+Invoke-Build -Task Build, Test   # ⛔ Red tests = not committable
 Invoke-Build -Task GenerateExternalHelp
 
-# 7. Update CHANGELOG.md under [NEXT VERSION]
-
-# 8. Commit and push
+# 4. Commit the complete functionality
 git add .
 git commit -m "Add: Description of change"
-git push origin feature/my-enhancement
 
-# 9. Create PR to master branch
+# 5. Repeat steps 2-4 for each additional functionality
+
+# 6. Push and create PR
+git push origin feature/my-enhancement
 ```
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,27 @@
+# Claude Code Instructions
+
+This file exists for Claude Code compatibility.
+
+**Canonical sources**:
+- Project rules: [AGENTS.md](AGENTS.md)
+- PowerShell rules: [.github/ai-context/powershell-rules.md](.github/ai-context/powershell-rules.md)
+
+## Quick Reference
+
+1. **One Functionality Per Commit** — code + tests + docs + green tests
+2. **Cloud AND Data Center** — all API changes must work on both Jira deployment types
+3. **User Identity** — `accountId` for Cloud, `username`/`name` for DC
+4. **REST calls** — always go through `Invoke-JiraMethod`
+5. **Tests required** — every function needs `.Unit.Tests.ps1`
+6. **Run tests before commit** — `Invoke-Build -Task Build, Test` (must build first!)
+
+## File Locations
+
+| Type | Location |
+|------|----------|
+| Public functions | `JiraPS/Public/` |
+| Private functions | `JiraPS/Private/` |
+| Tests | `Tests/Functions/Public/` or `Tests/Functions/Private/` |
+| Docs | `docs/en-US/commands/` |
+
+For full instructions, read `AGENTS.md` and `.github/ai-context/powershell-rules.md`.


### PR DESCRIPTION
## Summary

Add vendor-agnostic AI instruction architecture for multi-tool support (GitHub Copilot, Cursor, Claude Code).

## Changes

- Restructure `AGENTS.md` to be tool-agnostic (renamed from "GitHub Copilot Instructions")
- Add "One Functionality Per Commit" rule: code + tests + docs + green tests = one commit
- Add AI Tool Compatibility section with directory structure
- Create tool-specific entry points:
  - `CLAUDE.md` for Claude Code
  - `.github/copilot-instructions.md` for GitHub Copilot  
  - `.cursor/rules/jiraps.mdc` for Cursor
- Extract shared PowerShell rules to `.github/ai-context/powershell-rules.md`
- Simplify `.github/instructions/` to reference shared context
- Document correct test workflow: `Invoke-Build -Task Build, Test`
- Add common mistakes section for test execution

## Files Changed

| File | Purpose |
|------|---------|
| `AGENTS.md` | Canonical project rules (updated) |
| `CLAUDE.md` | Claude Code entry point (new) |
| `.github/copilot-instructions.md` | Copilot entry point (new) |
| `.cursor/rules/jiraps.mdc` | Cursor entry point (new) |
| `.github/ai-context/powershell-rules.md` | Shared PowerShell rules (new) |
| `.github/instructions/*.md` | Simplified to reference shared context |

## Test plan

- [x] Documentation only - no code changes
- [x] Verified all tool-specific files reference canonical sources