### PR TITLE
Paginate Get-JiraIssueCreateMetadata results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@ Both accept `SecureString` and work seamlessly in automation. See the updated [a
 - **BREAKING**: Minimum PowerShell version raised from 3.0 to 5.1. Windows PowerShell 3.x and 4.x are no longer supported.
 - Removed custom `ConvertFrom-Json` override (PS 5.1 native cmdlet has sufficient 2GB JSON limit)
 - Removed legacy PSv3 workaround for Accept header in module initialization
+## Unreleased
+
+### Fixed
+
+- `Get-JiraIssueCreateMetadata` now walks all pages of the Jira Cloud createmeta response instead of truncating at the default page size. The cmdlet opts into `SupportsPaging`, so `-First`, `-Skip`, and `-IncludeTotalCount` are also supported.
 
 ## 2.16 - 2026-04-13
 

--- a/JiraPS/Private/ConvertTo-JiraCreateMetaField.ps1
+++ b/JiraPS/Private/ConvertTo-JiraCreateMetaField.ps1
@@ -7,10 +7,8 @@
     )
 
     process {
-        foreach ($i in $InputObject.values) {
+        foreach ($item in $InputObject) {
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Converting `$InputObject to custom object"
-
-            $item = $i
 
             $props = @{
                 'Id'              = $item.fieldId

--- a/JiraPS/Public/Get-JiraIssueCreateMetadata.ps1
+++ b/JiraPS/Public/Get-JiraIssueCreateMetadata.ps1
@@ -1,7 +1,7 @@
 ﻿function Get-JiraIssueCreateMetadata {
     # .ExternalHelp ..\JiraPS-help.xml
     [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseSingularNouns', '')]
-    [CmdletBinding()]
+    [CmdletBinding( SupportsPaging )]
     param(
         [Parameter( Mandatory )]
         [String]
@@ -42,35 +42,20 @@
         }
 
         $parameter = @{
-            URI        = $resourceURi -f $projectObj.Id, $issueTypeObj.Id
-            Method     = "GET"
-            Credential = $Credential
+            URI          = $resourceURi -f $projectObj.Id, $issueTypeObj.Id
+            Method       = "GET"
+            GetParameter = @{ maxResults = $script:DefaultPageSize }
+            Paging       = $true
+            Credential   = $Credential
+        }
+
+        # Forward PowerShell's SupportsPaging common parameters (First/Skip/IncludeTotalCount)
+        ($PSCmdlet.PagingParameters | Get-Member -MemberType Property).Name | ForEach-Object {
+            $parameter[$_] = $PSCmdlet.PagingParameters.$_
         }
 
         Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
-        $result = Invoke-JiraMethod @parameter
-
-        if ($result) {
-            if (@($result.values).Count -eq 0) {
-                $errorMessage = @{
-                    Category         = "InvalidResult"
-                    CategoryActivity = "Validating response"
-                    Message          = "No values were found for the given project [$Project]. Use Get-JiraProject for more details."
-                }
-                Write-Error @errorMessage
-            }
-
-            Write-Output (ConvertTo-JiraCreateMetaField -InputObject $result)
-        }
-        else {
-            $exception = ([System.ArgumentException]"No results")
-            $errorId = 'IssueMetadata.ObjectNotFound'
-            $errorCategory = 'ObjectNotFound'
-            $errorTarget = $Project
-            $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
-            $errorItem.ErrorDetails = "No metadata found for project $Project and issueType $IssueType."
-            throw $errorItem
-        }
+        Invoke-JiraMethod @parameter | ConvertTo-JiraCreateMetaField
     }
 
     end {

--- a/Tests/Functions/Private/ConvertTo-JiraCreateMetaField.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraCreateMetaField.Unit.Tests.ps1
@@ -15,69 +15,71 @@ InModuleScope JiraPS {
             . "$PSScriptRoot/../../Helpers/TestTools.ps1"
 
             #region Definitions
+            # After the pagination refactor, ConvertTo-JiraCreateMetaField
+            # consumes one field item per input instead of the full envelope.
+            # The fixture mirrors what Invoke-PaginatedRequest streams to the
+            # converter: individual entries from the "values" collection.
             $sampleJson = @'
-{
-    "values": [
-        {
-            "required": true,
-            "schema": {
-                "type": "string",
-                "system": "summary"
-            },
-            "name": "Summary",
-            "fieldId": "summary",
-            "hasDefaultValue": false,
-            "operations": [
-                "set"
-            ]
+[
+    {
+        "required": true,
+        "schema": {
+            "type": "string",
+            "system": "summary"
         },
-        {
-            "required": false,
-            "schema": {
-                "type": "priority",
-                "system": "priority"
+        "name": "Summary",
+        "fieldId": "summary",
+        "hasDefaultValue": false,
+        "operations": [
+            "set"
+        ]
+    },
+    {
+        "required": false,
+        "schema": {
+            "type": "priority",
+            "system": "priority"
+        },
+        "name": "Priority",
+        "fieldId": "priority",
+        "hasDefaultValue": true,
+        "operations": [
+            "set"
+        ],
+        "allowedValues": [
+            {
+                "self": "http://jiraserver.example.com/rest/api/2/priority/1",
+                "iconUrl": "http://jiraserver.example.com/images/icons/priorities/blocker.png",
+                "name": "Block",
+                "id": "1"
             },
-            "name": "Priority",
-            "fieldId": "priority",
-            "hasDefaultValue": true,
-            "operations": [
-                "set"
-            ],
-            "allowedValues": [
-                {
-                    "self": "http://jiraserver.example.com/rest/api/2/priority/1",
-                    "iconUrl": "http://jiraserver.example.com/images/icons/priorities/blocker.png",
-                    "name": "Block",
-                    "id": "1"
-                },
-                {
-                    "self": "http://jiraserver.example.com/rest/api/2/priority/2",
-                    "iconUrl": "http://jiraserver.example.com/images/icons/priorities/critical.png",
-                    "name": "Critical",
-                    "id": "2"
-                },
-                {
-                    "self": "http://jiraserver.example.com/rest/api/2/priority/3",
-                    "iconUrl": "http://jiraserver.example.com/images/icons/priorities/major.png",
-                    "name": "Major",
-                    "id": "3"
-                },
-                {
-                    "self": "http://jiraserver.example.com/rest/api/2/priority/4",
-                    "iconUrl": "http://jiraserver.example.com/images/icons/priorities/minor.png",
-                    "name": "Minor",
-                    "id": "4"
-                },
-                {
-                    "self": "http://jiraserver.example.com/rest/api/2/priority/5",
-                    "iconUrl": "http://jiraserver.example.com/images/icons/priorities/trivial.png",
-                    "name": "Trivial",
-                    "id": "5"
-                }
-            ]
-        }
-    ]
-}
+            {
+                "self": "http://jiraserver.example.com/rest/api/2/priority/2",
+                "iconUrl": "http://jiraserver.example.com/images/icons/priorities/critical.png",
+                "name": "Critical",
+                "id": "2"
+            },
+            {
+                "self": "http://jiraserver.example.com/rest/api/2/priority/3",
+                "iconUrl": "http://jiraserver.example.com/images/icons/priorities/major.png",
+                "name": "Major",
+                "id": "3"
+            },
+            {
+                "self": "http://jiraserver.example.com/rest/api/2/priority/4",
+                "iconUrl": "http://jiraserver.example.com/images/icons/priorities/minor.png",
+                "name": "Minor",
+                "id": "4"
+            },
+            {
+                "self": "http://jiraserver.example.com/rest/api/2/priority/5",
+                "iconUrl": "http://jiraserver.example.com/images/icons/priorities/trivial.png",
+                "name": "Trivial",
+                "id": "5"
+            }
+        ]
+    }
+]
 '@
             $script:sampleObject = ConvertFrom-Json -InputObject $sampleJson
             #endregion Definitions
@@ -102,17 +104,16 @@ InModuleScope JiraPS {
             }
 
             Context "Inputs" {
-                It "converts multiple attachments from array input" {
-                    ConvertTo-JiraCreateMetaField -InputObject $sampleObject, $sampleObject | Should -HaveCount 4
+                It "converts multiple items from array input" {
+                    ConvertTo-JiraCreateMetaField -InputObject ($sampleObject + $sampleObject) | Should -HaveCount 4
                 }
 
                 It "accepts input from pipeline" {
-                    $sampleObject, $sampleObject | ConvertTo-JiraCreateMetaField | Should -HaveCount 4
+                    ($sampleObject + $sampleObject) | ConvertTo-JiraCreateMetaField | Should -HaveCount 4
                 }
             }
 
             Context "Property Mapping" {
-                # Our sample JSON includes two fields: summary and priority.
                 Context "Example: Summary" {
                     BeforeAll {
                         $script:summary = (ConvertTo-JiraCreateMetaField -InputObject $sampleObject) | Where-Object -FilterScript { $_.Name -eq 'Summary' }

--- a/Tests/Functions/Public/Get-JiraIssueCreateMetadata.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraIssueCreateMetadata.Unit.Tests.ps1
@@ -16,185 +16,74 @@ InModuleScope JiraPS {
             #region Definitions
             $script:jiraServer = 'https://jira.example.com'
 
+            # Paginated PageOfCreateMetaIssueTypeWithField response shape
+            # returned by GET /rest/api/2/issue/createmeta/{project}/issuetypes/{issueType}
             $script:restResult = @"
 {
-    "expand": "projects",
-    "projects": [{
-        "expand": "issuetypes",
-        "self": "$jiraserver/rest/api/2/project/10003",
-        "id": "10003",
-        "key": "TEST",
-        "name": "Test Project",
-        "issuetypes": [{
-            "self": "$jiraserver/rest/api/2/issuetype/2",
-            "id": "2",
-            "iconUrl": "$jiraserver/images/icons/issuetypes/newfeature.png",
-            "name": "Test Issue Type",
-            "subtask": false,
-            "expand": "fields",
-            "fields": {
-                "summary": {
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "system": "summary"
-                    },
-                    "name": "Summary",
-                    "hasDefaultValue": false,
-                    "operations": [
-                        "set"
-                    ]
-                },
-                "issuetype": {
-                    "required": true,
-                    "schema": {
-                        "type": "issuetype",
-                        "system": "issuetype"
-                    },
-                    "name": "Issue Type",
-                    "hasDefaultValue": false,
-                    "operations": [],
-                    "allowedValues": [{
-                        "self": "$jiraserver/rest/api/2/issuetype/2",
-                        "id": "2",
-                        "description": "This is a test issue type",
-                        "iconUrl": "$jiraserver/images/icons/issuetypes/newfeature.png",
-                        "name": "Test Issue Type",
-                        "subtask": false
-                    }]
-                },
-                "description": {
-                    "required": false,
-                    "schema": {
-                        "type": "string",
-                        "system": "description"
-                    },
-                    "name": "Description",
-                    "hasDefaultValue": false,
-                    "operations": [
-                        "set"
-                    ]
-                },
-                "project": {
-                    "required": true,
-                    "schema": {
-                        "type": "project",
-                        "system": "project"
-                    },
-                    "name": "Project",
-                    "hasDefaultValue": false,
-                    "operations": [
-                        "set"
-                    ],
-                    "allowedValues": [{
-                        "self": "$jiraserver/rest/api/2/project/10003",
-                        "id": "10003",
-                        "key": "TEST",
-                        "name": "Test Project",
-                        "projectCategory": {
-                            "self": "$jiraserver/rest/api/2/projectCategory/10000",
-                            "id": "10000",
-                            "description": "All Project Catagories",
-                            "name": "All Project"
-                        }
-                    }]
-                },
-                "reporter": {
-                    "required": true,
-                    "schema": {
-                        "type": "user",
-                        "system": "reporter"
-                    },
-                    "name": "Reporter",
-                    "autoCompleteUrl": "$jiraserver/rest/api/2/user/search?username=",
-                    "hasDefaultValue": false,
-                    "operations": [
-                        "set"
-                    ]
-                },
-                "assignee": {
-                    "required": false,
-                    "schema": {
-                        "type": "user",
-                        "system": "assignee"
-                    },
-                    "name": "Assignee",
-                    "autoCompleteUrl": "$jiraserver/rest/api/2/user/assignable/search?issueKey=null&username=",
-                    "hasDefaultValue": false,
-                    "operations": [
-                        "set"
-                    ]
-                },
-                "priority": {
-                    "required": false,
-                    "schema": {
-                        "type": "priority",
-                        "system": "priority"
-                    },
-                    "name": "Priority",
-                    "hasDefaultValue": true,
-                    "operations": [
-                        "set"
-                    ],
-                    "allowedValues": [{
-                            "self": "$jiraserver/rest/api/2/priority/1",
-                            "iconUrl": "$jiraserver/images/icons/priorities/blocker.png",
-                            "name": "Blocker",
-                            "id": "1"
-                        },
-                        {
-                            "self": "$jiraserver/rest/api/2/priority/2",
-                            "iconUrl": "$jiraserver/images/icons/priorities/critical.png",
-                            "name": "Critical",
-                            "id": "2"
-                        },
-                        {
-                            "self": "$jiraserver/rest/api/2/priority/3",
-                            "iconUrl": "$jiraserver/images/icons/priorities/major.png",
-                            "name": "Major",
-                            "id": "3"
-                        },
-                        {
-                            "self": "$jiraserver/rest/api/2/priority/4",
-                            "iconUrl": "$jiraserver/images/icons/priorities/minor.png",
-                            "name": "Minor",
-                            "id": "4"
-                        },
-                        {
-                            "self": "$jiraserver/rest/api/2/priority/5",
-                            "iconUrl": "$jiraserver/images/icons/priorities/trivial.png",
-                            "name": "Trivial",
-                            "id": "5"
-                        }
-                    ]
-                },
-                "labels": {
-                    "required": false,
-                    "schema": {
-                        "type": "array",
-                        "items": "string",
-                        "system": "labels"
-                    },
-                    "name": "Labels",
-                    "autoCompleteUrl": "$jiraserver/rest/api/1.0/labels/suggest?query=",
-                    "hasDefaultValue": false,
-                    "operations": [
-                        "add",
-                        "set",
-                        "remove"
-                    ]
-                }
-            }
-        }]
-    }]
+    "maxResults": 50,
+    "startAt": 0,
+    "total": 3,
+    "isLast": true,
+    "values": [
+        {
+            "required": true,
+            "schema": { "type": "string", "system": "summary" },
+            "name": "Summary",
+            "fieldId": "summary",
+            "hasDefaultValue": false,
+            "operations": [ "set" ]
+        },
+        {
+            "required": false,
+            "schema": { "type": "string", "system": "description" },
+            "name": "Description",
+            "fieldId": "description",
+            "hasDefaultValue": false,
+            "operations": [ "set" ]
+        },
+        {
+            "required": false,
+            "schema": { "type": "priority", "system": "priority" },
+            "name": "Priority",
+            "fieldId": "priority",
+            "hasDefaultValue": true,
+            "operations": [ "set" ],
+            "allowedValues": [ { "id": "1", "name": "Blocker" } ]
+        }
+    ]
+}
+"@
+
+            # Two-page fixtures for the multi-page walk test.
+            $script:pagedResponse1 = @"
+{
+    "maxResults": 2,
+    "startAt": 0,
+    "total": 4,
+    "isLast": false,
+    "values": [
+        { "required": true,  "schema": { "type": "string", "system": "summary" },     "name": "Summary",     "fieldId": "summary",     "hasDefaultValue": false, "operations": [ "set" ] },
+        { "required": false, "schema": { "type": "string", "system": "description" }, "name": "Description", "fieldId": "description", "hasDefaultValue": false, "operations": [ "set" ] }
+    ]
+}
+"@
+            $script:pagedResponse2 = @"
+{
+    "maxResults": 2,
+    "startAt": 2,
+    "total": 4,
+    "isLast": true,
+    "values": [
+        { "required": false, "schema": { "type": "priority", "system": "priority" }, "name": "Priority", "fieldId": "priority", "hasDefaultValue": true,  "operations": [ "set" ] },
+        { "required": false, "schema": { "type": "array",    "system": "labels" },   "name": "Labels",   "fieldId": "labels",   "hasDefaultValue": false, "operations": [ "add", "set", "remove" ] }
+    ]
 }
 "@
             #endregion Definitions
 
-            #region Mocks
             Mock Get-JiraConfigServer -ModuleName JiraPS {
                 Write-MockDebugInfo 'Get-JiraConfigServer'
-                $jiraserver
+                $jiraServer
             }
 
             Mock Get-JiraProject -ModuleName JiraPS {
@@ -212,27 +101,19 @@ InModuleScope JiraPS {
                 $object.PSObject.TypeNames.Insert(0, 'JiraPS.Project')
                 return $object
             }
-
-            Mock ConvertTo-JiraCreateMetaField -ModuleName JiraPS {
-                Write-MockDebugInfo 'ConvertTo-JiraCreateMetaField' 'InputObject'
-                $InputObject
-            }
-
-            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "$jiraserver/rest/api/*/issue/createmeta?*" } {
-                Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
-                return $restResult
-            }
-
-            Mock Invoke-JiraMethod -ModuleName JiraPS {
-                Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
-                throw "Unidentified call to Invoke-JiraMethod"
-            }
-            #endregion Mocks
         }
 
         Describe "Signature" {
+            BeforeAll {
+                $script:command = Get-Command -Name Get-JiraIssueCreateMetadata
+            }
+
             Context "Parameter Types" {
-                # TODO: Add parameter type validation tests
+                It "opts into SupportsPaging" {
+                    $command.Parameters.Keys | Should -Contain 'First'
+                    $command.Parameters.Keys | Should -Contain 'Skip'
+                    $command.Parameters.Keys | Should -Contain 'IncludeTotalCount'
+                }
             }
 
             Context "Mandatory Parameters" {}
@@ -242,19 +123,110 @@ InModuleScope JiraPS {
 
         Describe "Behavior" {
             Context "Behavior testing" {
-                It "Queries Jira for metadata information about creating an issue" {
-                    { Get-JiraIssueCreateMetadata -Project 10003 -IssueType 2 } | Should -Not -Throw
-                    Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1
+                BeforeAll {
+                    # Default mock: Invoke-JiraMethod -Paging would yield the
+                    # expanded field items, so the mock returns values directly.
+                    Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/*/issue/createmeta/*/issuetypes/*" } {
+                        Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
+                        (ConvertFrom-Json $restResult).values
+                    }
+
+                    Mock Invoke-JiraMethod -ModuleName JiraPS {
+                        Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
+                        throw "Unidentified call to Invoke-JiraMethod"
+                    }
                 }
 
-                It "Uses ConvertTo-JiraCreateMetaField to output CreateMetaField objects if JIRA returns data" {
+                It "Queries Jira for metadata information about creating an issue" {
                     { Get-JiraIssueCreateMetadata -Project 10003 -IssueType 2 } | Should -Not -Throw
-                    Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1
 
-                    # There are 2 example fields in our mock above, but they should
-                    # be passed to Convert-JiraCreateMetaField as a single object.
-                    # The method should only be called once.
-                    Should -Invoke ConvertTo-JiraCreateMetaField -ModuleName JiraPS -Exactly -Times 1
+                    Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {
+                        $Method -eq 'Get' -and
+                        $URI -like "$jiraServer/rest/api/*/issue/createmeta/*/issuetypes/*" -and
+                        $Paging -eq $true
+                    } -Exactly -Times 1
+                }
+
+                It "Streams each field through ConvertTo-JiraCreateMetaField" {
+                    Mock ConvertTo-JiraCreateMetaField -ModuleName JiraPS {
+                        Write-MockDebugInfo 'ConvertTo-JiraCreateMetaField' 'InputObject'
+                        $InputObject
+                    }
+
+                    $result = Get-JiraIssueCreateMetadata -Project 10003 -IssueType 2
+
+                    $result | Should -HaveCount 3
+
+                    # With pagination the converter is invoked once per streamed item.
+                    Should -Invoke ConvertTo-JiraCreateMetaField -ModuleName JiraPS -Exactly -Times 3
+                }
+
+                It "Emits JiraPS.CreateMetaField objects with mapped properties" {
+                    $result = Get-JiraIssueCreateMetadata -Project 10003 -IssueType 2
+
+                    $result | Should -HaveCount 3
+                    foreach ($field in $result) {
+                        $field.PSObject.TypeNames | Should -Contain 'JiraPS.CreateMetaField'
+                    }
+
+                    $summary = $result | Where-Object { $_.Id -eq 'summary' }
+                    $summary.Name | Should -Be 'Summary'
+                    $summary.Required | Should -BeTrue
+                    $summary.HasDefaultValue | Should -BeFalse
+
+                    $priority = $result | Where-Object { $_.Id -eq 'priority' }
+                    $priority.HasDefaultValue | Should -BeTrue
+                    $priority.AllowedValues | Should -Not -BeNullOrEmpty
+                }
+            }
+
+            Context "Walks multiple pages of createmeta results" {
+                BeforeAll {
+                    # Mock the HTTP layer only so that Invoke-JiraMethod (and
+                    # Invoke-PaginatedRequest) actually runs end-to-end and the
+                    # second page is fetched.
+                    Mock Resolve-DefaultParameterValue -ModuleName JiraPS { @{ } }
+                    Mock Set-TlsLevel -ModuleName JiraPS { }
+                    Mock Test-ServerResponse -ModuleName JiraPS { }
+                    Mock Get-JiraSession -ModuleName JiraPS {
+                        [PSCustomObject]@{
+                            WebSession = New-Object -TypeName Microsoft.PowerShell.Commands.WebRequestSession
+                        }
+                    }
+
+                    Mock Invoke-WebRequest -ModuleName JiraPS {
+                        Write-MockDebugInfo 'Invoke-WebRequest' -Params 'Uri', 'Method'
+
+                        $response = $pagedResponse1
+                        if ("$Uri" -match "startAt=(\d+)") {
+                            switch ($matches[1]) {
+                                '2' { $response = $pagedResponse2; break }
+                            }
+                        }
+
+                        $bytes = [System.Text.Encoding]::UTF8.GetBytes($response)
+                        $stream = [PSCustomObject]@{ _bytes = $bytes }
+                        $stream | Add-Member -MemberType ScriptMethod -Name 'ToArray' -Force -Value { return $this._bytes }
+
+                        [PSCustomObject]@{
+                            StatusCode       = 200
+                            Content          = $response
+                            RawContentStream = $stream
+                        }
+                    }
+                }
+
+                It "Requests all pages and returns every field" {
+                    $result = Get-JiraIssueCreateMetadata -Project 10003 -IssueType 2
+
+                    $result | Should -HaveCount 4
+
+                    Should -Invoke Invoke-WebRequest -ModuleName JiraPS -Exactly -Times 2 -Scope It
+
+                    # startAt=2 query should be issued for the second page request.
+                    Should -Invoke Invoke-WebRequest -ModuleName JiraPS -ParameterFilter {
+                        "$Uri" -match 'startAt=2'
+                    } -Exactly -Times 1 -Scope It
                 }
             }
         }

--- a/docs/en-US/commands/Get-JiraIssueCreateMetadata.md
+++ b/docs/en-US/commands/Get-JiraIssueCreateMetadata.md
@@ -17,7 +17,7 @@ Returns metadata required to create an issue in JIRA
 
 ```powershell
 Get-JiraIssueCreateMetadata [-Project] <String> [-IssueType] <String> [[-Credential] <PSCredential>]
- [<CommonParameters>]
+ [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -27,6 +27,11 @@ This can be used to identify custom fields in order to pass them to `New-JiraIss
 
 This function is particularly useful when your JIRA instance includes custom fields that are marked as mandatory.
 
+The cmdlet walks every page of the Jira Cloud createmeta response, so the full set
+of fields is returned by default even when the issue type has more fields than a
+single page holds. Use the `-First` / `-Skip` / `-IncludeTotalCount` common
+pagination parameters to limit or offset the results.
+
 ## EXAMPLES
 
 ### EXAMPLE 1
@@ -35,7 +40,8 @@ This function is particularly useful when your JIRA instance includes custom fie
 Get-JiraIssueCreateMetadata -Project 'TEST' -IssueType 'Bug'
 ```
 
-This example returns the fields available when creating an issue of type Bug under project TEST.
+This example returns all fields available when creating an issue of type Bug under
+project TEST, walking pagination as needed.
 
 ### EXAMPLE 2
 
@@ -46,6 +52,15 @@ Get-JiraIssueCreateMetadata -Project 'JIRA' -IssueType 'Bug' | ? {$_.Required -e
 This example returns fields available when creating an issue of type Bug under the project Jira.
 
 It then uses `Where-Object` (aliased by the question mark) to filter only the fields that are required.
+
+### EXAMPLE 3
+
+```powershell
+Get-JiraIssueCreateMetadata -Project 'TEST' -IssueType 'Bug' -First 10
+```
+
+This example returns only the first 10 fields, regardless of how many pages the
+Jira API would normally return.
 
 ## PARAMETERS
 
@@ -94,6 +109,58 @@ Aliases:
 Required: False
 Position: 3
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IncludeTotalCount
+
+Causes an extra output of the total count at the beginning.
+
+Note this is actually a uInt64, but with a custom string representation.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Skip
+
+Controls how many things will be skipped before starting output.
+
+Defaults to 0.
+
+```yaml
+Type: UInt64
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: 0
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -First
+
+Indicates how many items to return.
+
+```yaml
+Type: UInt64
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: 18446744073709551615
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
## Summary

- `Get-JiraIssueCreateMetadata` silently truncated field metadata at `$script:DefaultPageSize` (25) because it read only the first page of `GET /rest/api/2/issue/createmeta/{project}/issuetypes/{issueType}` and never went back for the rest. Opt the cmdlet into the existing `Invoke-JiraMethod -Paging` framework so the full `values` collection is always returned.
- Refactor `ConvertTo-JiraCreateMetaField` to consume a single field-item per input (the framework streams items via `Expand-Result`/`Convert-Result`), instead of reaching into `$InputObject.values` on the envelope.
- Replace the legacy `projects[].issuetypes[].fields` test fixture with the real `PageOfCreateMetaIssueTypeWithField` shape the endpoint actually returns, and add a multi-page walk test that exercises the real `Invoke-PaginatedRequest` loop (mocked at the `Invoke-WebRequest` layer so the pagination engine actually runs end-to-end).

No URL changes were needed: only the legacy flat `GET /rest/api/2/issue/createmeta` is deprecated (CHANGE-1304). The granular `.../createmeta/{project}/issuetypes/{issueType}` endpoint JiraPS uses is Atlassian's recommended replacement and is not deprecated.

## Changes

| File | Change |
|------|--------|
| `JiraPS/Public/Get-JiraIssueCreateMetadata.ps1` | `SupportsPaging` + forward `PagingParameters` + `Invoke-JiraMethod -Paging`; drop first-page-only error branches |
| `JiraPS/Private/ConvertTo-JiraCreateMetaField.ps1` | Iterate `$InputObject` (one field per item) instead of `$InputObject.values` |
| `Tests/Functions/Public/Get-JiraIssueCreateMetadata.Unit.Tests.ps1` | Paginated fixture, corrected URL `ParameterFilter`, multi-page walk test |
| `Tests/Functions/Private/ConvertTo-JiraCreateMetaField.Unit.Tests.ps1` | Fixture shape update to match new per-item contract |
| `docs/en-US/commands/Get-JiraIssueCreateMetadata.md` | Document paging common parameters, add example |
| `CHANGELOG.md` | Unreleased Fixed entry |

## Test plan

- [x] \`Invoke-Pester Tests/Functions/Public/Get-JiraIssueCreateMetadata.Unit.Tests.ps1\` — 5/5
- [x] \`Invoke-Pester Tests/Functions/Private/ConvertTo-JiraCreateMetaField.Unit.Tests.ps1\` — 15/15
- [x] \`Invoke-Pester Tests/Functions/Public/Invoke-JiraMethod.Unit.Tests.ps1\` — 36/36
- [x] \`Invoke-Pester Tests/Functions/Public/New-JiraIssue.Unit.Tests.ps1\` — no regression (consumes the converter)
- [x] Pre-rebase full regression: \`Tests/Functions/Public\` 741/741, \`Tests/Functions/Private\` 282/282 (only pre-existing skips)
- [x] Rebased on \`master\` (post PS 5.1 minimum bump); no conflicts, all suites still green


Made with [Cursor](https://cursor.com)