### PR TITLE
fix: warn once per process when integration env vars are missing

### DIFF
--- a/Tests/Helpers/IntegrationTestTools.ps1
+++ b/Tests/Helpers/IntegrationTestTools.ps1
@@ -114,11 +114,18 @@ function Initialize-IntegrationEnvironment {
         Returns $null if required environment variables are missing, allowing tests
         to be skipped gracefully when not configured.
 
+        Uses a global variable (`$global:_JiraPSIntegrationEnvWarned`) to ensure
+        the "missing env vars" warning fires at most once per PowerShell process.
+        A script-scoped flag would not work because Pester dot-sources this file
+        in every integration test's BeforeDiscovery block, resetting any
+        script-scoped state.
+
         .env format: KEY=value (no quotes needed around values)
         - Lines starting with # are comments
         - Inline comments (KEY=value # comment) are stripped
         - Surrounding quotes on values are stripped
     #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidGlobalVars', '', Justification = 'Process-wide warn-once flag; a script-scoped flag resets every time Pester dot-sources this file from BeforeDiscovery.')]
     [CmdletBinding()]
     [OutputType([PSCustomObject])]
     param()
@@ -151,8 +158,16 @@ function Initialize-IntegrationEnvironment {
     }
 
     if ($missing.Count -gt 0) {
-        Write-Warning "Integration tests require the following environment variables: $($missing -join ', ')"
-        Write-Warning "Copy .env.example to .env and configure your Jira Cloud connection."
+        # Warn once per PowerShell process. The `$script:` cache resets every
+        # time this file is dot-sourced (Pester does so in each integration
+        # test's BeforeDiscovery), so a script-scoped guard would still spam
+        # the warning N times. A process-wide global flag stays set across
+        # every dot-source within the same runspace.
+        if (-not $global:_JiraPSIntegrationEnvWarned) {
+            Write-Warning "Integration tests require the following environment variables: $($missing -join ', ')"
+            Write-Warning "Copy .env.example to .env and configure your Jira Cloud connection."
+            $global:_JiraPSIntegrationEnvWarned = $true
+        }
         $script:_EnvLoaded = $true
         $script:_CachedIntegrationEnv = $null
         return $null


### PR DESCRIPTION
## Summary

`Initialize-IntegrationEnvironment` is dot-sourced into every integration test file's `BeforeDiscovery` block. Because the warn-once guard (`$script:_EnvLoaded`) is script-scoped, it gets reset on every dot-source, and the "missing env vars" warning fires once per integration test file (~20 times) during a normal unit test run.

This PR moves the guard to a process-wide global so the warning is emitted **at most once per PowerShell session**, regardless of how many files dot-source the helper.

## Why a global?

- `$script:` resets every time the file is dot-sourced (Pester does this in each integration test's `BeforeDiscovery` block).
- A module-scoped variable would require turning the helper into a module — much larger refactor.
- A process-level env var would leak into child processes.
- A `$global:` flag is the smallest, most local fix.

The resulting `PSAvoidGlobalVars` rule is suppressed on the function with a justification explaining why script scope is insufficient.

## Before / After

Running `Invoke-Build -Task Build, Test` on a machine with no `.env` configured:

| | Warnings emitted |
|---|---|
| Before | **40** (20 pairs, one per integration test file) |
| After  | **2**  (one pair, total) |

## Test plan

- [x] `Invoke-Build -Task Build, Test` succeeds (3507 passed, 0 failed)
- [x] `Invoke-ScriptAnalyzer -Path Tests/Helpers/IntegrationTestTools.ps1 -Settings PSScriptAnalyzerSettings.psd1` returns no findings
- [x] Warning fires exactly once when env vars are missing
- [x] No behavioral change when env vars are configured (tests run normally)


Made with [Cursor](https://cursor.com)