### PR TITLE
feat: Add integration tests for transitions, issue links, and watchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Both accept `SecureString` and work seamlessly in automation. See the updated [a
 - Added `Invoke-Build -Task TestIntegration` for running integration tests with parallel execution support
 - Added `-Tag`, `-ExcludeTag`, and `-ThrottleLimit` parameters to `Invoke-Build` for test filtering
 - Added `Tests/Invoke-ParallelPester.ps1` script for parallel test execution (requires PowerShell 7+)
-- Added comprehensive integration test suite for Jira Cloud (18 test files covering authentication, issues, search, comments, attachments, and more)
+- Added comprehensive integration test suite for Jira Cloud (21 test files covering authentication, issues, search, comments, attachments, transitions, issue links, watchers, and more)
 - Added `-PersonalAccessToken` parameter to `New-JiraSession` for Personal Access Token (PAT) authentication on Jira Data Center, with `-PAT` and `-BearerToken` aliases (#576)
 - Added `-ApiToken` and `-EmailAddress` parameters to `New-JiraSession` for API token authentication on Jira Cloud (#576)
 - Added `-CacheKey`, `-CacheExpiry` (as `[TimeSpan]`), and `-BypassCache` parameters to `Invoke-JiraMethod` for built-in response caching (#576)

--- a/Tests/Integration/IssueLinks.Integration.Tests.ps1
+++ b/Tests/Integration/IssueLinks.Integration.Tests.ps1
@@ -1,0 +1,374 @@
+#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+
+<#
+.SYNOPSIS
+    Integration tests for Issue Link cmdlets.
+
+.DESCRIPTION
+    Tests issue linking functionality against a live Jira Cloud instance.
+    Covers:
+    - Get-JiraIssueLinkType
+    - Add-JiraIssueLink
+    - Get-JiraIssueLink
+    - Remove-JiraIssueLink
+
+.NOTES
+    Issue links connect two issues with a relationship type (e.g., "blocks", "relates to").
+    Common link types in Jira Cloud:
+    - Blocks / is blocked by
+    - Clones / is cloned by
+    - Duplicate / is duplicated by
+    - Relates to / relates to
+#>
+
+BeforeDiscovery {
+    . "$PSScriptRoot/../Helpers/TestTools.ps1"
+    . "$PSScriptRoot/../Helpers/IntegrationTestTools.ps1"
+
+    Initialize-TestEnvironment
+    $script:moduleToTest = Resolve-ModuleSource
+
+    Import-Module $script:moduleToTest -Force -ErrorAction Stop
+
+    $script:Skip = Skip-IntegrationTest
+    if (-not $Skip) {
+        $testEnv = Initialize-IntegrationEnvironment
+        $script:SkipWrite = $testEnv.ReadOnly
+    }
+}
+
+InModuleScope JiraPS {
+    Describe "Issue Links" -Tag 'Integration' -Skip:$Skip {
+        BeforeAll {
+            . "$PSScriptRoot/../Helpers/IntegrationTestTools.ps1"
+
+            $script:env = Initialize-IntegrationEnvironment
+            $script:session = Connect-JiraTestServer -Environment $env
+            $script:fixtures = Get-TestFixture -Environment $env
+
+            $script:createdIssues = [System.Collections.ArrayList]::new()
+
+            Remove-StaleTestResource -Fixtures $fixtures
+        }
+
+        AfterAll {
+            if ($script:createdIssues -and $script:createdIssues.Count -gt 0) {
+                foreach ($key in $script:createdIssues) {
+                    try {
+                        Remove-JiraIssue -IssueId $key -Force -ErrorAction SilentlyContinue
+                    }
+                    catch {
+                        Write-Verbose "Cleanup: Failed to remove issue $key - $_"
+                    }
+                }
+            }
+            Remove-JiraSession -ErrorAction SilentlyContinue
+        }
+
+        Describe "Get-JiraIssueLinkType" {
+            Context "Retrieving Link Types" {
+                It "retrieves all issue link types" {
+                    $linkTypes = Get-JiraIssueLinkType
+
+                    $linkTypes | Should -Not -BeNullOrEmpty
+                    $linkTypes.Count | Should -BeGreaterThan 0
+                }
+
+                It "link types have correct type name" {
+                    $linkTypes = Get-JiraIssueLinkType
+
+                    $linkTypes[0].PSObject.TypeNames[0] | Should -Be 'JiraPS.IssueLinkType'
+                }
+
+                It "link types have Id, Name, Inward, and Outward properties" {
+                    $linkTypes = Get-JiraIssueLinkType
+
+                    $linkTypes[0].Id | Should -Not -BeNullOrEmpty
+                    $linkTypes[0].Name | Should -Not -BeNullOrEmpty
+                    $linkTypes[0].InwardDescription | Should -Not -BeNullOrEmpty
+                    $linkTypes[0].OutwardDescription | Should -Not -BeNullOrEmpty
+                }
+
+                It "retrieves a specific link type by ID" {
+                    $allTypes = Get-JiraIssueLinkType
+                    $firstType = $allTypes[0]
+
+                    $specificType = Get-JiraIssueLinkType -LinkType $firstType.Id
+
+                    $specificType | Should -Not -BeNullOrEmpty
+                    $specificType.Id | Should -Be $firstType.Id
+                }
+
+                It "retrieves a specific link type by name" {
+                    $allTypes = Get-JiraIssueLinkType
+                    $firstName = $allTypes[0].Name
+
+                    $specificType = Get-JiraIssueLinkType -LinkType $firstName
+
+                    $specificType | Should -Not -BeNullOrEmpty
+                    $specificType.Name | Should -Be $firstName
+                }
+            }
+        }
+
+        Describe "Add-JiraIssueLink" -Skip:$SkipWrite {
+            BeforeAll {
+                if ([string]::IsNullOrEmpty($fixtures.TestProject)) {
+                    $script:sourceIssue = $null
+                    $script:targetIssue = $null
+                }
+                else {
+                    $summary1 = New-TestResourceName -Type "LinkSource"
+                    $script:sourceIssue = New-JiraIssue -Project $fixtures.TestProject -IssueType 'Task' -Summary $summary1
+                    if ($sourceIssue) {
+                        $null = $script:createdIssues.Add($sourceIssue.Key)
+                    }
+
+                    $summary2 = New-TestResourceName -Type "LinkTarget"
+                    $script:targetIssue = New-JiraIssue -Project $fixtures.TestProject -IssueType 'Task' -Summary $summary2
+                    if ($targetIssue) {
+                        $null = $script:createdIssues.Add($targetIssue.Key)
+                    }
+                }
+            }
+
+            Context "Creating Issue Links" {
+                It "creates an issue link between two issues" {
+                    if (-not $sourceIssue -or -not $targetIssue) {
+                        Set-ItResult -Skipped -Because "JIRA_TEST_PROJECT not configured"
+                        return
+                    }
+
+                    $linkTypes = Get-JiraIssueLinkType
+                    $relatesType = $linkTypes | Where-Object { $_.Name -like '*Relates*' -or $_.Name -like '*relates*' } | Select-Object -First 1
+                    if (-not $relatesType) {
+                        $relatesType = $linkTypes[0]
+                    }
+
+                    $issueLink = [PSCustomObject]@{
+                        type         = @{ name = $relatesType.Name }
+                        outwardIssue = @{ key = $targetIssue.Key }
+                    }
+
+                    { Add-JiraIssueLink -Issue $sourceIssue.Key -IssueLink $issueLink } |
+                        Should -Not -Throw
+                }
+
+                It "creates an issue link with inward direction" {
+                    if (-not $sourceIssue -or -not $targetIssue) {
+                        Set-ItResult -Skipped -Because "JIRA_TEST_PROJECT not configured"
+                        return
+                    }
+
+                    $linkTypes = Get-JiraIssueLinkType
+                    $blocksType = $linkTypes | Where-Object { $_.Name -like '*Block*' } | Select-Object -First 1
+                    if (-not $blocksType) {
+                        $blocksType = $linkTypes[0]
+                    }
+
+                    $issueLink = [PSCustomObject]@{
+                        type        = @{ name = $blocksType.Name }
+                        inwardIssue = @{ key = $targetIssue.Key }
+                    }
+
+                    { Add-JiraIssueLink -Issue $sourceIssue.Key -IssueLink $issueLink } |
+                        Should -Not -Throw
+                }
+
+                It "created links appear on the issue" {
+                    if (-not $sourceIssue) {
+                        Set-ItResult -Skipped -Because "JIRA_TEST_PROJECT not configured"
+                        return
+                    }
+
+                    $issue = Get-JiraIssue -Key $sourceIssue.Key
+                    $issue.issueLinks | Should -Not -BeNullOrEmpty
+                }
+
+                It "accepts issue via pipeline" {
+                    if (-not $sourceIssue -or -not $targetIssue) {
+                        Set-ItResult -Skipped -Because "JIRA_TEST_PROJECT not configured"
+                        return
+                    }
+
+                    $summary = New-TestResourceName -Type "LinkPipeline"
+                    $pipelineIssue = New-JiraIssue -Project $fixtures.TestProject -IssueType 'Task' -Summary $summary
+                    $null = $script:createdIssues.Add($pipelineIssue.Key)
+
+                    $linkTypes = Get-JiraIssueLinkType
+                    $issueLink = [PSCustomObject]@{
+                        type         = @{ name = $linkTypes[0].Name }
+                        outwardIssue = @{ key = $targetIssue.Key }
+                    }
+
+                    { $pipelineIssue | Add-JiraIssueLink -IssueLink $issueLink } |
+                        Should -Not -Throw
+                }
+            }
+        }
+
+        Describe "Get-JiraIssueLink" -Skip:$SkipWrite {
+            BeforeAll {
+                if ([string]::IsNullOrEmpty($fixtures.TestProject)) {
+                    $script:linkTestIssue = $null
+                }
+                else {
+                    $summary1 = New-TestResourceName -Type "GetLinkSource"
+                    $script:linkTestIssue = New-JiraIssue -Project $fixtures.TestProject -IssueType 'Task' -Summary $summary1
+                    if ($linkTestIssue) {
+                        $null = $script:createdIssues.Add($linkTestIssue.Key)
+                    }
+
+                    $summary2 = New-TestResourceName -Type "GetLinkTarget"
+                    $script:linkTestTarget = New-JiraIssue -Project $fixtures.TestProject -IssueType 'Task' -Summary $summary2
+                    if ($linkTestTarget) {
+                        $null = $script:createdIssues.Add($linkTestTarget.Key)
+                    }
+
+                    if ($linkTestIssue -and $linkTestTarget) {
+                        $linkTypes = Get-JiraIssueLinkType
+                        $issueLink = [PSCustomObject]@{
+                            type         = @{ name = $linkTypes[0].Name }
+                            outwardIssue = @{ key = $linkTestTarget.Key }
+                        }
+                        Add-JiraIssueLink -Issue $linkTestIssue.Key -IssueLink $issueLink
+                    }
+                }
+            }
+
+            Context "Retrieving Issue Links" {
+                It "retrieves an issue link by ID" {
+                    if (-not $linkTestIssue) {
+                        Set-ItResult -Skipped -Because "JIRA_TEST_PROJECT not configured"
+                        return
+                    }
+
+                    $issue = Get-JiraIssue -Key $linkTestIssue.Key
+                    if (-not $issue.issueLinks -or $issue.issueLinks.Count -eq 0) {
+                        Set-ItResult -Skipped -Because "No issue links found on test issue"
+                        return
+                    }
+
+                    $linkId = $issue.issueLinks[0].Id
+                    $link = Get-JiraIssueLink -Id $linkId
+
+                    $link | Should -Not -BeNullOrEmpty
+                    $link.Id | Should -Be $linkId
+                }
+
+                It "link has correct type name" {
+                    if (-not $linkTestIssue) {
+                        Set-ItResult -Skipped -Because "JIRA_TEST_PROJECT not configured"
+                        return
+                    }
+
+                    $issue = Get-JiraIssue -Key $linkTestIssue.Key
+                    if (-not $issue.issueLinks -or $issue.issueLinks.Count -eq 0) {
+                        Set-ItResult -Skipped -Because "No issue links found on test issue"
+                        return
+                    }
+
+                    $linkId = $issue.issueLinks[0].Id
+                    $link = Get-JiraIssueLink -Id $linkId
+
+                    $link.PSObject.TypeNames[0] | Should -Be 'JiraPS.IssueLink'
+                }
+
+                It "link includes type information" {
+                    if (-not $linkTestIssue) {
+                        Set-ItResult -Skipped -Because "JIRA_TEST_PROJECT not configured"
+                        return
+                    }
+
+                    $issue = Get-JiraIssue -Key $linkTestIssue.Key
+                    if (-not $issue.issueLinks -or $issue.issueLinks.Count -eq 0) {
+                        Set-ItResult -Skipped -Because "No issue links found on test issue"
+                        return
+                    }
+
+                    $linkId = $issue.issueLinks[0].Id
+                    $link = Get-JiraIssueLink -Id $linkId
+
+                    $link.Type | Should -Not -BeNullOrEmpty
+                }
+            }
+        }
+
+        Describe "Remove-JiraIssueLink" -Skip:$SkipWrite {
+            Context "Removing Issue Links" {
+                It "removes an issue link" {
+                    if ([string]::IsNullOrEmpty($fixtures.TestProject)) {
+                        Set-ItResult -Skipped -Because "JIRA_TEST_PROJECT not configured"
+                        return
+                    }
+
+                    $summary1 = New-TestResourceName -Type "RemoveLinkSource"
+                    $removeSource = New-JiraIssue -Project $fixtures.TestProject -IssueType 'Task' -Summary $summary1
+                    $null = $script:createdIssues.Add($removeSource.Key)
+
+                    $summary2 = New-TestResourceName -Type "RemoveLinkTarget"
+                    $removeTarget = New-JiraIssue -Project $fixtures.TestProject -IssueType 'Task' -Summary $summary2
+                    $null = $script:createdIssues.Add($removeTarget.Key)
+
+                    $linkTypes = Get-JiraIssueLinkType
+                    $issueLink = [PSCustomObject]@{
+                        type         = @{ name = $linkTypes[0].Name }
+                        outwardIssue = @{ key = $removeTarget.Key }
+                    }
+                    Add-JiraIssueLink -Issue $removeSource.Key -IssueLink $issueLink
+
+                    $issue = Get-JiraIssue -Key $removeSource.Key
+                    $linkToRemove = $issue.issueLinks[0]
+
+                    { Remove-JiraIssueLink -IssueLink $linkToRemove -Confirm:$false } |
+                        Should -Not -Throw
+
+                    $afterRemoval = Get-JiraIssue -Key $removeSource.Key
+                    $afterRemoval.issueLinks | Should -BeNullOrEmpty
+                }
+
+                It "removes issue link via pipeline from issue object" {
+                    if ([string]::IsNullOrEmpty($fixtures.TestProject)) {
+                        Set-ItResult -Skipped -Because "JIRA_TEST_PROJECT not configured"
+                        return
+                    }
+
+                    $summary1 = New-TestResourceName -Type "RemovePipeSource"
+                    $pipeSource = New-JiraIssue -Project $fixtures.TestProject -IssueType 'Task' -Summary $summary1
+                    $null = $script:createdIssues.Add($pipeSource.Key)
+
+                    $summary2 = New-TestResourceName -Type "RemovePipeTarget"
+                    $pipeTarget = New-JiraIssue -Project $fixtures.TestProject -IssueType 'Task' -Summary $summary2
+                    $null = $script:createdIssues.Add($pipeTarget.Key)
+
+                    $linkTypes = Get-JiraIssueLinkType
+                    $issueLink = [PSCustomObject]@{
+                        type         = @{ name = $linkTypes[0].Name }
+                        outwardIssue = @{ key = $pipeTarget.Key }
+                    }
+                    Add-JiraIssueLink -Issue $pipeSource.Key -IssueLink $issueLink
+
+                    $issue = Get-JiraIssue -Key $pipeSource.Key
+
+                    { $issue | Remove-JiraIssueLink -Confirm:$false } |
+                        Should -Not -Throw
+
+                    $afterRemoval = Get-JiraIssue -Key $pipeSource.Key
+                    $afterRemoval.issueLinks | Should -BeNullOrEmpty
+                }
+            }
+        }
+
+        Context "Error Handling" {
+            It "Get-JiraIssueLinkType fails for invalid link type ID" {
+                { Get-JiraIssueLinkType -LinkType 99999 -ErrorAction Stop } |
+                    Should -Throw
+            }
+
+            It "Get-JiraIssueLink fails for invalid link ID" {
+                { Get-JiraIssueLink -Id 99999999 -ErrorAction Stop } |
+                    Should -Throw
+            }
+        }
+    }
+}

--- a/Tests/Integration/IssueWatchers.Integration.Tests.ps1
+++ b/Tests/Integration/IssueWatchers.Integration.Tests.ps1
@@ -1,0 +1,298 @@
+#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+
+<#
+.SYNOPSIS
+    Integration tests for Issue Watcher cmdlets.
+
+.DESCRIPTION
+    Tests issue watcher functionality against a live Jira Cloud instance.
+    Covers:
+    - Get-JiraIssueWatcher
+    - Add-JiraIssueWatcher
+    - Remove-JiraIssueWatcher
+
+.NOTES
+    Watchers are users who receive notifications about changes to an issue.
+    On Jira Cloud, watchers are identified by accountId.
+    On Jira Data Center, watchers are identified by username.
+
+    These tests require JIRA_TEST_USER to be configured with the accountId
+    of a valid user that can be added as a watcher.
+#>
+
+BeforeDiscovery {
+    . "$PSScriptRoot/../Helpers/TestTools.ps1"
+    . "$PSScriptRoot/../Helpers/IntegrationTestTools.ps1"
+
+    Initialize-TestEnvironment
+    $script:moduleToTest = Resolve-ModuleSource
+
+    Import-Module $script:moduleToTest -Force -ErrorAction Stop
+
+    $script:Skip = Skip-IntegrationTest
+    if (-not $Skip) {
+        $testEnv = Initialize-IntegrationEnvironment
+        $script:SkipWrite = $testEnv.ReadOnly
+    }
+}
+
+InModuleScope JiraPS {
+    Describe "Issue Watchers" -Tag 'Integration' -Skip:$Skip {
+        BeforeAll {
+            . "$PSScriptRoot/../Helpers/IntegrationTestTools.ps1"
+
+            $script:env = Initialize-IntegrationEnvironment
+            $script:session = Connect-JiraTestServer -Environment $env
+            $script:fixtures = Get-TestFixture -Environment $env
+
+            $script:createdIssues = [System.Collections.ArrayList]::new()
+
+            Remove-StaleTestResource -Fixtures $fixtures
+        }
+
+        AfterAll {
+            if ($script:createdIssues -and $script:createdIssues.Count -gt 0) {
+                foreach ($key in $script:createdIssues) {
+                    try {
+                        Remove-JiraIssue -IssueId $key -Force -ErrorAction SilentlyContinue
+                    }
+                    catch {
+                        Write-Verbose "Cleanup: Failed to remove issue $key - $_"
+                    }
+                }
+            }
+            Remove-JiraSession -ErrorAction SilentlyContinue
+        }
+
+        Describe "Get-JiraIssueWatcher" {
+            Context "Retrieving Watchers" {
+                It "retrieves watchers from an issue" {
+                    if ([string]::IsNullOrEmpty($fixtures.TestIssue)) {
+                        Set-ItResult -Skipped -Because "JIRA_TEST_ISSUE not configured"
+                        return
+                    }
+
+                    { Get-JiraIssueWatcher -Issue $fixtures.TestIssue } | Should -Not -Throw
+                }
+
+                It "returns user objects" {
+                    if ([string]::IsNullOrEmpty($fixtures.TestIssue)) {
+                        Set-ItResult -Skipped -Because "JIRA_TEST_ISSUE not configured"
+                        return
+                    }
+
+                    $watchers = Get-JiraIssueWatcher -Issue $fixtures.TestIssue
+
+                    if ($watchers) {
+                        $watchers[0].PSObject.TypeNames[0] | Should -Be 'JiraPS.User'
+                    }
+                }
+
+                It "accepts issue key as string" {
+                    if ([string]::IsNullOrEmpty($fixtures.TestIssue)) {
+                        Set-ItResult -Skipped -Because "JIRA_TEST_ISSUE not configured"
+                        return
+                    }
+
+                    { Get-JiraIssueWatcher -Issue $fixtures.TestIssue } | Should -Not -Throw
+                }
+
+                It "accepts issue object via pipeline" {
+                    if ([string]::IsNullOrEmpty($fixtures.TestIssue)) {
+                        Set-ItResult -Skipped -Because "JIRA_TEST_ISSUE not configured"
+                        return
+                    }
+
+                    $issue = Get-JiraIssue -Key $fixtures.TestIssue
+                    { $issue | Get-JiraIssueWatcher } | Should -Not -Throw
+                }
+            }
+
+            Context "Watcher Properties" {
+                BeforeAll {
+                    if ([string]::IsNullOrEmpty($fixtures.TestIssue)) {
+                        $script:watchers = $null
+                    }
+                    else {
+                        $script:watchers = Get-JiraIssueWatcher -Issue $fixtures.TestIssue
+                    }
+                }
+
+                It "watcher has AccountId property (Cloud)" {
+                    if (-not $watchers -or $watchers.Count -eq 0) {
+                        Set-ItResult -Skipped -Because "No watchers on test issue"
+                        return
+                    }
+
+                    $watchers[0].AccountId | Should -Not -BeNullOrEmpty
+                }
+
+                It "watcher has DisplayName property" {
+                    if (-not $watchers -or $watchers.Count -eq 0) {
+                        Set-ItResult -Skipped -Because "No watchers on test issue"
+                        return
+                    }
+
+                    $watchers[0].DisplayName | Should -Not -BeNullOrEmpty
+                }
+            }
+        }
+
+        Describe "Add-JiraIssueWatcher" -Skip:$SkipWrite {
+            BeforeAll {
+                if ([string]::IsNullOrEmpty($fixtures.TestProject)) {
+                    $script:watcherTestIssue = $null
+                }
+                else {
+                    $summary = New-TestResourceName -Type "WatcherTest"
+                    $script:watcherTestIssue = New-JiraIssue -Project $fixtures.TestProject -IssueType 'Task' -Summary $summary
+                    if ($watcherTestIssue) {
+                        $null = $script:createdIssues.Add($watcherTestIssue.Key)
+                    }
+                }
+            }
+
+            Context "Adding Watchers" {
+                It "adds a watcher to an issue using accountId" {
+                    if (-not $watcherTestIssue) {
+                        Set-ItResult -Skipped -Because "JIRA_TEST_PROJECT not configured"
+                        return
+                    }
+                    if ([string]::IsNullOrEmpty($fixtures.TestUser)) {
+                        Set-ItResult -Skipped -Because "JIRA_TEST_USER not configured"
+                        return
+                    }
+
+                    { Add-JiraIssueWatcher -Issue $watcherTestIssue.Key -Watcher $fixtures.TestUser } |
+                        Should -Not -Throw
+                }
+
+                It "added watcher appears in watcher list" {
+                    if (-not $watcherTestIssue) {
+                        Set-ItResult -Skipped -Because "JIRA_TEST_PROJECT not configured"
+                        return
+                    }
+                    if ([string]::IsNullOrEmpty($fixtures.TestUser)) {
+                        Set-ItResult -Skipped -Because "JIRA_TEST_USER not configured"
+                        return
+                    }
+
+                    Add-JiraIssueWatcher -Issue $watcherTestIssue.Key -Watcher $fixtures.TestUser -ErrorAction SilentlyContinue
+
+                    $watchers = Get-JiraIssueWatcher -Issue $watcherTestIssue.Key
+                    $matchingWatcher = $watchers | Where-Object { $_.AccountId -eq $fixtures.TestUser }
+                    $matchingWatcher | Should -Not -BeNullOrEmpty
+                }
+
+                It "accepts issue object via pipeline" {
+                    if (-not $watcherTestIssue) {
+                        Set-ItResult -Skipped -Because "JIRA_TEST_PROJECT not configured"
+                        return
+                    }
+                    if ([string]::IsNullOrEmpty($fixtures.TestUser)) {
+                        Set-ItResult -Skipped -Because "JIRA_TEST_USER not configured"
+                        return
+                    }
+
+                    $summary = New-TestResourceName -Type "WatcherPipeline"
+                    $pipelineIssue = New-JiraIssue -Project $fixtures.TestProject -IssueType 'Task' -Summary $summary
+                    $null = $script:createdIssues.Add($pipelineIssue.Key)
+
+                    { $pipelineIssue | Add-JiraIssueWatcher -Watcher $fixtures.TestUser } |
+                        Should -Not -Throw
+                }
+
+                It "adds multiple watchers" {
+                    if (-not $watcherTestIssue) {
+                        Set-ItResult -Skipped -Because "JIRA_TEST_PROJECT not configured"
+                        return
+                    }
+                    if ([string]::IsNullOrEmpty($fixtures.TestUser)) {
+                        Set-ItResult -Skipped -Because "JIRA_TEST_USER not configured"
+                        return
+                    }
+
+                    $summary = New-TestResourceName -Type "MultiWatcher"
+                    $multiIssue = New-JiraIssue -Project $fixtures.TestProject -IssueType 'Task' -Summary $summary
+                    $null = $script:createdIssues.Add($multiIssue.Key)
+
+                    { Add-JiraIssueWatcher -Issue $multiIssue.Key -Watcher $fixtures.TestUser } |
+                        Should -Not -Throw
+                }
+            }
+        }
+
+        Describe "Remove-JiraIssueWatcher" -Skip:$SkipWrite {
+            Context "Removing Watchers" {
+                It "removes a watcher from an issue" {
+                    if ([string]::IsNullOrEmpty($fixtures.TestProject)) {
+                        Set-ItResult -Skipped -Because "JIRA_TEST_PROJECT not configured"
+                        return
+                    }
+                    if ([string]::IsNullOrEmpty($fixtures.TestUser)) {
+                        Set-ItResult -Skipped -Because "JIRA_TEST_USER not configured"
+                        return
+                    }
+
+                    $summary = New-TestResourceName -Type "RemoveWatcher"
+                    $removeIssue = New-JiraIssue -Project $fixtures.TestProject -IssueType 'Task' -Summary $summary
+                    $null = $script:createdIssues.Add($removeIssue.Key)
+
+                    Add-JiraIssueWatcher -Issue $removeIssue.Key -Watcher $fixtures.TestUser
+
+                    $watchersBefore = Get-JiraIssueWatcher -Issue $removeIssue.Key
+                    $watcherExistsBefore = $watchersBefore | Where-Object { $_.AccountId -eq $fixtures.TestUser }
+                    $watcherExistsBefore | Should -Not -BeNullOrEmpty -Because "Watcher should exist before removal"
+
+                    { Remove-JiraIssueWatcher -Issue $removeIssue.Key -Watcher $fixtures.TestUser } |
+                        Should -Not -Throw
+
+                    $watchersAfter = Get-JiraIssueWatcher -Issue $removeIssue.Key
+                    $watcherExistsAfter = $watchersAfter | Where-Object { $_.AccountId -eq $fixtures.TestUser }
+                    $watcherExistsAfter | Should -BeNullOrEmpty -Because "Watcher should not exist after removal"
+                }
+
+                It "accepts issue object via pipeline" {
+                    if ([string]::IsNullOrEmpty($fixtures.TestProject)) {
+                        Set-ItResult -Skipped -Because "JIRA_TEST_PROJECT not configured"
+                        return
+                    }
+                    if ([string]::IsNullOrEmpty($fixtures.TestUser)) {
+                        Set-ItResult -Skipped -Because "JIRA_TEST_USER not configured"
+                        return
+                    }
+
+                    $summary = New-TestResourceName -Type "RemoveWatcherPipe"
+                    $pipeIssue = New-JiraIssue -Project $fixtures.TestProject -IssueType 'Task' -Summary $summary
+                    $null = $script:createdIssues.Add($pipeIssue.Key)
+
+                    Add-JiraIssueWatcher -Issue $pipeIssue.Key -Watcher $fixtures.TestUser
+
+                    { $pipeIssue | Remove-JiraIssueWatcher -Watcher $fixtures.TestUser } |
+                        Should -Not -Throw
+                }
+            }
+        }
+
+        Context "Error Handling" {
+            It "Get-JiraIssueWatcher fails for non-existent issue" {
+                { Get-JiraIssueWatcher -Issue 'NONEXISTENT-99999' -ErrorAction Stop } |
+                    Should -Throw
+            }
+        }
+
+        Context "Add-JiraIssueWatcher Error Handling" -Skip:$SkipWrite {
+            It "fails for non-existent issue" {
+                { Add-JiraIssueWatcher -Issue 'NONEXISTENT-99999' -Watcher 'someuser' -ErrorAction Stop } |
+                    Should -Throw
+            }
+        }
+
+        Context "Remove-JiraIssueWatcher Error Handling" -Skip:$SkipWrite {
+            It "fails for non-existent issue" {
+                { Remove-JiraIssueWatcher -Issue 'NONEXISTENT-99999' -Watcher 'someuser' -ErrorAction Stop } |
+                    Should -Throw
+            }
+        }
+    }
+}

--- a/Tests/Integration/Transitions.Integration.Tests.ps1
+++ b/Tests/Integration/Transitions.Integration.Tests.ps1
@@ -1,0 +1,267 @@
+#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+
+<#
+.SYNOPSIS
+    Integration tests for Invoke-JiraIssueTransition.
+
+.DESCRIPTION
+    Tests workflow transitions against a live Jira Cloud instance.
+    Transitions are core Jira functionality for moving issues through workflows.
+
+.NOTES
+    These tests require:
+    - A project with a workflow that has at least one available transition
+    - Ability to create issues (JIRA_TEST_READONLY must be false)
+
+    The default Jira Cloud "Task" workflow typically includes:
+    - "To Do" -> "In Progress" (transition)
+    - "In Progress" -> "Done" (transition)
+    - "In Progress" -> "To Do" (transition back)
+#>
+
+BeforeDiscovery {
+    . "$PSScriptRoot/../Helpers/TestTools.ps1"
+    . "$PSScriptRoot/../Helpers/IntegrationTestTools.ps1"
+
+    Initialize-TestEnvironment
+    $script:moduleToTest = Resolve-ModuleSource
+
+    Import-Module $script:moduleToTest -Force -ErrorAction Stop
+
+    $script:Skip = Skip-IntegrationTest
+    if (-not $Skip) {
+        $testEnv = Initialize-IntegrationEnvironment
+        $script:SkipWrite = $testEnv.ReadOnly
+    }
+}
+
+InModuleScope JiraPS {
+    Describe "Invoke-JiraIssueTransition" -Tag 'Integration' -Skip:$Skip {
+        BeforeAll {
+            . "$PSScriptRoot/../Helpers/IntegrationTestTools.ps1"
+
+            $script:env = Initialize-IntegrationEnvironment
+            $script:session = Connect-JiraTestServer -Environment $env
+            $script:fixtures = Get-TestFixture -Environment $env
+
+            $script:createdIssues = [System.Collections.ArrayList]::new()
+
+            Remove-StaleTestResource -Fixtures $fixtures
+        }
+
+        AfterAll {
+            if ($script:createdIssues -and $script:createdIssues.Count -gt 0) {
+                foreach ($key in $script:createdIssues) {
+                    try {
+                        Remove-JiraIssue -IssueId $key -Force -ErrorAction SilentlyContinue
+                    }
+                    catch {
+                        Write-Verbose "Cleanup: Failed to remove issue $key - $_"
+                    }
+                }
+            }
+            Remove-JiraSession -ErrorAction SilentlyContinue
+        }
+
+        Context "Read Operations" {
+            It "retrieves available transitions for an issue" {
+                if ([string]::IsNullOrEmpty($fixtures.TestIssue)) {
+                    Set-ItResult -Skipped -Because "JIRA_TEST_ISSUE not configured"
+                    return
+                }
+                $issue = Get-JiraIssue -Key $fixtures.TestIssue
+
+                $issue.Transition | Should -Not -BeNullOrEmpty
+                $issue.Transition | Should -BeOfType [PSCustomObject]
+            }
+
+            It "transitions have Id and Name properties" {
+                if ([string]::IsNullOrEmpty($fixtures.TestIssue)) {
+                    Set-ItResult -Skipped -Because "JIRA_TEST_ISSUE not configured"
+                    return
+                }
+                $issue = Get-JiraIssue -Key $fixtures.TestIssue
+
+                if ($issue.Transition) {
+                    $issue.Transition[0].Id | Should -Not -BeNullOrEmpty
+                    $issue.Transition[0].Name | Should -Not -BeNullOrEmpty
+                }
+            }
+        }
+
+        Context "Transition Operations" -Skip:$SkipWrite {
+            BeforeAll {
+                if ([string]::IsNullOrEmpty($fixtures.TestProject)) {
+                    $script:transitionIssue = $null
+                }
+                else {
+                    $summary = New-TestResourceName -Type "Transition"
+                    $script:transitionIssue = New-JiraIssue -Project $fixtures.TestProject -IssueType 'Task' -Summary $summary
+                    if ($transitionIssue) {
+                        $null = $script:createdIssues.Add($transitionIssue.Key)
+                    }
+                }
+            }
+
+            It "transitions an issue using transition ID" {
+                if (-not $transitionIssue) {
+                    Set-ItResult -Skipped -Because "JIRA_TEST_PROJECT not configured"
+                    return
+                }
+
+                $issue = Get-JiraIssue -Key $transitionIssue.Key
+                $availableTransitions = $issue.Transition
+
+                if (-not $availableTransitions -or $availableTransitions.Count -eq 0) {
+                    Set-ItResult -Skipped -Because "No transitions available for issue"
+                    return
+                }
+
+                $targetTransition = $availableTransitions[0]
+
+                { Invoke-JiraIssueTransition -Issue $issue.Key -Transition $targetTransition.Id } |
+                    Should -Not -Throw
+            }
+
+            It "transitions an issue using transition object" {
+                if (-not $transitionIssue) {
+                    Set-ItResult -Skipped -Because "JIRA_TEST_PROJECT not configured"
+                    return
+                }
+
+                $issue = Get-JiraIssue -Key $transitionIssue.Key
+                $availableTransitions = $issue.Transition
+
+                if (-not $availableTransitions -or $availableTransitions.Count -eq 0) {
+                    Set-ItResult -Skipped -Because "No transitions available for issue"
+                    return
+                }
+
+                $targetTransition = $availableTransitions[0]
+
+                { Invoke-JiraIssueTransition -Issue $issue.Key -Transition $targetTransition } |
+                    Should -Not -Throw
+            }
+
+            It "returns the updated issue with -Passthru" {
+                if (-not $transitionIssue) {
+                    Set-ItResult -Skipped -Because "JIRA_TEST_PROJECT not configured"
+                    return
+                }
+
+                $issue = Get-JiraIssue -Key $transitionIssue.Key
+                $availableTransitions = $issue.Transition
+
+                if (-not $availableTransitions -or $availableTransitions.Count -eq 0) {
+                    Set-ItResult -Skipped -Because "No transitions available for issue"
+                    return
+                }
+
+                $targetTransition = $availableTransitions[0]
+
+                $result = Invoke-JiraIssueTransition -Issue $issue.Key -Transition $targetTransition.Id -Passthru
+
+                $result | Should -Not -BeNullOrEmpty
+                $result.Key | Should -Be $issue.Key
+            }
+
+            It "accepts issue object via pipeline" {
+                if (-not $transitionIssue) {
+                    Set-ItResult -Skipped -Because "JIRA_TEST_PROJECT not configured"
+                    return
+                }
+
+                $issue = Get-JiraIssue -Key $transitionIssue.Key
+                $availableTransitions = $issue.Transition
+
+                if (-not $availableTransitions -or $availableTransitions.Count -eq 0) {
+                    Set-ItResult -Skipped -Because "No transitions available for issue"
+                    return
+                }
+
+                $targetTransition = $availableTransitions[0]
+
+                { $issue | Invoke-JiraIssueTransition -Transition $targetTransition.Id } |
+                    Should -Not -Throw
+            }
+
+            It "transitions with a comment" {
+                if (-not $transitionIssue) {
+                    Set-ItResult -Skipped -Because "JIRA_TEST_PROJECT not configured"
+                    return
+                }
+
+                $issue = Get-JiraIssue -Key $transitionIssue.Key
+                $availableTransitions = $issue.Transition
+
+                if (-not $availableTransitions -or $availableTransitions.Count -eq 0) {
+                    Set-ItResult -Skipped -Because "No transitions available for issue"
+                    return
+                }
+
+                $targetTransition = $availableTransitions[0]
+                $commentText = "Transition comment added at $(Get-Date)"
+
+                { Invoke-JiraIssueTransition -Issue $issue.Key -Transition $targetTransition.Id -Comment $commentText } |
+                    Should -Not -Throw
+
+                $comments = Get-JiraIssueComment -Issue $issue.Key
+                $latestComment = $comments | Select-Object -Last 1
+                $latestComment.Body | Should -Match "Transition comment"
+            }
+        }
+
+        Context "Transition Cycle" -Skip:$SkipWrite {
+            It "completes a full transition cycle (To Do -> In Progress -> To Do)" {
+                if ([string]::IsNullOrEmpty($fixtures.TestProject)) {
+                    Set-ItResult -Skipped -Because "JIRA_TEST_PROJECT not configured"
+                    return
+                }
+
+                $summary = New-TestResourceName -Type "TransitionCycle"
+                $issue = New-JiraIssue -Project $fixtures.TestProject -IssueType 'Task' -Summary $summary
+                $null = $script:createdIssues.Add($issue.Key)
+
+                $initialStatus = $issue.Status.Name
+                $issue = Get-JiraIssue -Key $issue.Key
+                $availableTransitions = $issue.Transition
+
+                if (-not $availableTransitions -or $availableTransitions.Count -eq 0) {
+                    Set-ItResult -Skipped -Because "No transitions available for new issue"
+                    return
+                }
+
+                $firstTransition = $availableTransitions[0]
+                Invoke-JiraIssueTransition -Issue $issue.Key -Transition $firstTransition.Id
+
+                $afterFirst = Get-JiraIssue -Key $issue.Key
+                $afterFirst.Status.Name | Should -Not -Be $initialStatus
+
+                $backTransitions = $afterFirst.Transition
+                if ($backTransitions -and $backTransitions.Count -gt 0) {
+                    Invoke-JiraIssueTransition -Issue $issue.Key -Transition $backTransitions[0].Id
+
+                    $afterSecond = Get-JiraIssue -Key $issue.Key
+                    $afterSecond.Status.Name | Should -Not -Be $afterFirst.Status.Name
+                }
+            }
+        }
+
+        Context "Error Handling" {
+            It "fails for non-existent issue" {
+                { Invoke-JiraIssueTransition -Issue 'NONEXISTENT-99999' -Transition 1 -ErrorAction Stop } |
+                    Should -Throw
+            }
+
+            It "fails for invalid transition ID" {
+                if ([string]::IsNullOrEmpty($fixtures.TestIssue)) {
+                    Set-ItResult -Skipped -Because "JIRA_TEST_ISSUE not configured"
+                    return
+                }
+
+                { Invoke-JiraIssueTransition -Issue $fixtures.TestIssue -Transition 99999 -ErrorAction Stop } |
+                    Should -Throw
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds integration tests for commonly used Jira features that were prioritized for coverage:

- **High Priority**: `Invoke-JiraIssueTransition` - Workflow transitions are core Jira functionality
- **Medium Priority**: Issue Links - `Get-JiraIssueLinkType`, `Add-JiraIssueLink`, `Get-JiraIssueLink`, `Remove-JiraIssueLink`
- **Medium Priority**: Issue Watchers - `Get-JiraIssueWatcher`, `Add-JiraIssueWatcher`, `Remove-JiraIssueWatcher`

### New Test Files (3)

| File | Cmdlets Covered | Tests |
|------|----------------|-------|
| `Transitions.Integration.Tests.ps1` | `Invoke-JiraIssueTransition` | Read transitions, transition by ID/object, passthru, pipeline, transition with comment, full cycle test |
| `IssueLinks.Integration.Tests.ps1` | `Get-JiraIssueLinkType`, `Add-JiraIssueLink`, `Get-JiraIssueLink`, `Remove-JiraIssueLink` | Link types CRUD, create/retrieve/remove links, inward/outward direction, pipeline support |
| `IssueWatchers.Integration.Tests.ps1` | `Get-JiraIssueWatcher`, `Add-JiraIssueWatcher`, `Remove-JiraIssueWatcher` | Add/remove watchers, retrieve watcher list, pipeline support |

### Test Patterns

All tests follow the patterns established in PR #584:
- Proper `BeforeDiscovery`/`BeforeAll` setup
- Resource cleanup with `$script:createdIssues` tracking
- `Remove-StaleTestResource` for cleanup from failed runs
- `New-TestResourceName` for discoverable test resource names
- Read-only mode support with `$SkipWrite`
- Graceful skip handling when fixtures aren't configured

## Test Plan

- [ ] Unit tests pass (`Invoke-Build -Task Build, Test`)
- [ ] Integration test syntax validation passes (PSScriptAnalyzer clean)
- [ ] Smoke tests pass in CI (when secrets are configured)
- [ ] Manual verification against Jira Cloud test instance

## Notes

These tests require the following environment variables (configured in CI secrets):
- `JIRA_TEST_USER` - For watcher tests (accountId of a user that can be added as watcher)
- Standard integration test secrets from PR #584

Made with [Cursor](https://cursor.com)