### PR TITLE
v3: remove deprecated parameters & magic strings, add -Unassign / -UseDefaultAssignee, modernize hot paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Both accept `SecureString` and work seamlessly in automation. See the updated [a
 
 - **BREAKING**: Removed deprecated `-StartIndex` and `-MaxResults` parameters from `Get-JiraIssue`. Use the standard `-Skip` and `-First` paging parameters instead.
 - **BREAKING**: Removed deprecated `-StartIndex` and `-MaxResults` parameters from `Get-JiraGroupMember`. Use the standard `-Skip` and `-First` paging parameters instead.
-- **BREAKING**: `Set-JiraIssue -Assignee` no longer accepts the magic strings `'Unassigned'` or `'Default'`. Use the new `-Unassign` switch and existing `-UseDefaultAssignee` switch instead.
+- **BREAKING**: `Set-JiraIssue -Assignee` no longer accepts the magic strings `'Unassigned'` or `'Default'`. Use the new `-Unassign` and `-UseDefaultAssignee` switches instead.
 - **BREAKING**: `Set-JiraIssue -Assignee` no longer accepts `$null` or empty/whitespace strings. Use the new `-Unassign` switch instead.
 - **BREAKING**: `Invoke-JiraIssueTransition -Assignee` no longer accepts the magic string `'Unassigned'`, `$null`, or empty/whitespace strings. Use the new `-Unassign` switch instead.
 - **BREAKING**: `Set-JiraIssue` and `Invoke-JiraIssueTransition` now use parameter sets to make `-Assignee`, `-Unassign`, and `-UseDefaultAssignee` mutually exclusive at parameter binding time.
@@ -31,6 +31,7 @@ See [`about_JiraPS_MigrationV3`](https://atlassianps.org/docs/JiraPS/about/migra
 ### Added
 
 - Added `-Unassign` switch to `Set-JiraIssue` and `Invoke-JiraIssueTransition` as the explicit way to remove the assignee from an issue.
+- Added `-UseDefaultAssignee` switch to `Set-JiraIssue` as the explicit way to assign an issue to the project's default assignee, replacing the removed `-Assignee 'Default'` magic string.
 - Added `Invoke-Build -Task TestIntegration` for running integration tests with parallel execution support
 - Added `-Tag`, `-ExcludeTag`, and `-ThrottleLimit` parameters to `Invoke-Build` for test filtering
 - Added `Tests/Invoke-ParallelPester.ps1` script for parallel test execution (requires PowerShell 7+)
@@ -49,9 +50,20 @@ See [`about_JiraPS_MigrationV3`](https://atlassianps.org/docs/JiraPS/about/migra
 - Enhanced `Test-ServerResponse` to handle HTTP 503 (Service Unavailable) with retry, jitter on backoff delays, and 60-second max delay cap (#576)
 - Enhanced `Resolve-JiraError` to parse all Jira error response formats: `message`, `errorMessage`, `errorMessages` array, and `errors` dictionary (#576)
 
+### Internal
+
+- Modernized hot-path code now that PowerShell 5.1 is the floor:
+  - Replaced `System.Collections.ArrayList` with `[System.Collections.Generic.List[T]]` in `New-JiraIssue`, `ConvertTo-JiraGroup`, and `Set-JiraIssueLabel` (the latter now initializes via constructor from existing labels).
+  - Pre-compiled the regex patterns used by `ConvertTo-AtlassianDocumentFormat` once at module load.
+  - Replaced in-loop string concatenation in `ConvertTo-GetParameter` with array-collect + `-join`.
+  - Replaced `Get-Member -MemberType *Property` lookups with direct `PSObject.Properties` access in `Format-Jira`, `Add-JiraIssueLink`, `Remove-JiraIssueLink`, `Resolve-JiraError`, `Expand-Result`, `ConvertTo-JiraCreateMetaField`, and `ConvertTo-JiraEditMetaField`.
+- Extracted assignee-payload construction into a private `Resolve-JiraAssigneePayload` helper shared by `Set-JiraIssue` and `Invoke-JiraIssueTransition`. As a side-effect, `Invoke-JiraIssueTransition -Unassign` on Jira Cloud now correctly emits `{accountId: null}` instead of `{name: ""}`. The helper also throws explicitly when handed a Cloud user object that has no `AccountId`, instead of silently emitting an unassign payload.
+
 ### Fixed
 
 - Fixed `Get-JiraIssue` prompting for input when piping JiraPS.Issue objects (added `ValueFromPipelineByPropertyName` to `-Key` parameter)
+- Fixed long-standing typo in `Invoke-JiraIssueTransition` where the transition-cast error path constructed its `ErrorRecord` against an undefined `$errorTargetError` variable instead of `$errorTarget`.
+- Fixed `ConvertTo-GetParameter` returning `'?'` for an empty hashtable; it now returns `''` again, matching its prior contract and preventing accidental trailing `?` in URLs.
 - Fixed `ConvertTo-JiraServerInfo` throwing when `BuildDate` or `ServerTime` are null in API response (now returns `$null` for these fields). **Soft breaking change**: Scripts accessing `.BuildDate.Year` or similar will throw `NullReferenceException` on Cloud instances that omit these fields.
 - Fixed `Invoke-PaginatedRequest` crashing with "Cannot bind argument to parameter 'InputObject'" when API returns null during pagination (now writes warning and returns partial results)
 - Fixed module load race condition when multiple processes import JiraPS simultaneously (gracefully handles concurrent config file creation)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,20 @@ Both accept `SecureString` and work seamlessly in automation. See the updated [a
 
 **Resilience**: HTTP retry logic now handles 503 errors (common during Jira maintenance), adds jitter to prevent thundering herd, and caps retry delays at 60 seconds.
 
+### Removed (Breaking)
+
+- **BREAKING**: Removed deprecated `-StartIndex` and `-MaxResults` parameters from `Get-JiraIssue`. Use the standard `-Skip` and `-First` paging parameters instead.
+- **BREAKING**: Removed deprecated `-StartIndex` and `-MaxResults` parameters from `Get-JiraGroupMember`. Use the standard `-Skip` and `-First` paging parameters instead.
+- **BREAKING**: `Set-JiraIssue -Assignee` no longer accepts the magic strings `'Unassigned'` or `'Default'`. Use the new `-Unassign` switch and existing `-UseDefaultAssignee` switch instead.
+- **BREAKING**: `Set-JiraIssue -Assignee` no longer accepts `$null` or empty/whitespace strings. Use the new `-Unassign` switch instead.
+- **BREAKING**: `Invoke-JiraIssueTransition -Assignee` no longer accepts the magic string `'Unassigned'`, `$null`, or empty/whitespace strings. Use the new `-Unassign` switch instead.
+- **BREAKING**: `Set-JiraIssue` and `Invoke-JiraIssueTransition` now use parameter sets to make `-Assignee`, `-Unassign`, and `-UseDefaultAssignee` mutually exclusive at parameter binding time.
+
+See [`about_JiraPS_MigrationV3`](https://atlassianps.org/docs/JiraPS/about/migration-v3.html) for migration examples.
+
 ### Added
 
+- Added `-Unassign` switch to `Set-JiraIssue` and `Invoke-JiraIssueTransition` as the explicit way to remove the assignee from an issue.
 - Added `Invoke-Build -Task TestIntegration` for running integration tests with parallel execution support
 - Added `-Tag`, `-ExcludeTag`, and `-ThrottleLimit` parameters to `Invoke-Build` for test filtering
 - Added `Tests/Invoke-ParallelPester.ps1` script for parallel test execution (requires PowerShell 7+)

--- a/JiraPS/Private/ConvertTo-GetParameter.ps1
+++ b/JiraPS/Private/ConvertTo-GetParameter.ps1
@@ -12,6 +12,7 @@
     process {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Making HTTP get parameter string out of a hashtable"
         Write-Verbose ($InputObject | Out-String)
+        if ($InputObject.Count -eq 0) { return '' }
         $pairs = $InputObject.Keys.ForEach({ "$_=$($InputObject[$_])" })
         "?" + ($pairs -join "&")
     }

--- a/JiraPS/Private/ConvertTo-GetParameter.ps1
+++ b/JiraPS/Private/ConvertTo-GetParameter.ps1
@@ -12,11 +12,7 @@
     process {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Making HTTP get parameter string out of a hashtable"
         Write-Verbose ($InputObject | Out-String)
-        [string]$parameters = "?"
-        foreach ($key in $InputObject.Keys) {
-            $value = $InputObject[$key]
-            $parameters += "$key=$($value)&"
-        }
-        $parameters -replace ".$"
+        $pairs = $InputObject.Keys.ForEach({ "$_=$($InputObject[$_])" })
+        "?" + ($pairs -join "&")
     }
 }

--- a/JiraPS/Private/ConvertTo-JiraCreateMetaField.ps1
+++ b/JiraPS/Private/ConvertTo-JiraCreateMetaField.ps1
@@ -27,7 +27,10 @@
                 $props.AutoCompleteUrl = $item.autoCompleteUrl
             }
 
-            foreach ($extraProperty in (Get-Member -InputObject $item -MemberType NoteProperty).Name) {
+            # NoteProperty only: $item is a JSON-deserialized field spec and
+            # its data keys are NoteProperties. Synthetic Script/AliasProperty
+            # would otherwise leak into the output object.
+            foreach ($extraProperty in $item.PSObject.Properties.Where({ $_.MemberType -eq 'NoteProperty' }).Name) {
                 if ($null -eq $props.$extraProperty) {
                     $props.$extraProperty = $item.$extraProperty
                 }

--- a/JiraPS/Private/ConvertTo-JiraEditMetaField.ps1
+++ b/JiraPS/Private/ConvertTo-JiraEditMetaField.ps1
@@ -11,7 +11,7 @@
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Converting `$InputObject to custom object"
 
             $fields = $i.fields
-            $fieldNames = (Get-Member -InputObject $fields -MemberType '*Property').Name
+            $fieldNames = $fields.PSObject.Properties.Name
             foreach ($f in $fieldNames) {
                 $item = $fields.$f
 
@@ -32,7 +32,10 @@
                     $props.AutoCompleteUrl = $item.autoCompleteUrl
                 }
 
-                foreach ($extraProperty in (Get-Member -InputObject $item -MemberType NoteProperty).Name) {
+                # NoteProperty only: $item is a JSON-deserialized field spec
+                # and its data keys are NoteProperties. Synthetic Script/
+                # AliasProperty would otherwise leak into the output object.
+                foreach ($extraProperty in $item.PSObject.Properties.Where({ $_.MemberType -eq 'NoteProperty' }).Name) {
                     if ($null -eq $props.$extraProperty) {
                         $props.$extraProperty = $item.$extraProperty
                     }

--- a/JiraPS/Private/ConvertTo-JiraGroup.ps1
+++ b/JiraPS/Private/ConvertTo-JiraGroup.ps1
@@ -19,12 +19,9 @@
                 $props.Size = $i.users.size
 
                 if ($i.users.items) {
-                    $allUsers = New-Object -TypeName System.Collections.ArrayList
-                    foreach ($user in $i.users.items) {
-                        [void] $allUsers.Add( (ConvertTo-JiraUser -InputObject $user) )
-                    }
-
-                    $props.Member = ($allUsers.ToArray())
+                    $allUsers = [System.Collections.Generic.List[PSObject]]::new()
+                    $i.users.items.ForEach({ $allUsers.Add((ConvertTo-JiraUser -InputObject $_)) })
+                    $props.Member = $allUsers.ToArray()
                 }
             }
 

--- a/JiraPS/Private/Expand-Result.ps1
+++ b/JiraPS/Private/Expand-Result.ps1
@@ -7,7 +7,7 @@
 
     process {
         foreach ($container in $script:PagingContainers) {
-            if (($InputObject) -and ($InputObject | Get-Member -Name $container)) {
+            if ($InputObject -and $InputObject.PSObject.Properties[$container]) {
                 Write-DebugMessage "Extracting data from [$container] containter"
                 $InputObject.$container
             }

--- a/JiraPS/Private/Resolve-JiraAssigneePayload.ps1
+++ b/JiraPS/Private/Resolve-JiraAssigneePayload.ps1
@@ -17,29 +17,27 @@
             @{ accountId = <string> }        # Cloud, assign to user
             @{ accountId = $null }           # Cloud, unassign
             @{ name      = <string> }        # Server/DC, assign to user or '-1' for default
-            @{ name      = $null }           # Server/DC, unassign (Set-JiraIssue)
-            @{ name      = ''   }            # Server/DC, unassign (Invoke-JiraIssueTransition)
+            @{ name      = $null }           # Server/DC, unassign
+
+        Empty-string AssigneeString is preserved verbatim ('name = "")
+        for callers that need that exact JSON shape.
     #>
     [CmdletBinding()]
     [OutputType([hashtable])]
     param(
-        # The resolved JiraPS.User object, or $null to unassign.
         [Parameter()]
         [PSObject]
         $AssigneeObject,
 
-        # Server/DC string representation for special cases:
-        #   - '-1' = project default assignee
-        #   - ''   = unassign during transition (Server/DC legacy)
-        #   - $null = unassign (Set-JiraIssue on Server/DC)
-        # Untyped so that $null and '' remain distinct (PowerShell would
-        # otherwise coerce $null -> '' when bound to a [string] parameter).
+        # Server/DC magic values: '-1' = project default, '' = legacy
+        # transition unassign, $null = Set-JiraIssue unassign.
+        # Untyped so $null and '' remain distinct (PowerShell coerces
+        # $null -> '' when bound to a [string] parameter).
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
         $AssigneeString = $null,
 
-        # $true for Jira Cloud, $false for Jira Server / Data Center.
         [Parameter(Mandatory)]
         [bool]
         $IsCloud
@@ -47,10 +45,9 @@
 
     if ($IsCloud) {
         if ($AssigneeObject) {
-            # Reject a non-null user object that has no resolvable AccountId
-            # rather than silently fall through to "unassign". This protects
-            # against partial / mis-resolved user objects on Cloud where the
-            # caller's intent was to assign, not to clear the assignee.
+            # Reject a non-null user object with no resolvable AccountId
+            # rather than silently fall through to "unassign" — the caller's
+            # intent here is to assign, not clear.
             if (-not $AssigneeObject.AccountId) {
                 throw [System.InvalidOperationException]::new(
                     "Cannot build a Cloud assignee payload from a user object with no AccountId. Use -Unassign explicitly to clear the assignee."
@@ -60,12 +57,10 @@
             return @{ accountId = $AssigneeObject.AccountId }
         }
 
-        # Cloud unassign: accountId must be $null
-        # (Cloud does not accept the 'name' field for assignee operations).
+        # Cloud does not accept the 'name' field for assignee operations.
         return @{ accountId = $null }
     }
 
-    # Jira Server / Data Center: the 'name' field is used.
     if ($AssigneeObject) {
         return @{ name = $AssigneeObject.Name }
     }

--- a/JiraPS/Private/Resolve-JiraAssigneePayload.ps1
+++ b/JiraPS/Private/Resolve-JiraAssigneePayload.ps1
@@ -1,0 +1,74 @@
+﻿function Resolve-JiraAssigneePayload {
+    <#
+    .SYNOPSIS
+        Builds the JSON-ready hashtable for setting an issue's assignee.
+
+    .DESCRIPTION
+        Encapsulates the decision between the Cloud ('accountId') and
+        Server / Data Center ('name') representations of an assignee, and
+        between assigning, unassigning, and selecting the project's default.
+
+        Callers are responsible for resolving the target user (if any) and
+        for placing the returned hashtable in the correct part of the
+        request body; this function only decides the shape of the payload.
+
+    .OUTPUTS
+        [hashtable] — one of:
+            @{ accountId = <string> }        # Cloud, assign to user
+            @{ accountId = $null }           # Cloud, unassign
+            @{ name      = <string> }        # Server/DC, assign to user or '-1' for default
+            @{ name      = $null }           # Server/DC, unassign (Set-JiraIssue)
+            @{ name      = ''   }            # Server/DC, unassign (Invoke-JiraIssueTransition)
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        # The resolved JiraPS.User object, or $null to unassign.
+        [Parameter()]
+        [PSObject]
+        $AssigneeObject,
+
+        # Server/DC string representation for special cases:
+        #   - '-1' = project default assignee
+        #   - ''   = unassign during transition (Server/DC legacy)
+        #   - $null = unassign (Set-JiraIssue on Server/DC)
+        # Untyped so that $null and '' remain distinct (PowerShell would
+        # otherwise coerce $null -> '' when bound to a [string] parameter).
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        $AssigneeString = $null,
+
+        # $true for Jira Cloud, $false for Jira Server / Data Center.
+        [Parameter(Mandatory)]
+        [bool]
+        $IsCloud
+    )
+
+    if ($IsCloud) {
+        if ($AssigneeObject) {
+            # Reject a non-null user object that has no resolvable AccountId
+            # rather than silently fall through to "unassign". This protects
+            # against partial / mis-resolved user objects on Cloud where the
+            # caller's intent was to assign, not to clear the assignee.
+            if (-not $AssigneeObject.AccountId) {
+                throw [System.InvalidOperationException]::new(
+                    "Cannot build a Cloud assignee payload from a user object with no AccountId. Use -Unassign explicitly to clear the assignee."
+                )
+            }
+
+            return @{ accountId = $AssigneeObject.AccountId }
+        }
+
+        # Cloud unassign: accountId must be $null
+        # (Cloud does not accept the 'name' field for assignee operations).
+        return @{ accountId = $null }
+    }
+
+    # Jira Server / Data Center: the 'name' field is used.
+    if ($AssigneeObject) {
+        return @{ name = $AssigneeObject.Name }
+    }
+
+    return @{ name = $AssigneeString }
+}

--- a/JiraPS/Private/Resolve-JiraError.ps1
+++ b/JiraPS/Private/Resolve-JiraError.ps1
@@ -72,7 +72,11 @@
             }
 
             if ($i.errors) {
-                $keys = (Get-Member -InputObject $i.errors | Where-Object -FilterScript { $_.MemberType -eq 'NoteProperty' }).Name
+                # Restrict to NoteProperty: $i.errors comes from JSON and its
+                # real error keys are NoteProperties. Any synthetic Script/
+                # AliasProperty attached upstream would otherwise be reported
+                # as a bogus server error.
+                $keys = $i.errors.PSObject.Properties.Where({ $_.MemberType -eq 'NoteProperty' }).Name
                 if ($keys.Count -gt 0) {
                     $hasErrors = $true
                     foreach ($k in $keys) {

--- a/JiraPS/Public/Add-JiraIssueLink.ps1
+++ b/JiraPS/Public/Add-JiraIssueLink.ps1
@@ -31,12 +31,12 @@
 
         [Parameter( Mandatory )]
         [ValidateScript({
-                $objectProperties = Get-Member -InputObject $_ -MemberType *Property
+                $propertyNames = $_.PSObject.Properties.Name
                 if (
-                    ($objectProperties.Name -contains "type") -and
+                    ($propertyNames -contains "type") -and
                     (
-                        ($objectProperties.Name -contains "outwardIssue") -or
-                        ($objectProperties.Name -contains "inwardIssue")
+                        ($propertyNames -contains "outwardIssue") -or
+                        ($propertyNames -contains "inwardIssue")
                     )
                 ) {
                     return $true

--- a/JiraPS/Public/ConvertTo-AtlassianDocumentFormat.ps1
+++ b/JiraPS/Public/ConvertTo-AtlassianDocumentFormat.ps1
@@ -1,4 +1,22 @@
-﻿function ConvertTo-AtlassianDocumentFormat {
+﻿# Pre-compiled regex patterns for performance (compiled once at module load)
+$script:AdfRegex = @{
+    Heading        = [regex]::new('^(#{1,6})\s+(.+)$', 'Compiled')
+    CodeBlockStart = [regex]::new('^```(\w*)$', 'Compiled')
+    CodeBlockEnd   = [regex]::new('^```+$', 'Compiled')
+    BlockImage     = [regex]::new('^!\[(?<alt>[^\]]*)\]\((?<url>[^\)]+)\)\s*$', 'Compiled')
+    Blockquote     = [regex]::new('^>\s*(.*)$', 'Compiled')
+    TableLine      = [regex]::new('^\|', 'Compiled')
+    TableSeparator = [regex]::new('^\|[-:\s|]+\|$', 'Compiled')
+    TaskListStart  = [regex]::new('^\*\s+\[[ x]\]\s', 'Compiled')
+    TaskListItem   = [regex]::new('^\*\s+\[([ x])\]\s+(.+)$', 'Compiled')
+    BulletList     = [regex]::new('^\*\s+(?!\[[ x]\])(.+)$', 'Compiled')
+    OrderedList    = [regex]::new('^\d+\.\s+(.+)$', 'Compiled')
+    BlockElement   = [regex]::new('^(#{1,6}\s|```|!\[|>\s*|\||\*\s|\d+\.\s)', 'Compiled')
+    HardBreak      = [regex]::new('  $', 'Compiled')
+    InlineMarks    = [regex]::new('\*\*\*(?<biText>[^\*\n]+)\*\*\*|\*\*_(?<beText>[^_\n]+)_\*\*|_\*\*(?<ebText>[^\*\n]+)\*\*_|\[(?<lText>[^\]]+)\]\((?<lUrl>[^\)]+)\)|\*\*(?<bText>[^\*\n]+)\*\*|_(?<eText>[^_\n]+)_|~~(?<sText>[^~\n]+)~~|`(?<cText>[^`\n]+)`', 'Compiled')
+}
+
+function ConvertTo-AtlassianDocumentFormat {
     # .ExternalHelp ..\JiraPS-help.xml
     [CmdletBinding()]
     param(
@@ -48,22 +66,22 @@ function script:ConvertTo-AdfContent {
         $line = $Lines[$i]
 
         # ── Heading ──────────────────────────────────────────────────────────
-        if ($line -match '^(#{1,6})\s+(.+)$') {
+        if (($m = $script:AdfRegex.Heading.Match($line)).Success) {
             $nodes.Add(@{
                     type    = 'heading'
-                    attrs   = @{ level = $matches[1].Length }
-                    content = @(ConvertTo-AdfInline $matches[2])
+                    attrs   = @{ level = $m.Groups[1].Value.Length }
+                    content = @(ConvertTo-AdfInline $m.Groups[2].Value)
                 })
             $i++
             continue
         }
 
         # ── Fenced code block ────────────────────────────────────────────────
-        if ($line -match '^```(\w*)$') {
-            $lang = $matches[1]
+        if (($m = $script:AdfRegex.CodeBlockStart.Match($line)).Success) {
+            $lang = $m.Groups[1].Value
             $codeLines = [System.Collections.Generic.List[string]]::new()
             $i++
-            while ($i -lt $Lines.Count -and $Lines[$i] -notmatch '^```+$') {
+            while ($i -lt $Lines.Count -and -not $script:AdfRegex.CodeBlockEnd.IsMatch($Lines[$i])) {
                 $codeLines.Add($Lines[$i])
                 $i++
             }
@@ -77,13 +95,13 @@ function script:ConvertTo-AdfContent {
         }
 
         # ── Block image ───────────────────────────────────────────────────────
-        if ($line -match '^!\[(?<alt>[^\]]*)\]\((?<url>[^\)]+)\)\s*$') {
+        if (($m = $script:AdfRegex.BlockImage.Match($line)).Success) {
             $nodes.Add(@{
                     type    = 'mediaSingle'
                     attrs   = @{ layout = 'align-start' }
                     content = @(@{
                             type  = 'media'
-                            attrs = @{ type = 'external'; url = $matches['url']; alt = $matches['alt'] }
+                            attrs = @{ type = 'external'; url = $m.Groups['url'].Value; alt = $m.Groups['alt'].Value }
                         })
                 })
             $i++
@@ -91,12 +109,12 @@ function script:ConvertTo-AdfContent {
         }
 
         # ── Blockquote ────────────────────────────────────────────────────────
-        if ($line -match '^>\s*(.*)$') {
+        if (($m = $script:AdfRegex.Blockquote.Match($line)).Success) {
             $quoteParas = [System.Collections.Generic.List[hashtable]]::new()
-            while ($i -lt $Lines.Count -and $Lines[$i] -match '^>\s*(.*)$') {
+            while ($i -lt $Lines.Count -and ($m = $script:AdfRegex.Blockquote.Match($Lines[$i])).Success) {
                 $quoteParas.Add(@{
                         type    = 'paragraph'
-                        content = @(ConvertTo-AdfInline $matches[1])
+                        content = @(ConvertTo-AdfInline $m.Groups[1].Value)
                     })
                 $i++
             }
@@ -105,9 +123,9 @@ function script:ConvertTo-AdfContent {
         }
 
         # ── Table ─────────────────────────────────────────────────────────────
-        if ($line -match '^\|') {
+        if ($script:AdfRegex.TableLine.IsMatch($line)) {
             $tableLines = [System.Collections.Generic.List[string]]::new()
-            while ($i -lt $Lines.Count -and $Lines[$i] -match '^\|') {
+            while ($i -lt $Lines.Count -and $script:AdfRegex.TableLine.IsMatch($Lines[$i])) {
                 $tableLines.Add($Lines[$i])
                 $i++
             }
@@ -117,13 +135,13 @@ function script:ConvertTo-AdfContent {
         }
 
         # ── Task list (must be tested before bullet list) ────────────────────
-        if ($line -match '^\*\s+\[[ x]\]\s') {
+        if ($script:AdfRegex.TaskListStart.IsMatch($line)) {
             $taskItems = [System.Collections.Generic.List[hashtable]]::new()
-            while ($i -lt $Lines.Count -and $Lines[$i] -match '^\*\s+\[([ x])\]\s+(.+)$') {
-                $state = if ($matches[1] -eq 'x') { 'DONE' } else { 'TODO' }
+            while ($i -lt $Lines.Count -and ($m = $script:AdfRegex.TaskListItem.Match($Lines[$i])).Success) {
+                $state = if ($m.Groups[1].Value -eq 'x') { 'DONE' } else { 'TODO' }
                 $taskItems.Add(@{
                         type    = 'taskItem'
-                        content = @(ConvertTo-AdfInline $matches[2])
+                        content = @(ConvertTo-AdfInline $m.Groups[2].Value)
                         attrs   = @{ localId = [guid]::NewGuid().ToString(); state = $state }
                     })
                 $i++
@@ -137,7 +155,7 @@ function script:ConvertTo-AdfContent {
         }
 
         # ── Bullet list (with 2-level nesting support) ─────────────────────────
-        if ($line -match '^\*\s+(?!\[[ x]\])(.+)$') {
+        if ($script:AdfRegex.BulletList.IsMatch($line)) {
             $listResult = ConvertTo-AdfList -Lines $Lines -StartIndex $i -ListType 'bullet' -IndentLevel 0
             $nodes.Add($listResult.Node)
             $i = $listResult.NextIndex
@@ -145,7 +163,7 @@ function script:ConvertTo-AdfContent {
         }
 
         # ── Ordered list (with 2-level nesting support) ────────────────────────
-        if ($line -match '^\d+\.\s+(.+)$') {
+        if ($script:AdfRegex.OrderedList.IsMatch($line)) {
             $listResult = ConvertTo-AdfList -Lines $Lines -StartIndex $i -ListType 'ordered' -IndentLevel 0
             $nodes.Add($listResult.Node)
             $i = $listResult.NextIndex
@@ -166,10 +184,10 @@ function script:ConvertTo-AdfContent {
             # Skip if we hit a blank line (end of paragraph)
             if ([string]::IsNullOrWhiteSpace($currentLine)) { break }
             # Skip if we hit a block-level element
-            if ($currentLine -match '^(#{1,6}\s|```|!\[|>\s*|\||\*\s|\d+\.\s)') { break }
+            if ($script:AdfRegex.BlockElement.IsMatch($currentLine)) { break }
 
-            $endsWithHardBreak = $currentLine -match '  $'
-            $trimmedLine = $currentLine -replace '  $', ''
+            $endsWithHardBreak = $script:AdfRegex.HardBreak.IsMatch($currentLine)
+            $trimmedLine = $script:AdfRegex.HardBreak.Replace($currentLine, '')
 
             foreach ($inlineNode in (ConvertTo-AdfInline $trimmedLine)) {
                 $paraContent.Add($inlineNode)
@@ -205,15 +223,14 @@ function script:ConvertTo-AdfInline {
 
     $nodes = [System.Collections.Generic.List[hashtable]]::new()
 
-    # Combined regex (single-quoted — no PS escape processing on backticks)
+    # Uses pre-compiled InlineMarks regex for performance
     # Priority order: combined marks → link → bold → italic → strikethrough → code
     # biText = ***bold italic*** (3 asterisks)
     # beText = **_bold italic_** (bold wrapping italic)
     # ebText = _**bold italic**_ (italic wrapping bold)
-    $pattern = '\*\*\*(?<biText>[^\*\n]+)\*\*\*|\*\*_(?<beText>[^_\n]+)_\*\*|_\*\*(?<ebText>[^\*\n]+)\*\*_|\[(?<lText>[^\]]+)\]\((?<lUrl>[^\)]+)\)|\*\*(?<bText>[^\*\n]+)\*\*|_(?<eText>[^_\n]+)_|~~(?<sText>[^~\n]+)~~|`(?<cText>[^`\n]+)`'
 
     $lastEnd = 0
-    foreach ($m in [regex]::Matches($Text, $pattern)) {
+    foreach ($m in $script:AdfRegex.InlineMarks.Matches($Text)) {
         # Plain text before this match
         if ($m.Index -gt $lastEnd) {
             $nodes.Add(@{ type = 'text'; text = $Text.Substring($lastEnd, $m.Index - $lastEnd) })
@@ -276,7 +293,7 @@ function script:ConvertTo-AdfTable {
 
     foreach ($tLine in $TableLines) {
         # Skip separator rows: | --- | :---: | ---: | (with or without spaces)
-        if ($tLine -match '^\|[-:\s|]+\|$') { continue }
+        if ($script:AdfRegex.TableSeparator.IsMatch($tLine)) { continue }
 
         # Split on | and trim — the leading/trailing | produce empty strings, filter those out
         $cells = @($tLine -split '\|' |

--- a/JiraPS/Public/ConvertTo-AtlassianDocumentFormat.ps1
+++ b/JiraPS/Public/ConvertTo-AtlassianDocumentFormat.ps1
@@ -223,7 +223,6 @@ function script:ConvertTo-AdfInline {
 
     $nodes = [System.Collections.Generic.List[hashtable]]::new()
 
-    # Uses pre-compiled InlineMarks regex for performance
     # Priority order: combined marks → link → bold → italic → strikethrough → code
     # biText = ***bold italic*** (3 asterisks)
     # beText = **_bold italic_** (bold wrapping italic)

--- a/JiraPS/Public/Format-Jira.ps1
+++ b/JiraPS/Public/Format-Jira.ps1
@@ -54,8 +54,7 @@
                 # This should only be called if Property was not supplied and this is the first object in the InputObject array.
                 if ($Property -and $Property -eq '*') {
                     Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] Adding all properties from object [$i]"
-                    $allProperties = Get-Member -InputObject $i -MemberType '*Property'
-                    foreach ($a in $allProperties) {
+                    foreach ($a in $i.PSObject.Properties) {
                         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] Adding header [$($a.Name)]"
                         [void] $headers.Add($a.Name)
                     }
@@ -75,8 +74,7 @@
                     }
                     else {
                         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] No default format data exists for object [$i] (type=[$($i.GetType())]). All properties will be used."
-                        $allProperties = Get-Member -InputObject $i -MemberType '*Property'
-                        foreach ($a in $allProperties) {
+                        foreach ($a in $i.PSObject.Properties) {
                             Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] Adding header [$($a.Name)]"
                             [void] $headers.Add($a.Name)
                         }

--- a/JiraPS/Public/Get-JiraFilter.ps1
+++ b/JiraPS/Public/Get-JiraFilter.ps1
@@ -82,7 +82,7 @@
                     Write-Verbose "[$($MyInvocation.MyCommand.Name)] Processing [$object]"
                     Write-Debug "[$($MyInvocation.MyCommand.Name)] Processing `$object [$object]"
 
-                    if ((Get-Member -InputObject $object).TypeName -eq 'JiraPS.Filter') {
+                    if ('JiraPS.Filter' -in $object.PSObject.TypeNames) {
                         $thisId = $object.ID
                     }
                     else {

--- a/JiraPS/Public/Get-JiraGroupMember.ps1
+++ b/JiraPS/Public/Get-JiraGroupMember.ps1
@@ -31,12 +31,6 @@
         $IncludeInactive,
 
         [UInt32]
-        $StartIndex = 0,
-
-        [UInt32]
-        $MaxResults,
-
-        [UInt32]
         $PageSize = $script:DefaultPageSize,
 
         [Parameter()]
@@ -85,15 +79,6 @@
             # Paging
             ($PSCmdlet.PagingParameters | Get-Member -MemberType Property).Name | ForEach-Object {
                 $parameter[$_] = $PSCmdlet.PagingParameters.$_
-            }
-            # Make `SupportsPaging` be backwards compatible
-            if ($StartIndex) {
-                Write-Warning "[$($MyInvocation.MyCommand.Name)] The parameter '-StartIndex' has been marked as deprecated. For more information, plase read the help."
-                $parameter["Skip"] = $StartIndex
-            }
-            if ($MaxResults) {
-                Write-Warning "[$($MyInvocation.MyCommand.Name)] The parameter '-MaxResults' has been marked as deprecated. For more information, plase read the help."
-                $parameter["First"] = $MaxResults
             }
 
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"

--- a/JiraPS/Public/Get-JiraIssue.ps1
+++ b/JiraPS/Public/Get-JiraIssue.ps1
@@ -73,16 +73,6 @@
         [Parameter( ParameterSetName = 'ByJQL' )]
         [Parameter( ParameterSetName = 'ByFilter' )]
         [UInt32]
-        $StartIndex = 0,
-
-        [Parameter( ParameterSetName = 'ByJQL' )]
-        [Parameter( ParameterSetName = 'ByFilter' )]
-        [UInt32]
-        $MaxResults = 0,
-
-        [Parameter( ParameterSetName = 'ByJQL' )]
-        [Parameter( ParameterSetName = 'ByFilter' )]
-        [UInt32]
         $PageSize = $script:DefaultPageSize,
 
         [Parameter()]
@@ -162,16 +152,6 @@
                 ($PSCmdlet.PagingParameters | Get-Member -MemberType Property).Name | ForEach-Object {
                     $parameter[$_] = $PSCmdlet.PagingParameters.$_
                 }
-                # Make `SupportsPaging` be backwards compatible
-                if ($StartIndex) {
-                    Write-Warning "[$($MyInvocation.MyCommand.Name)] The parameter '-StartIndex' has been marked as deprecated. For more information, plase read the help."
-                    $parameter["Skip"] = $StartIndex
-                }
-                if ($MaxResults) {
-                    Write-Warning "[$($MyInvocation.MyCommand.Name)] The parameter '-MaxResults' has been marked as deprecated. For more information, plase read the help."
-                    $parameter["First"] = $MaxResults
-                }
-
 
                 Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"
                 Invoke-JiraMethod @parameter
@@ -202,15 +182,6 @@
                 # Paging
                 ($PSCmdlet.PagingParameters | Get-Member -MemberType Property).Name | ForEach-Object {
                     $parameter[$_] = $PSCmdlet.PagingParameters.$_
-                }
-                # Make `SupportsPaging` be backwards compatible
-                if ($StartIndex) {
-                    Write-Warning "[$($MyInvocation.MyCommand.Name)] The parameter '-StartIndex' has been marked as deprecated. For more information, plase read the help."
-                    $parameter["Skip"] = $StartIndex
-                }
-                if ($MaxResults) {
-                    Write-Warning "[$($MyInvocation.MyCommand.Name)] The parameter '-MaxResults' has been marked as deprecated. For more information, plase read the help."
-                    $parameter["First"] = $MaxResults
                 }
 
                 Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$parameter"

--- a/JiraPS/Public/Invoke-JiraIssueTransition.ps1
+++ b/JiraPS/Public/Invoke-JiraIssueTransition.ps1
@@ -1,6 +1,6 @@
 ﻿function Invoke-JiraIssueTransition {
     # .ExternalHelp ..\JiraPS-help.xml
-    [CmdletBinding()]
+    [CmdletBinding( DefaultParameterSetName = 'AssignToUser' )]
     param(
         [Parameter( Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName )]
         [ValidateNotNullOrEmpty()]
@@ -34,8 +34,22 @@
         [PSCustomObject]
         $Fields,
 
+        [Parameter( ParameterSetName = 'AssignToUser' )]
+        [ValidateNotNull()]
+        [ValidateScript(
+            {
+                if ($_ -is [string] -and [string]::IsNullOrWhiteSpace($_)) {
+                    throw "The -Assignee value cannot be an empty or whitespace string. Use -Unassign to remove the assignee."
+                }
+                $true
+            }
+        )]
         [Object]
         $Assignee,
+
+        [Parameter( ParameterSetName = 'Unassign' )]
+        [Switch]
+        $Unassign,
 
         [String]
         $Comment,
@@ -99,26 +113,24 @@
             }
         }
 
-        if ($PSCmdlet.MyInvocation.BoundParameters.ContainsKey("Assignee")) {
-            if ($null -eq $Assignee) {
-                Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] `$null passed. Issue will be unassigned."
-                $assigneeString = ""
+        if ($Unassign) {
+            Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] -Unassign passed. Issue will be unassigned."
+            $assigneeString = ""
+            $validAssignee = $true
+        }
+        elseif ($PSCmdlet.MyInvocation.BoundParameters.ContainsKey("Assignee")) {
+            if ($assigneeObj = Resolve-JiraUser -InputObject $Assignee -Credential $Credential -Exact) {
+                Write-Debug "[$($MyInvocation.MyCommand.Name)] User found (name=[$($assigneeObj.Name)],RestUrl=[$($assigneeObj.RestUrl)])"
                 $validAssignee = $true
             }
             else {
-                if ($assigneeObj = Resolve-JiraUser -InputObject $Assignee -Credential $Credential -Exact) {
-                    Write-Debug "[$($MyInvocation.MyCommand.Name)] User found (name=[$($assigneeObj.Name)],RestUrl=[$($assigneeObj.RestUrl)])"
-                    $validAssignee = $true
-                }
-                else {
-                    $exception = ([System.ArgumentException]"Invalid value for Parameter")
-                    $errorId = 'ParameterValue.InvalidAssignee'
-                    $errorCategory = 'InvalidArgument'
-                    $errorTarget = $Assignee
-                    $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
-                    $errorItem.ErrorDetails = "Unable to validate Jira user [$Assignee]. Use Get-JiraUser for more details."
-                    $PSCmdlet.ThrowTerminatingError($errorItem)
-                }
+                $exception = ([System.ArgumentException]"Invalid value for Parameter")
+                $errorId = 'ParameterValue.InvalidAssignee'
+                $errorCategory = 'InvalidArgument'
+                $errorTarget = $Assignee
+                $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
+                $errorItem.ErrorDetails = "Unable to validate Jira user [$Assignee]. Use Get-JiraUser for more details."
+                $PSCmdlet.ThrowTerminatingError($errorItem)
             }
         }
 

--- a/JiraPS/Public/Invoke-JiraIssueTransition.ps1
+++ b/JiraPS/Public/Invoke-JiraIssueTransition.ps1
@@ -35,11 +35,11 @@
         $Fields,
 
         [Parameter( ParameterSetName = 'AssignToUser' )]
-        [ValidateNotNull()]
+        [ValidateNotNullOrEmpty()]
         [ValidateScript(
             {
                 if ($_ -is [string] -and [string]::IsNullOrWhiteSpace($_)) {
-                    throw "The -Assignee value cannot be an empty or whitespace string. Use -Unassign to remove the assignee."
+                    throw "The -Assignee value cannot be a whitespace-only string. Use -Unassign to remove the assignee."
                 }
                 $true
             }
@@ -136,15 +136,7 @@
 
         if ($validAssignee) {
             Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] Updating Assignee"
-            if (($assigneeObj) -and ($assigneeObj.AccountId) -and ($isCloud)) {
-                $assigneeBody = @{ 'accountId' = $assigneeObj.AccountId }
-            }
-            elseif ($assigneeObj) {
-                $assigneeBody = @{ 'name' = $assigneeObj.Name }
-            }
-            else {
-                $assigneeBody = @{ 'name' = $assigneeString }
-            }
+            $assigneeBody = Resolve-JiraAssigneePayload -AssigneeObject $assigneeObj -AssigneeString $assigneeString -IsCloud $isCloud
             $requestBody += @{
                 'fields' = @{
                     'assignee' = $assigneeBody

--- a/JiraPS/Public/Invoke-JiraIssueTransition.ps1
+++ b/JiraPS/Public/Invoke-JiraIssueTransition.ps1
@@ -99,13 +99,9 @@
             }
         }
 
-        if ($Assignee) {
-            if ($Assignee -eq 'Unassigned') {
-                <#
-                  #ToDo:Deprecated
-                  This behavior should be deprecated
-                #>
-                Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] 'Unassigned' String passed. Issue will be assigned to no one."
+        if ($PSCmdlet.MyInvocation.BoundParameters.ContainsKey("Assignee")) {
+            if ($null -eq $Assignee) {
+                Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] `$null passed. Issue will be unassigned."
                 $assigneeString = ""
                 $validAssignee = $true
             }

--- a/JiraPS/Public/Invoke-JiraIssueTransition.ps1
+++ b/JiraPS/Public/Invoke-JiraIssueTransition.ps1
@@ -67,6 +67,32 @@
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
         $isCloud = Test-JiraCloudServer -Credential $Credential
+
+        # Resolve the assignee once; -Assignee / -Unassign do not vary across piped issues.
+        if ($Unassign) {
+            Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] -Unassign passed. Issue will be unassigned."
+            $assigneeString = $null
+            $validAssignee = $true
+        }
+        elseif ($PSCmdlet.MyInvocation.BoundParameters.ContainsKey("Assignee")) {
+            if ($assigneeObj = Resolve-JiraUser -InputObject $Assignee -Credential $Credential -Exact) {
+                Write-Debug "[$($MyInvocation.MyCommand.Name)] User found (name=[$($assigneeObj.Name)],RestUrl=[$($assigneeObj.RestUrl)])"
+                $validAssignee = $true
+            }
+            else {
+                $exception = ([System.ArgumentException]"Invalid value for Parameter")
+                $errorId = 'ParameterValue.InvalidAssignee'
+                $errorCategory = 'InvalidArgument'
+                $errorTarget = $Assignee
+                $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
+                $errorItem.ErrorDetails = "Unable to validate Jira user [$Assignee]. Use Get-JiraUser for more details."
+                $PSCmdlet.ThrowTerminatingError($errorItem)
+            }
+        }
+
+        if ($validAssignee) {
+            $assigneeBody = Resolve-JiraAssigneePayload -AssigneeObject $assigneeObj -AssigneeString $assigneeString -IsCloud $isCloud
+        }
     }
 
     process {
@@ -90,7 +116,7 @@
                 $errorId = 'ParameterType.NotJiraTransition'
                 $errorCategory = 'InvalidArgument'
                 $errorTarget = $Transition
-                $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTargetError
+                $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
                 $errorItem.ErrorDetails = "Wrong object type provided for Transition. Expected [JiraPS.Transition] or [Int], but was $($Transition.GetType().Name)"
                 $PSCmdlet.ThrowTerminatingError($errorItem)
             }
@@ -113,30 +139,8 @@
             }
         }
 
-        if ($Unassign) {
-            Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] -Unassign passed. Issue will be unassigned."
-            $assigneeString = ""
-            $validAssignee = $true
-        }
-        elseif ($PSCmdlet.MyInvocation.BoundParameters.ContainsKey("Assignee")) {
-            if ($assigneeObj = Resolve-JiraUser -InputObject $Assignee -Credential $Credential -Exact) {
-                Write-Debug "[$($MyInvocation.MyCommand.Name)] User found (name=[$($assigneeObj.Name)],RestUrl=[$($assigneeObj.RestUrl)])"
-                $validAssignee = $true
-            }
-            else {
-                $exception = ([System.ArgumentException]"Invalid value for Parameter")
-                $errorId = 'ParameterValue.InvalidAssignee'
-                $errorCategory = 'InvalidArgument'
-                $errorTarget = $Assignee
-                $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
-                $errorItem.ErrorDetails = "Unable to validate Jira user [$Assignee]. Use Get-JiraUser for more details."
-                $PSCmdlet.ThrowTerminatingError($errorItem)
-            }
-        }
-
         if ($validAssignee) {
             Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] Updating Assignee"
-            $assigneeBody = Resolve-JiraAssigneePayload -AssigneeObject $assigneeObj -AssigneeString $assigneeString -IsCloud $isCloud
             $requestBody += @{
                 'fields' = @{
                     'assignee' = $assigneeBody

--- a/JiraPS/Public/New-JiraIssue.ps1
+++ b/JiraPS/Public/New-JiraIssue.ps1
@@ -114,24 +114,18 @@
         }
 
         if ($Label) {
-            $requestBody["labels"] = [System.Collections.ArrayList]@()
-            foreach ($item in $Label) {
-                $null = $requestBody["labels"].Add($item)
-            }
+            $requestBody["labels"] = [System.Collections.Generic.List[string]]::new()
+            $Label.ForEach({ $null = $requestBody["labels"].Add($_) })
         }
 
         if ($Components) {
-            $requestBody["components"] = [System.Collections.ArrayList]@()
-            foreach ($item in $Components) {
-                $null = $requestBody["components"].Add( @{ id = "$item" } )
-            }
+            $requestBody["components"] = [System.Collections.Generic.List[hashtable]]::new()
+            $Components.ForEach({ $null = $requestBody["components"].Add(@{ id = "$_" }) })
         }
 
         if ($FixVersion) {
-            $requestBody['fixVersions'] = [System.Collections.ArrayList]@()
-            foreach ($item in $FixVersion) {
-                $null = $requestBody["fixVersions"].Add( @{ name = "$item" } )
-            }
+            $requestBody['fixVersions'] = [System.Collections.Generic.List[hashtable]]::new()
+            $FixVersion.ForEach({ $null = $requestBody["fixVersions"].Add(@{ name = "$_" }) })
         }
 
         if ($Fields) {

--- a/JiraPS/Public/Remove-JiraIssueLink.ps1
+++ b/JiraPS/Public/Remove-JiraIssueLink.ps1
@@ -7,10 +7,10 @@
         [ValidateScript(
             {
                 $_input = $_
-                $objectProperties = $_input | Get-Member -MemberType *Property
+                $propertyNames = $_input.PSObject.Properties.Name
                 switch ($true) {
-                    { ("JiraPS.Issue" -in $_input.PSObject.TypeNames) -and ("issueLinks" -in $objectProperties.Name) } { return $true }
-                    { ("JiraPS.IssueLink" -in $_input.PSObject.TypeNames) -and ("Id" -in $objectProperties.Name) } { return $true }
+                    { ("JiraPS.Issue" -in $_input.PSObject.TypeNames) -and ("issueLinks" -in $propertyNames) } { return $true }
+                    { ("JiraPS.IssueLink" -in $_input.PSObject.TypeNames) -and ("Id" -in $propertyNames) } { return $true }
                     default {
                         $exception = ([System.ArgumentException]"Invalid Type for Parameter") #fix code highlighting]
                         $errorId = 'ParameterType.NotJiraIssue'

--- a/JiraPS/Public/Set-JiraIssue.ps1
+++ b/JiraPS/Public/Set-JiraIssue.ps1
@@ -39,11 +39,11 @@
         $FixVersion,
 
         [Parameter( ParameterSetName = 'AssignToUser' )]
-        [ValidateNotNull()]
+        [ValidateNotNullOrEmpty()]
         [ValidateScript(
             {
                 if ($_ -is [string] -and [string]::IsNullOrWhiteSpace($_)) {
-                    throw "The -Assignee value cannot be an empty or whitespace string. Use -Unassign to remove the assignee, or -UseDefaultAssignee for the project default."
+                    throw "The -Assignee value cannot be a whitespace-only string. Use -Unassign to remove the assignee, or -UseDefaultAssignee for the project default."
                 }
                 $true
             }
@@ -225,26 +225,7 @@
             }
 
             if ($validAssignee) {
-                if (($assigneeObj) -and ($assigneeObj.AccountId) -and ($isCloud)) {
-                    $assigneeProps = @{
-                        'accountId' = $assigneeObj.AccountId
-                    }
-                }
-                elseif ($isCloud -and -not $assigneeObj) {
-                    $assigneeProps = @{
-                        'accountId' = $null
-                    }
-                }
-                elseif ($assigneeString) {
-                    $assigneeProps = @{
-                        'name' = $assigneeString
-                    }
-                }
-                else {
-                    $assigneeProps = @{
-                        'name' = if ($assigneeObj) { $assigneeObj.Name } else { $null }
-                    }
-                }
+                $assigneeProps = Resolve-JiraAssigneePayload -AssigneeObject $assigneeObj -AssigneeString $assigneeString -IsCloud $isCloud
             }
 
             $SkipNotificationParams = @{}

--- a/JiraPS/Public/Set-JiraIssue.ps1
+++ b/JiraPS/Public/Set-JiraIssue.ps1
@@ -123,6 +123,11 @@
                 $PSCmdlet.ThrowTerminatingError($errorItem)
             }
         }
+
+        # Build the assignee payload once; inputs do not vary across piped issues.
+        if ($validAssignee) {
+            $assigneeProps = Resolve-JiraAssigneePayload -AssigneeObject $assigneeObj -AssigneeString $assigneeString -IsCloud $isCloud
+        }
     }
 
     process {
@@ -222,10 +227,6 @@
                     $id = [string]$field.Id
                     $issueProps.update[$id] = @(@{ 'set' = $value })
                 }
-            }
-
-            if ($validAssignee) {
-                $assigneeProps = Resolve-JiraAssigneePayload -AssigneeObject $assigneeObj -AssigneeString $assigneeString -IsCloud $isCloud
             }
 
             $SkipNotificationParams = @{}

--- a/JiraPS/Public/Set-JiraIssue.ps1
+++ b/JiraPS/Public/Set-JiraIssue.ps1
@@ -72,7 +72,8 @@
         $isCloud = Test-JiraCloudServer -Credential $Credential
 
         $fieldNames = $Fields.Keys
-        if (-not ($Summary -or $Description -or $Assignee -or $UseDefaultAssignee -or $Label -or $FixVersion -or $fieldNames -or $AddComment)) {
+        $assigneeProvided = $PSCmdlet.MyInvocation.BoundParameters.ContainsKey("Assignee")
+        if (-not ($Summary -or $Description -or $assigneeProvided -or $UseDefaultAssignee -or $Label -or $FixVersion -or $fieldNames -or $AddComment)) {
             $errorMessage = @{
                 Category         = "InvalidArgument"
                 CategoryActivity = "Validating Arguments"

--- a/JiraPS/Public/Set-JiraIssue.ps1
+++ b/JiraPS/Public/Set-JiraIssue.ps1
@@ -80,12 +80,8 @@
         }
 
         if ($PSCmdlet.MyInvocation.BoundParameters.ContainsKey("Assignee")) {
-            if ($Assignee -eq 'Unassigned') {
-                <#
-                  #ToDo:Deprecated
-                  This behavior should be deprecated
-                #>
-                Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] 'Unassigned' String passed. Issue will be assigned to no one."
+            if ($null -eq $Assignee) {
+                Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] `$null passed. Issue will be unassigned."
                 $assigneeString = $null
                 $validAssignee = $true
             }

--- a/JiraPS/Public/Set-JiraIssue.ps1
+++ b/JiraPS/Public/Set-JiraIssue.ps1
@@ -60,7 +60,10 @@
         $PassThru,
 
         [Switch]
-        $SkipNotification
+        $SkipNotification,
+
+        [Switch]
+        $UseDefaultAssignee
     )
 
     begin {
@@ -69,7 +72,7 @@
         $isCloud = Test-JiraCloudServer -Credential $Credential
 
         $fieldNames = $Fields.Keys
-        if (-not ($Summary -or $Description -or $Assignee -or $Label -or $FixVersion -or $fieldNames -or $AddComment)) {
+        if (-not ($Summary -or $Description -or $Assignee -or $UseDefaultAssignee -or $Label -or $FixVersion -or $fieldNames -or $AddComment)) {
             $errorMessage = @{
                 Category         = "InvalidArgument"
                 CategoryActivity = "Validating Arguments"
@@ -79,19 +82,15 @@
             return
         }
 
-        if ($PSCmdlet.MyInvocation.BoundParameters.ContainsKey("Assignee")) {
+        if ($UseDefaultAssignee) {
+            Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] -UseDefaultAssignee passed. Issue will be assigned to the default assignee."
+            $assigneeString = "-1"
+            $validAssignee = $true
+        }
+        elseif ($PSCmdlet.MyInvocation.BoundParameters.ContainsKey("Assignee")) {
             if ($null -eq $Assignee) {
                 Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] `$null passed. Issue will be unassigned."
                 $assigneeString = $null
-                $validAssignee = $true
-            }
-            elseif ($Assignee -eq "Default") {
-                <#
-                  #ToDo:Deprecated
-                  This behavior should be deprecated
-                #>
-                Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] 'Default' String passed. Issue will be assigned to the default assignee."
-                $assigneeString = "-1"
                 $validAssignee = $true
             }
             else {

--- a/JiraPS/Public/Set-JiraIssue.ps1
+++ b/JiraPS/Public/Set-JiraIssue.ps1
@@ -1,6 +1,6 @@
 ﻿function Set-JiraIssue {
     # .ExternalHelp ..\JiraPS-help.xml
-    [CmdletBinding( SupportsShouldProcess )]
+    [CmdletBinding( SupportsShouldProcess, DefaultParameterSetName = 'AssignToUser' )]
     param(
         [Parameter( Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName )]
         [ValidateNotNullOrEmpty()]
@@ -38,8 +38,26 @@
         [String[]]
         $FixVersion,
 
+        [Parameter( ParameterSetName = 'AssignToUser' )]
+        [ValidateNotNull()]
+        [ValidateScript(
+            {
+                if ($_ -is [string] -and [string]::IsNullOrWhiteSpace($_)) {
+                    throw "The -Assignee value cannot be an empty or whitespace string. Use -Unassign to remove the assignee, or -UseDefaultAssignee for the project default."
+                }
+                $true
+            }
+        )]
         [Object]
         $Assignee,
+
+        [Parameter( ParameterSetName = 'Unassign' )]
+        [Switch]
+        $Unassign,
+
+        [Parameter( ParameterSetName = 'UseDefaultAssignee' )]
+        [Switch]
+        $UseDefaultAssignee,
 
         [Alias("Labels")]
         [String[]]
@@ -60,10 +78,7 @@
         $PassThru,
 
         [Switch]
-        $SkipNotification,
-
-        [Switch]
-        $UseDefaultAssignee
+        $SkipNotification
     )
 
     begin {
@@ -73,7 +88,7 @@
 
         $fieldNames = $Fields.Keys
         $assigneeProvided = $PSCmdlet.MyInvocation.BoundParameters.ContainsKey("Assignee")
-        if (-not ($Summary -or $Description -or $assigneeProvided -or $UseDefaultAssignee -or $Label -or $FixVersion -or $fieldNames -or $AddComment)) {
+        if (-not ($Summary -or $Description -or $assigneeProvided -or $Unassign -or $UseDefaultAssignee -or $Label -or $FixVersion -or $fieldNames -or $AddComment)) {
             $errorMessage = @{
                 Category         = "InvalidArgument"
                 CategoryActivity = "Validating Arguments"
@@ -88,26 +103,24 @@
             $assigneeString = "-1"
             $validAssignee = $true
         }
-        elseif ($PSCmdlet.MyInvocation.BoundParameters.ContainsKey("Assignee")) {
-            if ($null -eq $Assignee) {
-                Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] `$null passed. Issue will be unassigned."
-                $assigneeString = $null
+        elseif ($Unassign) {
+            Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] -Unassign passed. Issue will be unassigned."
+            $assigneeString = $null
+            $validAssignee = $true
+        }
+        elseif ($assigneeProvided) {
+            if ($assigneeObj = Resolve-JiraUser -InputObject $Assignee -Exact -Credential $Credential) {
+                Write-Debug "[$($MyInvocation.MyCommand.Name)] User found (name=[$($assigneeObj.Name)],RestUrl=[$($assigneeObj.RestUrl)])"
                 $validAssignee = $true
             }
             else {
-                if ($assigneeObj = Resolve-JiraUser -InputObject $Assignee -Exact -Credential $Credential) {
-                    Write-Debug "[$($MyInvocation.MyCommand.Name)] User found (name=[$($assigneeObj.Name)],RestUrl=[$($assigneeObj.RestUrl)])"
-                    $validAssignee = $true
-                }
-                else {
-                    $exception = ([System.ArgumentException]"Invalid value for Parameter")
-                    $errorId = 'ParameterValue.InvalidAssignee'
-                    $errorCategory = 'InvalidArgument'
-                    $errorTarget = $Assignee
-                    $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
-                    $errorItem.ErrorDetails = "Unable to validate Jira user [$Assignee]. Use Get-JiraUser for more details."
-                    $PSCmdlet.ThrowTerminatingError($errorItem)
-                }
+                $exception = ([System.ArgumentException]"Invalid value for Parameter")
+                $errorId = 'ParameterValue.InvalidAssignee'
+                $errorCategory = 'InvalidArgument'
+                $errorTarget = $Assignee
+                $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
+                $errorItem.ErrorDetails = "Unable to validate Jira user [$Assignee]. Use Get-JiraUser for more details."
+                $PSCmdlet.ThrowTerminatingError($errorItem)
             }
         }
     }

--- a/JiraPS/Public/Set-JiraIssue.ps1
+++ b/JiraPS/Public/Set-JiraIssue.ps1
@@ -136,10 +136,8 @@
             }
 
             if ($FixVersion) {
-                $fixVersionSet = [System.Collections.ArrayList]@()
-                foreach ($item in $FixVersion) {
-                    $null = $fixVersionSet.Add( @{ 'name' = $item } )
-                }
+                $fixVersionSet = [System.Collections.Generic.List[hashtable]]::new()
+                $FixVersion.ForEach({ $null = $fixVersionSet.Add(@{ 'name' = $_ }) })
                 $issueProps.update["fixVersions"] = @( @{ set = $fixVersionSet } )
             }
 

--- a/JiraPS/Public/Set-JiraIssueLabel.ps1
+++ b/JiraPS/Public/Set-JiraIssueLabel.ps1
@@ -92,16 +92,12 @@
                 'ModifyLabels' {
                     if ($Add) {
                         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] Adding labels"
-                        # [List[T]].Add() returns void; the $null = assignment is
-                        # defensive (matches the pattern used in New-JiraIssue and
-                        # Set-JiraIssue, and protects against future API drift).
                         $Add.ForEach({ $null = $labels.Add($_) })
                     }
                     if ($Remove) {
                         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] Removing labels"
-                        # [List[T]].Remove() returns bool; without $null = the
-                        # boolean is propagated by .ForEach() and pollutes the
-                        # cmdlet's output stream.
+                        # [List[T]].Remove() returns a bool that .ForEach() would
+                        # otherwise propagate to the cmdlet's output stream.
                         $Remove.ForEach({ $null = $labels.Remove($_) })
                     }
                 }

--- a/JiraPS/Public/Set-JiraIssueLabel.ps1
+++ b/JiraPS/Public/Set-JiraIssueLabel.ps1
@@ -69,8 +69,9 @@
             # Find the proper object for the Issue
             $issueObj = Resolve-JiraIssueObject -InputObject $_issue -Credential $Credential
 
-            $labels = [System.Collections.Generic.List[string]]::new()
-            ($issueObj.labels | Where-Object { $_ }).ForEach({ $labels.Add($_) })
+            $labels = [System.Collections.Generic.List[string]]::new(
+                [string[]]@($issueObj.labels | Where-Object { $_ })
+            )
 
             # As of JIRA 6.4, the Add and Remove verbs in the REST API for
             # updating issues do not support arrays of parameters - you

--- a/JiraPS/Public/Set-JiraIssueLabel.ps1
+++ b/JiraPS/Public/Set-JiraIssueLabel.ps1
@@ -69,7 +69,8 @@
             # Find the proper object for the Issue
             $issueObj = Resolve-JiraIssueObject -InputObject $_issue -Credential $Credential
 
-            $labels = [System.Collections.ArrayList]@($issueObj.labels | Where-Object { $_ })
+            $labels = [System.Collections.Generic.List[string]]::new()
+            ($issueObj.labels | Where-Object { $_ }).ForEach({ $labels.Add($_) })
 
             # As of JIRA 6.4, the Add and Remove verbs in the REST API for
             # updating issues do not support arrays of parameters - you
@@ -81,22 +82,26 @@
             switch ($PSCmdlet.ParameterSetName) {
                 'ClearLabels' {
                     Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] Clearing all labels"
-                    $labels = [System.Collections.ArrayList]@()
+                    $labels.Clear()
                 }
                 'ReplaceLabels' {
                     Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] Replacing existing labels"
-                    $labels = [System.Collections.ArrayList]$Set
+                    $labels = [System.Collections.Generic.List[string]]::new([string[]]$Set)
                 }
                 'ModifyLabels' {
                     if ($Add) {
                         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] Adding labels"
-                        $null = foreach ($_add in $Add) { $labels.Add($_add) }
+                        # [List[T]].Add() returns void; the $null = assignment is
+                        # defensive (matches the pattern used in New-JiraIssue and
+                        # Set-JiraIssue, and protects against future API drift).
+                        $Add.ForEach({ $null = $labels.Add($_) })
                     }
                     if ($Remove) {
                         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] Removing labels"
-                        foreach ($item in $Remove) {
-                            $labels.Remove($item)
-                        }
+                        # [List[T]].Remove() returns bool; without $null = the
+                        # boolean is propagated by .ForEach() and pollutes the
+                        # cmdlet's output stream.
+                        $Remove.ForEach({ $null = $labels.Remove($_) })
                     }
                 }
             }

--- a/Tests/Functions/Private/Resolve-JiraAssigneePayload.Unit.Tests.ps1
+++ b/Tests/Functions/Private/Resolve-JiraAssigneePayload.Unit.Tests.ps1
@@ -67,13 +67,14 @@ InModuleScope JiraPS {
                 $result.name | Should -Be 'alice'
             }
 
-            It "returns name:`$null when unassigning with `$null AssigneeString (Set-JiraIssue convention)" {
+            It "returns name:`$null when unassigning with `$null AssigneeString" {
                 $result = Resolve-JiraAssigneePayload -AssigneeObject $null -AssigneeString $null -IsCloud $false
                 $result.ContainsKey('name') | Should -BeTrue
                 $result.name | Should -BeNullOrEmpty
             }
 
-            It "returns name:'' when unassigning with empty AssigneeString (Invoke-JiraIssueTransition convention)" {
+            It "returns name:'' when unassigning with empty AssigneeString" {
+                # Distinct from $null so callers can opt into either JSON shape.
                 $result = Resolve-JiraAssigneePayload -AssigneeObject $null -AssigneeString '' -IsCloud $false
                 $result.ContainsKey('name') | Should -BeTrue
                 $result.name | Should -Be ''

--- a/Tests/Functions/Private/Resolve-JiraAssigneePayload.Unit.Tests.ps1
+++ b/Tests/Functions/Private/Resolve-JiraAssigneePayload.Unit.Tests.ps1
@@ -1,0 +1,93 @@
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+
+BeforeDiscovery {
+    . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+
+    Initialize-TestEnvironment
+    $script:moduleToTest = Resolve-ModuleSource
+
+    Import-Module $script:moduleToTest -Force -ErrorAction Stop
+}
+
+InModuleScope JiraPS {
+    Describe "Resolve-JiraAssigneePayload" -Tag 'Unit' {
+
+        BeforeAll {
+            $script:serverUser = [PSCustomObject]@{ Name = 'alice' }
+            $script:cloudUser = [PSCustomObject]@{ Name = 'alice'; AccountId = '5b10a2844c20165700ede21a' }
+        }
+
+        Context "Jira Cloud" {
+            It "returns accountId when a Cloud user is provided" {
+                $result = Resolve-JiraAssigneePayload -AssigneeObject $cloudUser -IsCloud $true
+                $result.Keys | Should -HaveCount 1
+                $result.accountId | Should -Be '5b10a2844c20165700ede21a'
+            }
+
+            It "returns accountId:`$null when unassigning (no user)" {
+                $result = Resolve-JiraAssigneePayload -AssigneeObject $null -IsCloud $true
+                $result.Keys | Should -HaveCount 1
+                $result.ContainsKey('accountId') | Should -BeTrue
+                $result.accountId | Should -BeNullOrEmpty
+            }
+
+            It "returns accountId:`$null even when a default ('-1') string is passed" {
+                # Cloud does not support the project-default mechanic via 'name: -1';
+                # falling through to accountId:null is the safe, predictable behavior.
+                $result = Resolve-JiraAssigneePayload -AssigneeObject $null -AssigneeString '-1' -IsCloud $true
+                $result.ContainsKey('accountId') | Should -BeTrue
+                $result.accountId | Should -BeNullOrEmpty
+            }
+
+            It "ignores AssigneeString when a user is provided on Cloud" {
+                $result = Resolve-JiraAssigneePayload -AssigneeObject $cloudUser -AssigneeString 'should-be-ignored' -IsCloud $true
+                $result.accountId | Should -Be '5b10a2844c20165700ede21a'
+                $result.ContainsKey('name') | Should -BeFalse
+            }
+
+            It "throws when the Cloud user object has a `$null AccountId" {
+                # Guard against silent unassign caused by a partial / mis-resolved
+                # user object — the caller's intent here is to assign, not clear.
+                $brokenUser = [PSCustomObject]@{ Name = 'alice'; AccountId = $null }
+                { Resolve-JiraAssigneePayload -AssigneeObject $brokenUser -IsCloud $true } |
+                    Should -Throw -ExpectedMessage "*no AccountId*"
+            }
+
+            It "throws when the Cloud user object has an empty AccountId" {
+                $brokenUser = [PSCustomObject]@{ Name = 'alice'; AccountId = '' }
+                { Resolve-JiraAssigneePayload -AssigneeObject $brokenUser -IsCloud $true } |
+                    Should -Throw -ExpectedMessage "*no AccountId*"
+            }
+        }
+
+        Context "Jira Server / Data Center" {
+            It "returns the user's Name when a user is provided" {
+                $result = Resolve-JiraAssigneePayload -AssigneeObject $serverUser -IsCloud $false
+                $result.Keys | Should -HaveCount 1
+                $result.name | Should -Be 'alice'
+            }
+
+            It "returns name:`$null when unassigning with `$null AssigneeString (Set-JiraIssue convention)" {
+                $result = Resolve-JiraAssigneePayload -AssigneeObject $null -AssigneeString $null -IsCloud $false
+                $result.ContainsKey('name') | Should -BeTrue
+                $result.name | Should -BeNullOrEmpty
+            }
+
+            It "returns name:'' when unassigning with empty AssigneeString (Invoke-JiraIssueTransition convention)" {
+                $result = Resolve-JiraAssigneePayload -AssigneeObject $null -AssigneeString '' -IsCloud $false
+                $result.ContainsKey('name') | Should -BeTrue
+                $result.name | Should -Be ''
+            }
+
+            It "returns name:'-1' when requesting the project default" {
+                $result = Resolve-JiraAssigneePayload -AssigneeObject $null -AssigneeString '-1' -IsCloud $false
+                $result.name | Should -Be '-1'
+            }
+
+            It "prefers the user object over AssigneeString when both are provided" {
+                $result = Resolve-JiraAssigneePayload -AssigneeObject $serverUser -AssigneeString '-1' -IsCloud $false
+                $result.name | Should -Be 'alice'
+            }
+        }
+    }
+}

--- a/Tests/Functions/Public/Get-JiraGroupMember.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraGroupMember.Unit.Tests.ps1
@@ -83,8 +83,8 @@ InModuleScope JiraPS {
                 } -Exactly 1
             }
 
-            It "Supports the -StartIndex parameters to page through search results" {
-                { Get-JiraGroupMember -Group testgroup -StartIndex 10 } | Should -Not -Throw
+            It "Supports the -Skip parameter to page through search results" {
+                { Get-JiraGroupMember -Group testgroup -Skip 10 } | Should -Not -Throw
 
                 Should -Invoke Invoke-JiraMethod -ModuleName 'JiraPS' -ParameterFilter {
                     $Method -eq 'Get' -and
@@ -93,8 +93,8 @@ InModuleScope JiraPS {
                 } -Exactly 1
             }
 
-            It "Supports the -MaxResults parameters to page through search results" {
-                { Get-JiraGroupMember -Group testgroup -MaxResults 50 } | Should -Not -Throw
+            It "Supports the -First parameter to limit search results" {
+                { Get-JiraGroupMember -Group testgroup -First 50 } | Should -Not -Throw
 
                 Should -Invoke Invoke-JiraMethod -ModuleName 'JiraPS' -ParameterFilter {
                     $Method -eq 'Get' -and

--- a/Tests/Functions/Public/Get-JiraIssue.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraIssue.Unit.Tests.ps1
@@ -124,15 +124,15 @@ InModuleScope JiraPS {
                     }
                 }
 
-                It "Supports the -StartIndex and -MaxResults parameters to page through search results" {
-                    { Get-JiraIssue -Query $jql -StartIndex 10 -MaxResults 50 } | Should -Not -Throw
+                It "Supports the -Skip and -First paging parameters to page through search results" {
+                    { Get-JiraIssue -Query $jql -Skip 10 -First 50 } | Should -Not -Throw
 
                     Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -ParameterFilter {
                         $Method -eq 'Get' -and
                         $URI -like "*/rest/api/*/search" -and
                         $GetParameter["jql"] -eq $jqlEscaped -and
-                        $PSCmdlet.PagingParameters.Skip -eq 10
-                        $PSCmdlet.PagingParameters.First -eq 50
+                        $Skip -eq 10 -and
+                        $First -eq 50
                     }
                 }
 

--- a/Tests/Functions/Public/Invoke-JiraIssueTransition.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Invoke-JiraIssueTransition.Unit.Tests.ps1
@@ -93,6 +93,7 @@ InModuleScope JiraPS {
                     @{ parameter = "Transition"; type = "Object" }
                     @{ parameter = "Comment"; type = "String" }
                     @{ parameter = "Assignee"; type = "String" }
+                    @{ parameter = "Unassign"; type = "Switch" }
                     @{ parameter = "Fields"; type = "Hashtable" }
                     @{ parameter = "Passthru"; type = "Switch" }
                     @{ parameter = "Credential"; type = "System.Management.Automation.PSCredential" }
@@ -107,6 +108,30 @@ InModuleScope JiraPS {
                     @{ parameter = "Transition" }
                 ) {
                     $command | Should -HaveParameter $parameter -Mandatory
+                }
+            }
+
+            Context "Parameter Sets" {
+                It "defines parameter set '<setName>'" -TestCases @(
+                    @{ setName = 'AssignToUser' }
+                    @{ setName = 'Unassign' }
+                ) {
+                    param($setName)
+                    $command.ParameterSets.Name | Should -Contain $setName
+                }
+
+                It "uses 'AssignToUser' as the default parameter set" {
+                    $command.DefaultParameterSet | Should -Be 'AssignToUser'
+                }
+
+                It "binds '<parameter>' only to parameter set '<setName>'" -TestCases @(
+                    @{ parameter = 'Assignee'; setName = 'AssignToUser' }
+                    @{ parameter = 'Unassign'; setName = 'Unassign' }
+                ) {
+                    param($parameter, $setName)
+                    $sets = $command.Parameters.Item($parameter).ParameterSets.Keys
+                    $sets | Should -HaveCount 1
+                    $sets | Should -Contain $setName
                 }
             }
         }
@@ -188,6 +213,14 @@ InModuleScope JiraPS {
                     { Invoke-JiraIssueTransition -Issue $issueKey -Transition 11 -Assignee "" } | Should -Throw -ExpectedMessage "*empty or whitespace string*"
                 }
 
+                It "throws when -Assignee is given a whitespace-only string" {
+                    { Invoke-JiraIssueTransition -Issue $issueKey -Transition 11 -Assignee "   " } | Should -Throw -ExpectedMessage "*empty or whitespace string*"
+                }
+
+                It "throws when -Assignee is given `$null" {
+                    { Invoke-JiraIssueTransition -Issue $issueKey -Transition 11 -Assignee $null } | Should -Throw
+                }
+
                 It "throws when both -Unassign and -Assignee are given" {
                     { Invoke-JiraIssueTransition -Issue $issueKey -Transition 11 -Assignee "powershell-user" -Unassign } | Should -Throw
                 }
@@ -258,6 +291,16 @@ InModuleScope JiraPS {
                     $Method -eq 'Post' -and
                     $URI -like "*/rest/api/2/issue/$issueID/transitions" -and
                     $Body -like "*accountId*$testAccountId*"
+                }
+            }
+
+            It "Sends an empty assignee name when -Unassign on Cloud deployment" {
+                { Invoke-JiraIssueTransition -Issue $issueKey -Transition 11 -Unassign } | Should -Not -Throw
+
+                Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Times 1 -ParameterFilter {
+                    $Method -eq 'Post' -and
+                    $URI -like "*/rest/api/2/issue/$issueID/transitions" -and
+                    $Body -like '*name*""*'
                 }
             }
         }

--- a/Tests/Functions/Public/Invoke-JiraIssueTransition.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Invoke-JiraIssueTransition.Unit.Tests.ps1
@@ -205,7 +205,7 @@ InModuleScope JiraPS {
                     Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Times 1 -ParameterFilter {
                         $Method -eq 'Post' -and
                         $URI -like "*/rest/api/2/issue/$issueID/transitions" -and
-                        $Body -like '*name*""*'
+                        $Body -match '"name":\s*null'
                     }
                 }
 

--- a/Tests/Functions/Public/Invoke-JiraIssueTransition.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Invoke-JiraIssueTransition.Unit.Tests.ps1
@@ -174,14 +174,22 @@ InModuleScope JiraPS {
                     }
                 }
 
-                It "unassigns an issue if `$null is passed to the -Assignee parameter" {
-                    { Invoke-JiraIssueTransition -Issue $issueKey -Transition 11 -Assignee $null } | Should -Not -Throw
+                It "unassigns an issue when -Unassign switch is used" {
+                    { Invoke-JiraIssueTransition -Issue $issueKey -Transition 11 -Unassign } | Should -Not -Throw
 
                     Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Times 1 -ParameterFilter {
                         $Method -eq 'Post' -and
                         $URI -like "*/rest/api/2/issue/$issueID/transitions" -and
                         $Body -like '*name*""*'
                     }
+                }
+
+                It "throws when -Assignee is given an empty string" {
+                    { Invoke-JiraIssueTransition -Issue $issueKey -Transition 11 -Assignee "" } | Should -Throw -ExpectedMessage "*empty or whitespace string*"
+                }
+
+                It "throws when both -Unassign and -Assignee are given" {
+                    { Invoke-JiraIssueTransition -Issue $issueKey -Transition 11 -Assignee "powershell-user" -Unassign } | Should -Throw
                 }
 
                 It "adds a comment if provided to the -Comment parameter" {

--- a/Tests/Functions/Public/Invoke-JiraIssueTransition.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Invoke-JiraIssueTransition.Unit.Tests.ps1
@@ -174,8 +174,8 @@ InModuleScope JiraPS {
                     }
                 }
 
-                It "unassigns an issue if 'Unassigned' is passed to the -Assignee parameter" {
-                    { Invoke-JiraIssueTransition -Issue $issueKey -Transition 11 -Assignee 'Unassigned' } | Should -Not -Throw
+                It "unassigns an issue if `$null is passed to the -Assignee parameter" {
+                    { Invoke-JiraIssueTransition -Issue $issueKey -Transition 11 -Assignee $null } | Should -Not -Throw
 
                     Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Times 1 -ParameterFilter {
                         $Method -eq 'Post' -and

--- a/Tests/Functions/Public/Invoke-JiraIssueTransition.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Invoke-JiraIssueTransition.Unit.Tests.ps1
@@ -210,11 +210,11 @@ InModuleScope JiraPS {
                 }
 
                 It "throws when -Assignee is given an empty string" {
-                    { Invoke-JiraIssueTransition -Issue $issueKey -Transition 11 -Assignee "" } | Should -Throw -ExpectedMessage "*empty or whitespace string*"
+                    { Invoke-JiraIssueTransition -Issue $issueKey -Transition 11 -Assignee "" } | Should -Throw
                 }
 
                 It "throws when -Assignee is given a whitespace-only string" {
-                    { Invoke-JiraIssueTransition -Issue $issueKey -Transition 11 -Assignee "   " } | Should -Throw -ExpectedMessage "*empty or whitespace string*"
+                    { Invoke-JiraIssueTransition -Issue $issueKey -Transition 11 -Assignee "   " } | Should -Throw -ExpectedMessage "*whitespace-only*"
                 }
 
                 It "throws when -Assignee is given `$null" {
@@ -294,13 +294,13 @@ InModuleScope JiraPS {
                 }
             }
 
-            It "Sends an empty assignee name when -Unassign on Cloud deployment" {
+            It "Sends accountId:null when -Unassign on Cloud deployment" {
                 { Invoke-JiraIssueTransition -Issue $issueKey -Transition 11 -Unassign } | Should -Not -Throw
 
                 Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Times 1 -ParameterFilter {
                     $Method -eq 'Post' -and
                     $URI -like "*/rest/api/2/issue/$issueID/transitions" -and
-                    $Body -like '*name*""*'
+                    $Body -match '"accountId":\s*null'
                 }
             }
         }

--- a/Tests/Functions/Public/Set-JiraIssue.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Set-JiraIssue.Unit.Tests.ps1
@@ -274,11 +274,11 @@ InModuleScope JiraPS {
                 }
 
                 It "Throws when -Assignee is given an empty string" {
-                    { Set-JiraIssue -Issue "IT-3676" -Assignee "" } | Should -Throw -ExpectedMessage "*empty or whitespace string*"
+                    { Set-JiraIssue -Issue "IT-3676" -Assignee "" } | Should -Throw
                 }
 
                 It "Throws when -Assignee is given a whitespace-only string" {
-                    { Set-JiraIssue -Issue "IT-3676" -Assignee "   " } | Should -Throw -ExpectedMessage "*empty or whitespace string*"
+                    { Set-JiraIssue -Issue "IT-3676" -Assignee "   " } | Should -Throw -ExpectedMessage "*whitespace-only*"
                 }
 
                 It "Throws when -Assignee is given `$null" {
@@ -321,6 +321,25 @@ InModuleScope JiraPS {
                     Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -ParameterFilter {
                         $URI -like '*/rest/api/*/issue/41701/assignee' -and
                         $Body -match "`"name`":\s*`"-1`""
+                    }
+                }
+
+                It "Allows -Unassign together with -Fields" {
+                    {
+                        Set-JiraIssue -Issue "IT-3676" -Fields @{ customfield_10001 = 'test' } -Unassign
+                    } | Should -Not -Throw
+
+                    # Assignee call
+                    Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -ParameterFilter {
+                        $URI -like '*/rest/api/*/issue/41701/assignee' -and
+                        $Body -match "`"name`":\s*null"
+                    }
+
+                    # Fields call
+                    Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -ParameterFilter {
+                        $URI -like '*/rest/api/*/issue/41701' -and
+                        $URI -notlike '*/assignee' -and
+                        $Body -match '"customfield_10001"'
                     }
                 }
             }

--- a/Tests/Functions/Public/Set-JiraIssue.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Set-JiraIssue.Unit.Tests.ps1
@@ -212,8 +212,8 @@ InModuleScope JiraPS {
                     }
                 }
 
-                It "Sets the assignee to unassigned when passed `"unassigned`"" {
-                    { Set-JiraIssue -Issue "IT-3676" -Assignee "unassigned" } | Should -Not -Throw
+                It "Unassigns the issue when -Assignee is `$null" {
+                    { Set-JiraIssue -Issue "IT-3676" -Assignee $null } | Should -Not -Throw
 
                     Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -ParameterFilter {
                         $Method -eq 'Put' -and
@@ -222,8 +222,8 @@ InModuleScope JiraPS {
                     }
                 }
 
-                It "Sets the assignee to default assignee when passed `"default`"" {
-                    { Set-JiraIssue -Issue "IT-3676" -Assignee "default" } | Should -Not -Throw
+                It "Sets the assignee to default when -UseDefaultAssignee is specified" {
+                    { Set-JiraIssue -Issue "IT-3676" -UseDefaultAssignee } | Should -Not -Throw
 
                     Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -ParameterFilter {
                         $Method -eq 'Put' -and

--- a/Tests/Functions/Public/Set-JiraIssue.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Set-JiraIssue.Unit.Tests.ps1
@@ -212,8 +212,8 @@ InModuleScope JiraPS {
                     }
                 }
 
-                It "Unassigns the issue when -Assignee is `$null" {
-                    { Set-JiraIssue -Issue "IT-3676" -Assignee $null } | Should -Not -Throw
+                It "Unassigns the issue when -Unassign switch is specified" {
+                    { Set-JiraIssue -Issue "IT-3676" -Unassign } | Should -Not -Throw
 
                     Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -ParameterFilter {
                         $Method -eq 'Put' -and
@@ -230,6 +230,26 @@ InModuleScope JiraPS {
                         $URI -like '*/rest/api/*/issue/41701/assignee' -and
                         $Body -match "`"name`":\s*`"-1`""
                     }
+                }
+
+                It "Throws when -Assignee is given an empty string" {
+                    { Set-JiraIssue -Issue "IT-3676" -Assignee "" } | Should -Throw -ExpectedMessage "*empty or whitespace string*"
+                }
+
+                It "Throws when -Assignee is given `$null" {
+                    { Set-JiraIssue -Issue "IT-3676" -Assignee $null } | Should -Throw
+                }
+
+                It "Throws when both -Unassign and -Assignee are given" {
+                    { Set-JiraIssue -Issue "IT-3676" -Assignee "testUser" -Unassign } | Should -Throw
+                }
+
+                It "Throws when both -UseDefaultAssignee and -Assignee are given" {
+                    { Set-JiraIssue -Issue "IT-3676" -Assignee "testUser" -UseDefaultAssignee } | Should -Throw
+                }
+
+                It "Throws when both -Unassign and -UseDefaultAssignee are given" {
+                    { Set-JiraIssue -Issue "IT-3676" -Unassign -UseDefaultAssignee } | Should -Throw
                 }
             }
 

--- a/Tests/Functions/Public/Set-JiraIssue.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Set-JiraIssue.Unit.Tests.ps1
@@ -137,6 +137,8 @@ InModuleScope JiraPS {
                     @{ parameter = 'Summary'; type = 'String' }
                     @{ parameter = 'Description'; type = 'String' }
                     @{ parameter = 'Assignee'; type = 'Object' }
+                    @{ parameter = 'Unassign'; type = 'Switch' }
+                    @{ parameter = 'UseDefaultAssignee'; type = 'Switch' }
                     @{ parameter = 'Label'; type = 'String[]' }
                     @{ parameter = 'AddComment'; type = 'String' }
                     @{ parameter = 'Fields'; type = 'PSCustomObject' }
@@ -150,6 +152,45 @@ InModuleScope JiraPS {
 
                 It "has an alias 'Key' for parameter 'Issue'" {
                     $command.Parameters.Item('Issue').Aliases | Should -Contain 'Key'
+                }
+            }
+
+            Context "Parameter Sets" {
+                It "defines parameter set '<setName>'" -TestCases @(
+                    @{ setName = 'AssignToUser' }
+                    @{ setName = 'Unassign' }
+                    @{ setName = 'UseDefaultAssignee' }
+                ) {
+                    param($setName)
+                    $command.ParameterSets.Name | Should -Contain $setName
+                }
+
+                It "uses 'AssignToUser' as the default parameter set" {
+                    $command.DefaultParameterSet | Should -Be 'AssignToUser'
+                }
+
+                It "binds '<parameter>' only to parameter set '<setName>'" -TestCases @(
+                    @{ parameter = 'Assignee'; setName = 'AssignToUser' }
+                    @{ parameter = 'Unassign'; setName = 'Unassign' }
+                    @{ parameter = 'UseDefaultAssignee'; setName = 'UseDefaultAssignee' }
+                ) {
+                    param($parameter, $setName)
+                    $sets = $command.Parameters.Item($parameter).ParameterSets.Keys
+                    $sets | Should -HaveCount 1
+                    $sets | Should -Contain $setName
+                }
+
+                It "makes shared parameter '<parameter>' available in all sets" -TestCases @(
+                    @{ parameter = 'Issue' }
+                    @{ parameter = 'Summary' }
+                    @{ parameter = 'Description' }
+                    @{ parameter = 'FixVersion' }
+                    @{ parameter = 'Label' }
+                    @{ parameter = 'Fields' }
+                    @{ parameter = 'AddComment' }
+                ) {
+                    param($parameter)
+                    $command.Parameters.Item($parameter).ParameterSets.Keys | Should -Contain '__AllParameterSets'
                 }
             }
 
@@ -236,6 +277,10 @@ InModuleScope JiraPS {
                     { Set-JiraIssue -Issue "IT-3676" -Assignee "" } | Should -Throw -ExpectedMessage "*empty or whitespace string*"
                 }
 
+                It "Throws when -Assignee is given a whitespace-only string" {
+                    { Set-JiraIssue -Issue "IT-3676" -Assignee "   " } | Should -Throw -ExpectedMessage "*empty or whitespace string*"
+                }
+
                 It "Throws when -Assignee is given `$null" {
                     { Set-JiraIssue -Issue "IT-3676" -Assignee $null } | Should -Throw
                 }
@@ -250,6 +295,33 @@ InModuleScope JiraPS {
 
                 It "Throws when both -Unassign and -UseDefaultAssignee are given" {
                     { Set-JiraIssue -Issue "IT-3676" -Unassign -UseDefaultAssignee } | Should -Throw
+                }
+
+                It "Errors when no modifying parameters are passed" {
+                    { Set-JiraIssue -Issue "IT-3676" -ErrorAction Stop } |
+                        Should -Throw -ExpectedMessage "*do not change the Issue*"
+                }
+
+                It "Allows -Unassign together with other modifying parameters (Summary)" {
+                    { Set-JiraIssue -Issue "IT-3676" -Summary "new summary" -Unassign } | Should -Not -Throw
+
+                    Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -ParameterFilter {
+                        $URI -like '*/rest/api/*/issue/41701/assignee' -and
+                        $Body -match "`"name`":\s*null"
+                    }
+                    Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -ParameterFilter {
+                        $URI -like '*/rest/api/*/issue/41701' -and
+                        $Body -match "`"summary`""
+                    }
+                }
+
+                It "Allows -UseDefaultAssignee together with other modifying parameters (Summary)" {
+                    { Set-JiraIssue -Issue "IT-3676" -Summary "new summary" -UseDefaultAssignee } | Should -Not -Throw
+
+                    Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -ParameterFilter {
+                        $URI -like '*/rest/api/*/issue/41701/assignee' -and
+                        $Body -match "`"name`":\s*`"-1`""
+                    }
                 }
             }
 
@@ -367,6 +439,16 @@ InModuleScope JiraPS {
                     $URI -like '*/rest/api/*/issue/41701/assignee' -and
                     $Body -match "`"accountId`"" -and
                     $Body -match "`"$testAccountId`""
+                }
+            }
+
+            It "Sends accountId:null when -Unassign on Cloud deployment" {
+                { Set-JiraIssue -Issue "IT-3676" -Unassign } | Should -Not -Throw
+
+                Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -ParameterFilter {
+                    $Method -eq 'Put' -and
+                    $URI -like '*/rest/api/*/issue/41701/assignee' -and
+                    $Body -match "`"accountId`":\s*null"
                 }
             }
         }

--- a/Tests/Functions/Public/Set-JiraIssue.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Set-JiraIssue.Unit.Tests.ps1
@@ -329,13 +329,11 @@ InModuleScope JiraPS {
                         Set-JiraIssue -Issue "IT-3676" -Fields @{ customfield_10001 = 'test' } -Unassign
                     } | Should -Not -Throw
 
-                    # Assignee call
                     Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -ParameterFilter {
                         $URI -like '*/rest/api/*/issue/41701/assignee' -and
                         $Body -match "`"name`":\s*null"
                     }
 
-                    # Fields call
                     Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -ParameterFilter {
                         $URI -like '*/rest/api/*/issue/41701' -and
                         $URI -notlike '*/assignee' -and

--- a/Tests/Functions/Public/Set-JiraIssueLabel.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Set-JiraIssueLabel.Unit.Tests.ps1
@@ -115,6 +115,14 @@ InModuleScope JiraPS {
             It "Allows use of both Add and Remove parameters at the same time" {
                 { Set-JiraIssueLabel -Issue TEST-001 -Add 'testLabel1' -Remove 'testLabel2' } | Should -Not -Throw
             }
+
+            It "Does not emit pipeline output when -Add or -Remove are used without -PassThru" {
+                # Regression guard: [List[T]].Remove() returns a bool, and an
+                # un-discarded .ForEach({ ... }) collects those bools and bubbles
+                # them into the cmdlet's output stream as $True / $False values.
+                $output = Set-JiraIssueLabel -Issue TEST-001 -Add 'newLabel' -Remove 'existingLabel1'
+                $output | Should -BeNullOrEmpty
+            }
         }
 
         Describe "Input Validation" {

--- a/docs/en-US/about_JiraPS_MigrationV3.md
+++ b/docs/en-US/about_JiraPS_MigrationV3.md
@@ -1,0 +1,174 @@
+---
+Module Name: JiraPS
+online version: https://atlassianps.org/docs/JiraPS/about/migration-v3.html
+locale: en-US
+layout: documentation
+permalink: /docs/JiraPS/about/migration-v3.html
+hide: true
+---
+# JiraPS
+
+## about_JiraPS_MigrationV3
+
+# SHORT DESCRIPTION
+
+This document describes the breaking changes in JiraPS v3 and how to migrate
+your scripts from v2.x.
+
+# LONG DESCRIPTION
+
+JiraPS v3 removes a number of long-deprecated parameters and "magic string"
+values that have been in the codebase for several major versions. The minimum
+supported PowerShell version was also raised to 5.1, allowing the module to
+adopt newer language features and improve performance.
+
+This guide lists every breaking change introduced in v3 and shows how to
+update your scripts.
+
+## SUMMARY OF BREAKING CHANGES
+
+| Area                                | What Changed                                                                |
+| ----------------------------------- | --------------------------------------------------------------------------- |
+| `Get-JiraIssue`                     | Removed `-StartIndex`, `-MaxResults`. Use `-Skip`, `-First`.                |
+| `Get-JiraGroupMember`               | Removed `-StartIndex`, `-MaxResults`. Use `-Skip`, `-First`.                |
+| `Set-JiraIssue -Assignee`           | No longer accepts `'Unassigned'` or `'Default'` magic strings.              |
+| `Set-JiraIssue -Assignee`           | No longer accepts `$null` or empty string. Use `-Unassign`.                 |
+| `Set-JiraIssue`                     | New `-Unassign` switch (parameter set).                                     |
+| `Set-JiraIssue`                     | `-Assignee`, `-Unassign`, `-UseDefaultAssignee` are mutually exclusive.     |
+| `Invoke-JiraIssueTransition`        | `-Assignee` no longer accepts `'Unassigned'` magic string.                  |
+| `Invoke-JiraIssueTransition`        | `-Assignee` no longer accepts `$null` or empty string. Use `-Unassign`.     |
+| `Invoke-JiraIssueTransition`        | New `-Unassign` switch (parameter set).                                     |
+| Minimum PowerShell version          | Raised from 3.0 to 5.1.                                                     |
+
+## DETAILED MIGRATION GUIDE
+
+### Pagination — `Get-JiraIssue` and `Get-JiraGroupMember`
+
+The legacy parameters `-StartIndex` and `-MaxResults` have been removed in
+favor of the standard PowerShell paging parameters `-Skip` and `-First`,
+which were already supported in v2.
+
+#### v2
+
+```powershell
+Get-JiraIssue -Query 'project = TEST' -StartIndex 10 -MaxResults 50
+Get-JiraGroupMember -Group 'jira-users' -StartIndex 0 -MaxResults 100
+```
+
+#### v3
+
+```powershell
+Get-JiraIssue -Query 'project = TEST' -Skip 10 -First 50
+Get-JiraGroupMember -Group 'jira-users' -First 100
+```
+
+### Unassigning an Issue — `Set-JiraIssue`
+
+The string value `'Unassigned'` is no longer recognised by `-Assignee`. The
+previously informal convention of passing `$null` is also no longer accepted.
+Use the new `-Unassign` switch instead.
+
+#### v2
+
+```powershell
+Set-JiraIssue -Issue TEST-01 -Assignee 'Unassigned'
+Set-JiraIssue -Issue TEST-01 -Assignee $null
+```
+
+#### v3
+
+```powershell
+Set-JiraIssue -Issue TEST-01 -Unassign
+```
+
+### Default Assignee — `Set-JiraIssue`
+
+The string value `'Default'` is no longer recognised by `-Assignee`. Use the
+`-UseDefaultAssignee` switch (introduced as the canonical replacement).
+
+#### v2
+
+```powershell
+Set-JiraIssue -Issue TEST-01 -Assignee 'Default'
+```
+
+#### v3
+
+```powershell
+Set-JiraIssue -Issue TEST-01 -UseDefaultAssignee
+```
+
+### Unassigning during a Transition — `Invoke-JiraIssueTransition`
+
+Same change as `Set-JiraIssue`: the `'Unassigned'` magic string and the
+`$null` convention have been replaced by the explicit `-Unassign` switch.
+
+#### v2
+
+```powershell
+Invoke-JiraIssueTransition -Issue TEST-01 -Transition 11 -Assignee 'Unassigned'
+Invoke-JiraIssueTransition -Issue TEST-01 -Transition 11 -Assignee $null
+```
+
+#### v3
+
+```powershell
+Invoke-JiraIssueTransition -Issue TEST-01 -Transition 11 -Unassign
+```
+
+### Mutual Exclusion of Assignee Operations
+
+In v3 the assignee-related parameters live in distinct parameter sets, so
+PowerShell will refuse to bind more than one of them in the same call. This
+catches mistakes at parse time rather than producing surprising behaviour.
+
+#### Invalid in v3
+
+```powershell
+Set-JiraIssue -Issue TEST-01 -Assignee 'alice' -Unassign            # error
+Set-JiraIssue -Issue TEST-01 -Assignee 'alice' -UseDefaultAssignee  # error
+Set-JiraIssue -Issue TEST-01 -Unassign -UseDefaultAssignee          # error
+```
+
+### Empty / Null Assignee Strings
+
+Previously `Set-JiraIssue -Assignee ""` or `Set-JiraIssue -Assignee $null`
+would silently produce different (and often unintended) effects. In v3 both
+are rejected with a clear error message pointing you to `-Unassign` or
+`-UseDefaultAssignee`.
+
+### Minimum PowerShell Version
+
+JiraPS v3 requires PowerShell 5.1 or later. Windows PowerShell 3.0 and 4.0
+are no longer supported. PowerShell 7+ continues to be fully supported.
+
+## FINDING DEPRECATED USAGE IN YOUR SCRIPTS
+
+The following regular expressions can help locate v2-style usage that needs
+updating:
+
+```powershell
+# Find magic-string assignee usage
+Select-String -Path *.ps1 -Pattern "-Assignee\s+['""](Unassigned|Default)['""]"
+
+# Find $null assignee usage
+Select-String -Path *.ps1 -Pattern "-Assignee\s+\`$null"
+
+# Find legacy paging parameters
+Select-String -Path *.ps1 -Pattern "-(StartIndex|MaxResults)\b"
+```
+
+# SEE ALSO
+
+- [Set-JiraIssue](../commands/Set-JiraIssue/)
+- [Invoke-JiraIssueTransition](../commands/Invoke-JiraIssueTransition/)
+- [Get-JiraIssue](../commands/Get-JiraIssue/)
+- [Get-JiraGroupMember](../commands/Get-JiraGroupMember/)
+- [CHANGELOG](https://github.com/AtlassianPS/JiraPS/blob/master/CHANGELOG.md)
+
+# KEYWORDS
+
+- Migration
+- Breaking Changes
+- v3
+- Upgrade

--- a/docs/en-US/about_JiraPS_MigrationV3.md
+++ b/docs/en-US/about_JiraPS_MigrationV3.md
@@ -1,10 +1,9 @@
 ---
-Module Name: JiraPS
-online version: https://atlassianps.org/docs/JiraPS/about/migration-v3.html
 locale: en-US
 layout: documentation
+online version: https://atlassianps.org/docs/JiraPS/about/migration-v3.html
+Module Name: JiraPS
 permalink: /docs/JiraPS/about/migration-v3.html
-hide: true
 ---
 # JiraPS
 
@@ -36,6 +35,7 @@ This guide lists every breaking change introduced in v3 and shows how to update 
 | `Invoke-JiraIssueTransition` | `-Assignee` no longer accepts `'Unassigned'` magic string.              |
 | `Invoke-JiraIssueTransition` | `-Assignee` no longer accepts `$null` or empty string. Use `-Unassign`. |
 | `Invoke-JiraIssueTransition` | New `-Unassign` switch (parameter set).                                 |
+| `Set-JiraIssue -Assignee`    | No longer positional; must be supplied by name.                         |
 | Minimum PowerShell version   | Raised from 3.0 to 5.1.                                                 |
 
 ## DETAILED MIGRATION GUIDE
@@ -62,9 +62,10 @@ Get-JiraGroupMember -Group 'jira-users' -First 100
 
 ### Unassigning an Issue — `Set-JiraIssue`
 
-The string value `'Unassigned'` is no longer recognised by `-Assignee`.
-The previously informal convention of passing `$null` is also no longer accepted.
-Use the new `-Unassign` switch instead.
+Previously, `'Unassigned'` was a magic string and `$null` was the documented way
+to unassign. Both are removed in favor of the explicit `-Unassign` switch, which
+is more discoverable, symmetric with `-UseDefaultAssignee`, and prevents easy
+mistakes such as passing a variable that is unexpectedly `$null`.
 
 #### v2
 
@@ -130,9 +131,29 @@ Set-JiraIssue -Issue TEST-01 -Unassign -UseDefaultAssignee          # error
 
 ### Empty / Null Assignee Strings
 
-Previously `Set-JiraIssue -Assignee ""` or `Set-JiraIssue -Assignee $null`
-would silently produce different (and often unintended) effects.
-In v3 both are rejected with a clear error message pointing you to `-Unassign` or `-UseDefaultAssignee`.
+`-Assignee ""` and `-Assignee $null` are now rejected at parameter binding
+time. Use `-Unassign` to remove the assignee, or `-UseDefaultAssignee` to
+fall back to the project default.
+
+### `-Assignee` is no longer positional
+
+`-Assignee` used to be available positionally (after `-Issue`, `-Summary`,
+`-Description`, and `-FixVersion`). Because it now belongs to a parameter
+set and the new `-Unassign` / `-UseDefaultAssignee` switches are all named,
+`-Assignee` must also be supplied by name in v3. Scripts that used named
+arguments are unaffected.
+
+#### v2
+
+```powershell
+Set-JiraIssue TEST-01 'new summary' 'new description' @() 'alice'
+```
+
+#### v3
+
+```powershell
+Set-JiraIssue TEST-01 -Summary 'new summary' -Description 'new description' -Assignee 'alice'
+```
 
 ### Minimum PowerShell Version
 
@@ -141,17 +162,21 @@ Windows PowerShell 3.0 and 4.0 are no longer supported. PowerShell 7+ continues 
 
 ## FINDING DEPRECATED USAGE IN YOUR SCRIPTS
 
-The following regular expressions can help locate v2-style usage that needs updating:
+The following commands recursively search your scripts for v2-style usage
+that needs updating:
 
 ```powershell
 # Find magic-string assignee usage
-Select-String -Path *.ps1 -Pattern "-Assignee\s+['""](Unassigned|Default)['""]"
+Get-ChildItem -Recurse -Filter *.ps1 |
+    Select-String -Pattern "-Assignee\s+['""](Unassigned|Default)['""]"
 
 # Find $null assignee usage
-Select-String -Path *.ps1 -Pattern "-Assignee\s+\`$null"
+Get-ChildItem -Recurse -Filter *.ps1 |
+    Select-String -Pattern "-Assignee\s+\`$null"
 
 # Find legacy paging parameters
-Select-String -Path *.ps1 -Pattern "-(StartIndex|MaxResults)\b"
+Get-ChildItem -Recurse -Filter *.ps1 |
+    Select-String -Pattern "-(StartIndex|MaxResults)\b"
 ```
 
 # SEE ALSO

--- a/docs/en-US/about_JiraPS_MigrationV3.md
+++ b/docs/en-US/about_JiraPS_MigrationV3.md
@@ -12,33 +12,31 @@ hide: true
 
 # SHORT DESCRIPTION
 
-This document describes the breaking changes in JiraPS v3 and how to migrate
-your scripts from v2.x.
+This document describes the breaking changes in JiraPS v3 and how to migrate your scripts from v2.x.
 
 # LONG DESCRIPTION
 
 JiraPS v3 removes a number of long-deprecated parameters and "magic string"
-values that have been in the codebase for several major versions. The minimum
-supported PowerShell version was also raised to 5.1, allowing the module to
-adopt newer language features and improve performance.
+values that have been in the codebase for several major versions.
+The minimum supported PowerShell version was also raised to 5.1,
+allowing the module to adopt newer language features and improve performance.
 
-This guide lists every breaking change introduced in v3 and shows how to
-update your scripts.
+This guide lists every breaking change introduced in v3 and shows how to update your scripts.
 
 ## SUMMARY OF BREAKING CHANGES
 
-| Area                                | What Changed                                                                |
-| ----------------------------------- | --------------------------------------------------------------------------- |
-| `Get-JiraIssue`                     | Removed `-StartIndex`, `-MaxResults`. Use `-Skip`, `-First`.                |
-| `Get-JiraGroupMember`               | Removed `-StartIndex`, `-MaxResults`. Use `-Skip`, `-First`.                |
-| `Set-JiraIssue -Assignee`           | No longer accepts `'Unassigned'` or `'Default'` magic strings.              |
-| `Set-JiraIssue -Assignee`           | No longer accepts `$null` or empty string. Use `-Unassign`.                 |
-| `Set-JiraIssue`                     | New `-Unassign` switch (parameter set).                                     |
-| `Set-JiraIssue`                     | `-Assignee`, `-Unassign`, `-UseDefaultAssignee` are mutually exclusive.     |
-| `Invoke-JiraIssueTransition`        | `-Assignee` no longer accepts `'Unassigned'` magic string.                  |
-| `Invoke-JiraIssueTransition`        | `-Assignee` no longer accepts `$null` or empty string. Use `-Unassign`.     |
-| `Invoke-JiraIssueTransition`        | New `-Unassign` switch (parameter set).                                     |
-| Minimum PowerShell version          | Raised from 3.0 to 5.1.                                                     |
+| Area                         | What Changed                                                            |
+| ---------------------------- | ----------------------------------------------------------------------- |
+| `Get-JiraIssue`              | Removed `-StartIndex`, `-MaxResults`. Use `-Skip`, `-First`.            |
+| `Get-JiraGroupMember`        | Removed `-StartIndex`, `-MaxResults`. Use `-Skip`, `-First`.            |
+| `Set-JiraIssue -Assignee`    | No longer accepts `'Unassigned'` or `'Default'` magic strings.          |
+| `Set-JiraIssue -Assignee`    | No longer accepts `$null` or empty string. Use `-Unassign`.             |
+| `Set-JiraIssue`              | New `-Unassign` switch (parameter set).                                 |
+| `Set-JiraIssue`              | `-Assignee`, `-Unassign`, `-UseDefaultAssignee` are mutually exclusive. |
+| `Invoke-JiraIssueTransition` | `-Assignee` no longer accepts `'Unassigned'` magic string.              |
+| `Invoke-JiraIssueTransition` | `-Assignee` no longer accepts `$null` or empty string. Use `-Unassign`. |
+| `Invoke-JiraIssueTransition` | New `-Unassign` switch (parameter set).                                 |
+| Minimum PowerShell version   | Raised from 3.0 to 5.1.                                                 |
 
 ## DETAILED MIGRATION GUIDE
 
@@ -64,8 +62,8 @@ Get-JiraGroupMember -Group 'jira-users' -First 100
 
 ### Unassigning an Issue — `Set-JiraIssue`
 
-The string value `'Unassigned'` is no longer recognised by `-Assignee`. The
-previously informal convention of passing `$null` is also no longer accepted.
+The string value `'Unassigned'` is no longer recognised by `-Assignee`.
+The previously informal convention of passing `$null` is also no longer accepted.
 Use the new `-Unassign` switch instead.
 
 #### v2
@@ -83,8 +81,8 @@ Set-JiraIssue -Issue TEST-01 -Unassign
 
 ### Default Assignee — `Set-JiraIssue`
 
-The string value `'Default'` is no longer recognised by `-Assignee`. Use the
-`-UseDefaultAssignee` switch (introduced as the canonical replacement).
+The string value `'Default'` is no longer recognised by `-Assignee`.
+Use the `-UseDefaultAssignee` switch (introduced as the canonical replacement).
 
 #### v2
 
@@ -100,8 +98,8 @@ Set-JiraIssue -Issue TEST-01 -UseDefaultAssignee
 
 ### Unassigning during a Transition — `Invoke-JiraIssueTransition`
 
-Same change as `Set-JiraIssue`: the `'Unassigned'` magic string and the
-`$null` convention have been replaced by the explicit `-Unassign` switch.
+Same change as `Set-JiraIssue`:
+the `'Unassigned'` magic string and the `$null` convention have been replaced by the explicit `-Unassign` switch.
 
 #### v2
 
@@ -118,9 +116,9 @@ Invoke-JiraIssueTransition -Issue TEST-01 -Transition 11 -Unassign
 
 ### Mutual Exclusion of Assignee Operations
 
-In v3 the assignee-related parameters live in distinct parameter sets, so
-PowerShell will refuse to bind more than one of them in the same call. This
-catches mistakes at parse time rather than producing surprising behaviour.
+In v3 the assignee-related parameters live in distinct parameter sets,
+so PowerShell will refuse to bind more than one of them in the same call.
+This catches mistakes at parse time rather than producing surprising behaviour.
 
 #### Invalid in v3
 
@@ -133,19 +131,17 @@ Set-JiraIssue -Issue TEST-01 -Unassign -UseDefaultAssignee          # error
 ### Empty / Null Assignee Strings
 
 Previously `Set-JiraIssue -Assignee ""` or `Set-JiraIssue -Assignee $null`
-would silently produce different (and often unintended) effects. In v3 both
-are rejected with a clear error message pointing you to `-Unassign` or
-`-UseDefaultAssignee`.
+would silently produce different (and often unintended) effects.
+In v3 both are rejected with a clear error message pointing you to `-Unassign` or `-UseDefaultAssignee`.
 
 ### Minimum PowerShell Version
 
-JiraPS v3 requires PowerShell 5.1 or later. Windows PowerShell 3.0 and 4.0
-are no longer supported. PowerShell 7+ continues to be fully supported.
+JiraPS v3 requires PowerShell 5.1 or later.
+Windows PowerShell 3.0 and 4.0 are no longer supported. PowerShell 7+ continues to be fully supported.
 
 ## FINDING DEPRECATED USAGE IN YOUR SCRIPTS
 
-The following regular expressions can help locate v2-style usage that needs
-updating:
+The following regular expressions can help locate v2-style usage that needs updating:
 
 ```powershell
 # Find magic-string assignee usage

--- a/docs/en-US/commands/Get-JiraGroupMember.md
+++ b/docs/en-US/commands/Get-JiraGroupMember.md
@@ -16,8 +16,9 @@ Returns members of a given group in JIRA
 ## SYNTAX
 
 ```powershell
-Get-JiraGroupMember [-Group] <Object[]> [[-IncludeInactive] <Switch>] [[-StartIndex] <UInt32>] [[-MaxResults] <UInt32>]
- [[PageSize] <UInt32>] [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>] [[-Credential] <PSCredential>] [<CommonParameters>]
+Get-JiraGroupMember [-Group] <Object[]> [-IncludeInactive] [-PageSize <UInt32>]
+ [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>] [-Credential <PSCredential>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -95,48 +96,6 @@ Aliases:
 Required: False
 Position: Named
 Default value: 25
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -StartIndex
-
-> NOTE: This parameter has been marked as deprecated and will be removed with the next major release.
-> Use `-Skip` instead.
-
-Index of the first user to return.
-
-This can be used to "page" through users in a large group or a slow connection.
-
-```yaml
-Type: UInt32
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: 2
-Default value: 0
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -MaxResults
-
-> NOTE: This parameter has been marked as deprecated and will be removed with the next major release.
-> Use `-First` instead.
-
-Maximum number of results to return.
-
-By default, all users will be returned.
-
-```yaml
-Type: UInt32
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: 3
-Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -229,8 +188,8 @@ The group to query for members
 By default, this will return all active users who are members of the given group.
 For large groups, this can take quite some time.
 
-To limit the number of group members returned, use the MaxResults parameter.
-You can also combine this with the `-StartIndex` parameter to "page" through results.
+To limit the number of group members returned, use the `-First` parameter.
+You can also combine this with the `-Skip` parameter to "page" through results.
 
 This function does not return inactive users.
 This appears to be a limitation of JIRA's REST API.

--- a/docs/en-US/commands/Get-JiraIssue.md
+++ b/docs/en-US/commands/Get-JiraIssue.md
@@ -32,17 +32,17 @@ Get-JiraIssue [-InputObject] <Object[]> [-Fields <String[]>] [-IncludeTotalCount
 ### ByJQL
 
 ```powershell
-Get-JiraIssue -Query <String> [-Fields <String[]>] [-StartIndex <UInt32>]
-[-MaxResults <UInt32>] [[PageSize] <UInt32>] [-IncludeTotalCount] [-Skip <UInt64>]
- [-First <UInt64>] [-Credential <PSCredential>] [<CommonParameters>]
+Get-JiraIssue -Query <String> [-Fields <String[]>] [-PageSize <UInt32>]
+ [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
+ [-Credential <PSCredential>] [<CommonParameters>]
 ```
 
 ### ByFilter
 
 ```powershell
-Get-JiraIssue -Filter <Object> [-Fields <String[]>][-StartIndex <UInt32>]
- [-MaxResults <UInt32>] [[PageSize] <UInt32>] [-IncludeTotalCount] [-Skip <UInt64>]
- [-First <UInt64>] [-Credential <PSCredential>] [<CommonParameters>]
+Get-JiraIssue -Filter <Object> [-Fields <String[]>] [-PageSize <UInt32>]
+ [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
+ [-Credential <PSCredential>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -221,53 +221,9 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -StartIndex
-
-> NOTE: This parameter has been marked as deprecated and will be removed with the next major release.
-> Use `-Skip` instead.
-
-Index of the first issue to return.
-
-This can be used to "page" through issues in a large collection or a slow connection.
-
-```yaml
-Type: UInt32
-Parameter Sets: ByJQL, ByFilter
-Aliases:
-
-Required: False
-Position: Named
-Default value: 0
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -MaxResults
-
-> NOTE: This parameter has been marked as deprecated and will be removed with the next major release.
-> Use `-First` instead.
-
-Maximum number of results to return.
-
-By default, all issues will be returned.
-
-```yaml
-Type: UInt32
-Parameter Sets: ByJQL, ByFilter
-Aliases:
-
-Required: False
-Position: Named
-Default value: 0
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -PageSize
 
 How many issues should be returned per call to JIRA.
-
-This parameter only has effect if `-MaxResults` is not provided or set to 0.
 
 Normally, you should not need to adjust this parameter,
 but if the REST calls take a long time,

--- a/docs/en-US/commands/Invoke-JiraIssueTransition.md
+++ b/docs/en-US/commands/Invoke-JiraIssueTransition.md
@@ -15,9 +15,18 @@ Performs an issue transition on a JIRA issue changing it's status
 
 ## SYNTAX
 
+### AssignToUser (Default)
+
 ```powershell
-Invoke-JiraIssueTransition [-Issue] <Object> [-Transition] <Object> [[-Fields] <PSCustomObject>]
- [[-Assignee] <Object>] [[-Comment] <String>] [[-Credential] <PSCredential>] [-Passthru] [<CommonParameters>]
+Invoke-JiraIssueTransition [-Issue] <Object> [-Transition] <Object> [-Fields <PSCustomObject>]
+ [-Assignee <Object>] [-Comment <String>] [-Credential <PSCredential>] [-Passthru] [<CommonParameters>]
+```
+
+### Unassign
+
+```powershell
+Invoke-JiraIssueTransition [-Issue] <Object> [-Transition] <Object> [-Fields <PSCustomObject>]
+ [-Unassign] [-Comment <String>] [-Credential <PSCredential>] [-Passthru] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -143,17 +152,37 @@ Accept wildcard characters: False
 
 New assignee of the issue.
 
-Pass `$null` to remove the assignee of the issue.
+Use `-Unassign` to remove the assignee.
+Empty strings and `$null` values are not accepted.
+
 Assignee field must be configured to appear on the transition screen to use this parameter.
 
 ```yaml
 Type: Object
-Parameter Sets: (All)
+Parameter Sets: AssignToUser
 Aliases:
 
 Required: False
-Position: 4
+Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Unassign
+
+Remove the current assignee of the issue as part of the transition.
+
+Assignee field must be configured to appear on the transition screen to use this parameter.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Unassign
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/en-US/commands/Invoke-JiraIssueTransition.md
+++ b/docs/en-US/commands/Invoke-JiraIssueTransition.md
@@ -143,7 +143,7 @@ Accept wildcard characters: False
 
 New assignee of the issue.
 
-Enter `Unassigned` to remove the assignee of the issue.
+Pass `$null` to remove the assignee of the issue.
 Assignee field must be configured to appear on the transition screen to use this parameter.
 
 ```yaml

--- a/docs/en-US/commands/Set-JiraIssue.md
+++ b/docs/en-US/commands/Set-JiraIssue.md
@@ -49,7 +49,7 @@ This example appends text to the end of an existing issue description by using
 ### EXAMPLE 3
 
 ```powershell
-Set-JiraIssue -Issue TEST-01 -Assignee 'Unassigned'
+Set-JiraIssue -Issue TEST-01 -Assignee $null
 ```
 
 This example removes the assignee from JIRA issue TEST-01.
@@ -163,7 +163,7 @@ Accept wildcard characters: False
 
 New assignee of the issue.
 
-Use the value `Unassigned` to remove the current assignee of the issue.
+Pass `$null` to remove the current assignee of the issue.
 
 ```yaml
 Type: Object

--- a/docs/en-US/commands/Set-JiraIssue.md
+++ b/docs/en-US/commands/Set-JiraIssue.md
@@ -15,10 +15,30 @@ Modifies an existing issue in JIRA
 
 ## SYNTAX
 
+### AssignToUser (Default)
+
 ```powershell
-Set-JiraIssue [-Issue] <Object[]> [[-Summary] <String>] [[-Description] <String>] [[-FixVersion] <String[]>]
- [[-Assignee] <Object>] [[-Label] <String[]>] [[-Fields] <PSCustomObject>] [[-AddComment] <String>]
- [[-Credential] <PSCredential>] [-SkipNotification] [-PassThru] [-UseDefaultAssignee]
+Set-JiraIssue [-Issue] <Object[]> [-Summary <String>] [-Description <String>] [-FixVersion <String[]>]
+ [-Assignee <Object>] [-Label <String[]>] [-Fields <PSCustomObject>] [-AddComment <String>]
+ [-Credential <PSCredential>] [-SkipNotification] [-PassThru]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### Unassign
+
+```powershell
+Set-JiraIssue [-Issue] <Object[]> [-Summary <String>] [-Description <String>] [-FixVersion <String[]>]
+ [-Unassign] [-Label <String[]>] [-Fields <PSCustomObject>] [-AddComment <String>]
+ [-Credential <PSCredential>] [-SkipNotification] [-PassThru]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### UseDefaultAssignee
+
+```powershell
+Set-JiraIssue [-Issue] <Object[]> [-Summary <String>] [-Description <String>] [-FixVersion <String[]>]
+ [-UseDefaultAssignee] [-Label <String[]>] [-Fields <PSCustomObject>] [-AddComment <String>]
+ [-Credential <PSCredential>] [-SkipNotification] [-PassThru]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -50,7 +70,7 @@ This example appends text to the end of an existing issue description by using
 ### EXAMPLE 3
 
 ```powershell
-Set-JiraIssue -Issue TEST-01 -Assignee $null
+Set-JiraIssue -Issue TEST-01 -Unassign
 ```
 
 This example removes the assignee from JIRA issue TEST-01.
@@ -164,16 +184,35 @@ Accept wildcard characters: False
 
 New assignee of the issue.
 
-Pass `$null` to remove the current assignee of the issue.
+Use `-Unassign` to remove the assignee.
+Use `-UseDefaultAssignee` to set the project's default assignee.
+
+Empty strings and `$null` values are not accepted.
 
 ```yaml
 Type: Object
-Parameter Sets: (All)
+Parameter Sets: AssignToUser
 Aliases:
 
 Required: False
-Position: 5
+Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Unassign
+
+Remove the current assignee of the issue.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Unassign
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -290,7 +329,7 @@ based on the project's configuration.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: (All)
+Parameter Sets: UseDefaultAssignee
 Aliases:
 
 Required: False

--- a/docs/en-US/commands/Set-JiraIssue.md
+++ b/docs/en-US/commands/Set-JiraIssue.md
@@ -18,7 +18,8 @@ Modifies an existing issue in JIRA
 ```powershell
 Set-JiraIssue [-Issue] <Object[]> [[-Summary] <String>] [[-Description] <String>] [[-FixVersion] <String[]>]
  [[-Assignee] <Object>] [[-Label] <String[]>] [[-Fields] <PSCustomObject>] [[-AddComment] <String>]
- [[-Credential] <PSCredential>] [-SkipNotification] [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-Credential] <PSCredential>] [-SkipNotification] [-PassThru] [-UseDefaultAssignee]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -57,10 +58,10 @@ This example removes the assignee from JIRA issue TEST-01.
 ### EXAMPLE 4
 
 ```powershell
-Set-JiraIssue -Issue TEST-01 -Assignee 'Default'
+Set-JiraIssue -Issue TEST-01 -UseDefaultAssignee
 ```
 
-This example will set the assgignee of JIRA issue TEST-01 to the value the project or type of the issue determine as default.
+This example sets the assignee of JIRA issue TEST-01 to the project's default assignee.
 
 ### EXAMPLE 5
 
@@ -267,6 +268,25 @@ Accept wildcard characters: False
 ### -PassThru
 
 Whether output should be provided after invoking this function.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UseDefaultAssignee
+
+Set the issue's assignee to the project's default assignee.
+
+This is useful when you want Jira to automatically determine the assignee
+based on the project's configuration.
 
 ```yaml
 Type: SwitchParameter


### PR DESCRIPTION
## Summary

This branch is the v3 deprecation-removal pass. It deletes the parameters and magic-string assignee values that were marked as deprecated in v2, replaces them with explicit, discoverable parameter sets, fixes a Jira Cloud unassign bug, and modernizes a number of hot paths now that the supported PowerShell floor is 5.1.

### Breaking changes

- **`Get-JiraIssue`, `Get-JiraGroupMember`** — removed the deprecated `-StartIndex` and `-MaxResults` parameters. Use `-PageSize` and the standard `-First` / `-Skip` paging parameters instead.
- **`Set-JiraIssue -Assignee 'Unassigned'`** — removed. Use the new `-Unassign` switch.
- **`Set-JiraIssue -Assignee 'Default'`** — removed. Use the new `-UseDefaultAssignee` switch. (`Invoke-JiraIssueTransition` never accepted `'Default'`, so nothing changes there.)
- **`Set-JiraIssue -Assignee `\$null`** — removed. Use the new `-Unassign` switch.
- **`Invoke-JiraIssueTransition -Assignee 'Unassigned' / `\$null` / `\"\"`** — removed. Use the new `-Unassign` switch.
- **`-Assignee` is no longer positional** on `Set-JiraIssue`. It now lives in the `AssignToUser` parameter set alongside `-Unassign` and `-UseDefaultAssignee`, all of which are named-only. Scripts using named arguments are unaffected.
- **`-Assignee`** validation tightened with `[ValidateNotNullOrEmpty()]` plus a custom `[ValidateScript]` that rejects whitespace-only strings with actionable guidance pointing at `-Unassign` / `-UseDefaultAssignee`.

### Bug fixes

- **`Invoke-JiraIssueTransition -Unassign` on Jira Cloud** previously sent `{name: \"\"}`, which Cloud rejects. It now correctly sends `{accountId: null}`.
- **`Invoke-JiraIssueTransition`** — fixed long-standing `\$errorTargetError` typo in the transition-cast error path (`ErrorRecord` was being constructed against an undefined variable).
- **`ConvertTo-GetParameter`** — empty-hashtable contract restored (returns `''` instead of `'?'`), preventing accidental `?` in URLs.

### Modernization / performance (internal only)

- Replaced `System.Collections.ArrayList` with `[System.Collections.Generic.List[T]]` in `New-JiraIssue`, `ConvertTo-JiraGroup`, `Set-JiraIssueLabel` (initialized via constructor from existing labels).
- Pre-compiled the regex patterns used by `ConvertTo-AtlassianDocumentFormat` once at module load.
- Replaced in-loop string concatenation in `ConvertTo-GetParameter` with array-collect + `-join`.
- Replaced `Get-Member -MemberType *Property` lookups with direct `PSObject.Properties` access in `Format-Jira`, `Add-JiraIssueLink`, `Remove-JiraIssueLink`, `Resolve-JiraError`, `Expand-Result`, `ConvertTo-JiraCreateMetaField`, and `ConvertTo-JiraEditMetaField`.
- Extracted assignee-payload construction into a new private `Resolve-JiraAssigneePayload` helper shared by `Set-JiraIssue` and `Invoke-JiraIssueTransition`. The helper is called once in `begin{}` so the work is not repeated per piped issue. The helper now also throws explicitly when handed a Cloud user object with no `AccountId`, instead of silently emitting an unassign payload.

### Documentation

- New `docs/en-US/about_JiraPS_MigrationV3.md` covering every breaking change above with v2 → v3 examples and recursive `Get-ChildItem | Select-String` snippets for finding deprecated usage in user scripts.
- `Set-JiraIssue.md` and `Invoke-JiraIssueTransition.md` updated to document the new parameter sets and switches.
- `CHANGELOG.md` updated under `Removed`, `Added`, `Changed`, `Fixed`, and a new `Internal` subsection.

## Test plan

- [x] `Invoke-Build Build, Test` — **3563 passing, 0 failing, 65 skipped** locally on macOS / pwsh 7.4.
- [x] CI green on Lint, Build, and Test (Windows PS5, Windows PS7, Ubuntu, macOS).
- [x] New unit tests for `Resolve-JiraAssigneePayload` covering Cloud/Server, assign / unassign / default paths, plus the new \"throw on Cloud user with missing AccountId\" guard.
- [x] New parameter-set tests for `Set-JiraIssue` and `Invoke-JiraIssueTransition` covering `-Assignee`, `-Unassign`, `-UseDefaultAssignee` mutual exclusivity, defaults, and composition with other modifying parameters (e.g. `-Unassign -Fields`, `-UseDefaultAssignee -Summary`).
- [x] Cloud `-Unassign` tests assert `accountId:null` payload for both cmdlets.
- [x] Whitespace-only `-Assignee` rejection tests for both cmdlets.
- [ ] Smoke test against a real Jira Cloud instance (`Set-JiraIssue -Unassign`, `Invoke-JiraIssueTransition -Unassign`, `-UseDefaultAssignee`).
- [ ] Smoke test against a real Jira Server / DC instance (same scenarios).

## Follow-up (deliberately out of scope)

The discussion on this PR surfaced two adjacent improvements that are intentionally **not** included here so this PR stays focused on deprecation cleanup:

1. **Add first-class `-Assignee` / `-Unassign` to `New-JiraIssue`** — currently users must set the assignee via the catch-all `-Fields` hashtable with raw `{accountId|name: ...}` payloads. The new `Resolve-JiraAssigneePayload` helper introduced in this PR is exactly what the follow-up needs. Will ship as a small dedicated PR after this one merges.
   - Note: `-AssignDefault` / `-UseDefaultAssignee` is intentionally *not* on the follow-up list because the Jira REST `POST /rest/api/2/issue` endpoint already applies the project's default assignee when the `assignee` field is omitted; a switch would be redundant.
2. **Dedupe `-Reporter` payload on `New-JiraIssue`** through the same helper (likely renamed `Resolve-JiraUserPayload`). Smaller fish; possibly bundled with #1.