### PR TITLE
Add homepage notification on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,3 +51,12 @@ jobs:
           prerelease: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Notify homepage to update submodule
+        if: ${{ !contains(github.ref_name, 'alpha') && !contains(github.ref_name, 'beta') && !contains(github.ref_name, 'rc') }}
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.HOMEPAGE_PAT }}
+          repository: AtlassianPS/AtlassianPS.github.io
+          event-type: module-release
+          client-payload: '{"module": "JiraPS", "version": "${{ github.ref_name }}"}'


### PR DESCRIPTION
## Summary

Adds a `repository_dispatch` step to the release workflow that notifies the AtlassianPS homepage when a stable release is published.

- Triggers `module-release` event to `AtlassianPS/AtlassianPS.github.io`
- Only fires for stable releases (excludes alpha/beta/rc)
- Enables automatic submodule update PRs on the homepage

## Requirements

- `HOMEPAGE_PAT` secret must be configured with access to dispatch events on the homepage repo

## Related

This works with the new `update-submodule.yml` workflow added to the homepage: AtlassianPS/AtlassianPS.github.io@5a405b7

Made with [Cursor](https://cursor.com)