### PR TITLE
ci: skip integration tests for Dependabot PRs

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -45,11 +45,13 @@ jobs:
   smoke_tests:
     name: Smoke Tests
     runs-on: ubuntu-latest
-    # Skip on fork PRs - secrets are not available and tests would fail.
-    # The TestIntegration build task validates required env vars and fails
-    # early with a clear error if any are missing.
+    # Skip on fork PRs and Dependabot PRs - secrets are not available in
+    # those contexts and tests would fail. The TestIntegration build task
+    # validates required env vars and fails early with a clear error if any
+    # are missing.
     if: github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+       github.actor != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-powershell
@@ -67,11 +69,14 @@ jobs:
   integration_tests:
     name: Full Integration Tests
     needs: smoke_tests
+    # Dependabot PRs are excluded because GitHub does not expose repo
+    # secrets to them, even when manually labeled.
     if: |
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
        github.event.pull_request.head.repo.full_name == github.repository &&
+       github.actor != 'dependabot[bot]' &&
        contains(github.event.pull_request.labels.*.name, 'run-integration-tests'))
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

GitHub does not expose repository secrets to workflows triggered by Dependabot PRs, which causes the Jira integration test jobs in `integration_tests.yml` to always fail (the `TestIntegration` build task throws when `JIRA_CLOUD_URL`, `JIRA_CLOUD_USERNAME`, etc. are empty). The previous skip condition only excluded **fork** PRs, but Dependabot branches live on the same repo, so the smoke tests still tried to run against an empty secret context.

This PR extends the skip conditions to also exclude Dependabot:

- **Smoke Tests**: appended `github.actor != 'dependabot[bot]'` to the existing fork-skip condition.
- **Full Integration Tests**: added the same exclusion defensively. Even if a maintainer manually labeled a Dependabot PR with `run-integration-tests`, GitHub would not pass secrets, so it would just produce another confusing failure.

Triggered by the failing Smoke Tests check on #590 (Dependabot bump of `actions/upload-artifact` v6 → v7).

## Test plan

- [x] CI on this PR runs Lint / Build / Test and **does** run Smoke Tests (this PR is not from Dependabot, so the bot exclusion must not affect normal contributors).
- [ ] After merging, re-run / rebase #590 and confirm Smoke Tests is now skipped (not failed) and the PR can go fully green.
- [ ] Confirm the scheduled nightly run and `workflow_dispatch` trigger still execute Full Integration Tests (the new condition only adds an extra clause inside the `pull_request` branch).

Made with [Cursor](https://cursor.com)