### PR TITLE
Fix PlatyPS 1.0 help regressions with reflection-based MAML repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ See [`about_JiraPS_MigrationV3`](https://atlassianps.org/docs/JiraPS/about/migra
 - `Invoke-Build -Task Test` now excludes integration tests by default (use `-Tag 'Integration'` to include them)
 - Enhanced `Test-ServerResponse` to handle HTTP 503 (Service Unavailable) with retry, jitter on backoff delays, and 60-second max delay cap (#576)
 - Enhanced `Resolve-JiraError` to parse all Jira error response formats: `message`, `errorMessage`, `errorMessages` array, and `errors` dictionary (#576)
+- Hid internal `-Cmdlet` and `-_RetryCount` parameters on `Invoke-JiraMethod` from tab-completion via `[Parameter(DontShow)]` (follow-up to #582)
+- Hardened the `GenerateExternalHelp` build task with explicit command-count and file-existence assertions, warnings on multi-fence examples, and UTF-8-with-BOM encoding for about-topic files (follow-up to #582/#587)
 
 ### Internal
 
@@ -64,6 +66,7 @@ See [`about_JiraPS_MigrationV3`](https://atlassianps.org/docs/JiraPS/about/migra
 - Fixed `Get-JiraIssue` prompting for input when piping JiraPS.Issue objects (added `ValueFromPipelineByPropertyName` to `-Key` parameter)
 - Fixed long-standing typo in `Invoke-JiraIssueTransition` where the transition-cast error path constructed its `ErrorRecord` against an undefined `$errorTargetError` variable instead of `$errorTarget`.
 - Fixed `ConvertTo-GetParameter` returning `'?'` for an empty hashtable; it now returns `''` again, matching its prior contract and preventing accidental trailing `?` in URLs.
+- Fixed PlatyPS 1.0 MAML regressions introduced in #582: every `<command:parameter>` was emitted with `aliases="none"` and `pipelineInput="false"`, `<dev:defaultValue>` was never written, `### [Type]` INPUTS/OUTPUTS headings collapsed to a literal `[` typename, and fenced example code was buried inside `maml:introduction` instead of `dev:code`/`dev:remarks`. `Get-Help` now correctly reports aliases, pipeline binding, default values, typed INPUTS/OUTPUTS, and split code/remarks for every example. Parameter aliases and pipeline flags are read back from the live module via reflection, so the source code is the single source of truth (no markdown drift).
 - Fixed `ConvertTo-JiraServerInfo` throwing when `BuildDate` or `ServerTime` are null in API response (now returns `$null` for these fields). **Soft breaking change**: Scripts accessing `.BuildDate.Year` or similar will throw `NullReferenceException` on Cloud instances that omit these fields.
 - Fixed `Invoke-PaginatedRequest` crashing with "Cannot bind argument to parameter 'InputObject'" when API returns null during pagination (now writes warning and returns partial results)
 - Fixed module load race condition when multiple processes import JiraPS simultaneously (gracefully handles concurrent config file creation)

--- a/JiraPS.build.ps1
+++ b/JiraPS.build.ps1
@@ -209,22 +209,200 @@ Task CompileModule {
     "Private", "Public" | ForEach-Object { Remove-Item -Path "$env:BHBuildOutput/$env:BHProjectName/$_" -Recurse -Force }
 }
 
+# Helper: patch the MAML XmlDocument in place to restore the metadata that
+# Microsoft.PowerShell.PlatyPS 1.0's Export-MamlCommandHelp drops or mangles:
+#
+#   * Every <command:parameter> ends up with aliases="none" and
+#     pipelineInput="false", regardless of source.
+#   * <dev:defaultValue> is never emitted.
+#   * INPUTS/OUTPUTS headings of the form '### [A] / [B]' collapse to a
+#     single <dev:name>[</dev:name>` because PlatyPS' heading parser chokes
+#     on the '/' separator.
+#
+# Aliases and pipeline behaviour are read back from the live module via
+# reflection so the code is the single source of truth (no markdown drift).
+# INPUTS/OUTPUTS and default values come from the parsed CommandHelp objects,
+# whose Markdig-based parser strips the brackets correctly.
+function Repair-MamlMetadata {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = '"Metadata" is grammatically singular (mass noun); the analyzer''s pluralization service incorrectly treats it as plural.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [System.Xml.XmlDocument] $Xml,
+
+        [Parameter(Mandatory)]
+        [System.Management.Automation.PSModuleInfo] $Module,
+
+        [Hashtable] $CommandHelpMap = @{}
+    )
+
+    $devNs = 'http://schemas.microsoft.com/maml/dev/2004/10'
+    $mamlNs = 'http://schemas.microsoft.com/maml/2004/10'
+    $cmdNs = 'http://schemas.microsoft.com/maml/dev/command/2004/10'
+
+    $nsmgr = [System.Xml.XmlNamespaceManager]::new($Xml.NameTable)
+    $nsmgr.AddNamespace('command', $cmdNs)
+    $nsmgr.AddNamespace('maml', $mamlNs)
+    $nsmgr.AddNamespace('dev', $devNs)
+
+    # Build a maml:description element from a (possibly multi-paragraph) string.
+    $buildDescription = {
+        param($descriptionText)
+        $descElem = $Xml.CreateElement('maml', 'description', $mamlNs)
+        $trimmed = ($descriptionText -as [String]).Trim()
+        if ($trimmed) {
+            foreach ($paragraph in ($trimmed -split '(?:\r?\n){2,}')) {
+                $paraText = $paragraph.Trim()
+                if ($paraText) {
+                    $paraElem = $Xml.CreateElement('maml', 'para', $mamlNs)
+                    $paraElem.InnerText = $paraText
+                    $null = $descElem.AppendChild($paraElem)
+                }
+            }
+        }
+        else {
+            $null = $descElem.AppendChild($Xml.CreateElement('maml', 'para', $mamlNs))
+        }
+        $descElem
+    }
+
+    foreach ($commandNode in $Xml.SelectNodes('//command:command', $nsmgr)) {
+        $nameNode = $commandNode.SelectSingleNode('command:details/command:name', $nsmgr)
+        if (-not $nameNode) { continue }
+        $commandName = $nameNode.InnerText.Trim()
+
+        $cmdInfo = $Module.ExportedCommands[$commandName]
+        if (-not $cmdInfo) {
+            Write-Warning "Repair-MamlMetadata: command '$commandName' is in the MAML but not exported by module '$($Module.Name)'; skipping."
+            continue
+        }
+        $cmdHelp = $CommandHelpMap[$commandName]
+
+        foreach ($paramNode in $commandNode.SelectNodes('.//command:parameter', $nsmgr)) {
+            $paramNameNode = $paramNode.SelectSingleNode('maml:name', $nsmgr)
+            if (-not $paramNameNode) { continue }
+            $paramName = $paramNameNode.InnerText.Trim()
+            $paramInfo = $cmdInfo.Parameters[$paramName]
+            if (-not $paramInfo) { continue }
+
+            $aliasList = @($paramInfo.Aliases | Where-Object { $_ })
+            $paramNode.SetAttribute('aliases', $(if ($aliasList) { $aliasList -join ', ' } else { 'none' }))
+
+            $byValue = $false
+            $byProperty = $false
+            foreach ($set in $paramInfo.ParameterSets.Values) {
+                if ($set.ValueFromPipeline) { $byValue = $true }
+                if ($set.ValueFromPipelineByPropertyName) { $byProperty = $true }
+            }
+            $pipelineInput = if (-not ($byValue -or $byProperty)) { 'False' }
+            elseif ($byValue -and $byProperty) { 'True (ByValue, ByPropertyName)' }
+            elseif ($byValue) { 'True (ByValue)' }
+            else { 'True (ByPropertyName)' }
+            $paramNode.SetAttribute('pipelineInput', $pipelineInput)
+
+            # <dev:defaultValue> only belongs on the full parameter block
+            # (parent: command:parameters), not on command:syntaxItem variants.
+            if ($paramNode.ParentNode.LocalName -eq 'parameters' -and $cmdHelp) {
+                $helpParam = $cmdHelp.Parameters | Where-Object { $_.Name -eq $paramName } | Select-Object -First 1
+                $defaultText = ($helpParam.DefaultValue -as [String]).Trim()
+                if ($defaultText -and $defaultText -notin @('None', 'none')) {
+                    $existing = $paramNode.SelectSingleNode('dev:defaultValue', $nsmgr)
+                    if (-not $existing) {
+                        $defaultElem = $Xml.CreateElement('dev', 'defaultValue', $devNs)
+                        $defaultElem.InnerText = $defaultText
+                        $null = $paramNode.AppendChild($defaultElem)
+                    }
+                }
+            }
+        }
+
+        if (-not $cmdHelp) { continue }
+
+        # Replace INPUTS / OUTPUTS containers from the parsed CommandHelp object,
+        # which captures the typenames correctly even when Export-MamlCommandHelp's
+        # heading parser collapses '### [A] / [B]' to a literal '['.
+        $inputsContainer = $commandNode.SelectSingleNode('command:inputTypes', $nsmgr)
+        if ($inputsContainer -and $cmdHelp.Inputs -and $cmdHelp.Inputs.Count -gt 0) {
+            $inputsContainer.RemoveAll()
+            foreach ($t in $cmdHelp.Inputs) {
+                $inputTypeElem = $Xml.CreateElement('command', 'inputType', $cmdNs)
+                $typeElem = $Xml.CreateElement('dev', 'type', $devNs)
+                $nameElem = $Xml.CreateElement('dev', 'name', $devNs)
+                $nameElem.InnerText = ($t.Typename -as [String]).Trim()
+                $null = $typeElem.AppendChild($nameElem)
+                $null = $inputTypeElem.AppendChild($typeElem)
+                $null = $inputTypeElem.AppendChild((& $buildDescription $t.Description))
+                $null = $inputsContainer.AppendChild($inputTypeElem)
+            }
+        }
+
+        $outputsContainer = $commandNode.SelectSingleNode('command:returnValues', $nsmgr)
+        if ($outputsContainer -and $cmdHelp.Outputs -and $cmdHelp.Outputs.Count -gt 0) {
+            $outputsContainer.RemoveAll()
+            foreach ($t in $cmdHelp.Outputs) {
+                $returnValueElem = $Xml.CreateElement('command', 'returnValue', $cmdNs)
+                $typeElem = $Xml.CreateElement('dev', 'type', $devNs)
+                $nameElem = $Xml.CreateElement('dev', 'name', $devNs)
+                $nameElem.InnerText = ($t.Typename -as [String]).Trim()
+                $null = $typeElem.AppendChild($nameElem)
+                $null = $returnValueElem.AppendChild($typeElem)
+                $null = $returnValueElem.AppendChild((& $buildDescription $t.Description))
+                $null = $outputsContainer.AppendChild($returnValueElem)
+            }
+        }
+    }
+}
+
 # Synopsis: Use PlatyPS to generate External-Help
 Task GenerateExternalHelp {
     Import-Module Microsoft.PowerShell.PlatyPS -Force
 
-    foreach ($locale in (Get-ChildItem "$env:BHProjectPath/docs" -Attribute Directory)) {
-        $outputPath = "$env:BHModulePath/$($locale.Basename)"
-        $null = New-Item -ItemType Directory -Path $outputPath -Force
+    try {
+        foreach ($locale in (Get-ChildItem "$env:BHProjectPath/docs" -Attribute Directory)) {
+            $outputPath = "$env:BHModulePath/$($locale.Basename)"
+            $null = New-Item -ItemType Directory -Path $outputPath -Force
 
-        # Import command help markdown and export to MAML
-        $commandHelpFiles = Get-ChildItem "$($locale.FullName)/commands/*.md" -File |
-            Where-Object { $_.Name -ne 'index.md' }
+            $commandHelpFiles = Get-ChildItem "$($locale.FullName)/commands/*.md" -File |
+                Where-Object { $_.Name -ne 'index.md' }
 
-        if ($commandHelpFiles) {
-            $commandHelp = $commandHelpFiles | Import-MarkdownCommandHelp -ErrorAction SilentlyContinue
-            if ($commandHelp) {
+            if ($commandHelpFiles) {
+                # PlatyPS 1.0's Markdig-based import parser collapses bracketed
+                # INPUTS/OUTPUTS headings of the form `### [Type]` to a literal
+                # '[' typename, so write each markdown into a temp directory
+                # with that heading style normalized to `### Type`. The source
+                # files are never modified.
+                $tempDocsDir = Join-Path ([System.IO.Path]::GetTempPath()) "JiraPS_help_$([Guid]::NewGuid())"
+                $null = New-Item -ItemType Directory -Path $tempDocsDir -Force
+                $patchedFiles = foreach ($mdFile in $commandHelpFiles) {
+                    $content = [System.IO.File]::ReadAllText($mdFile.FullName)
+                    # Iteratively strip a [bracket] occurrence from each `### ` heading
+                    # until none are left, so both single (`### [A]`) and compound
+                    # (`### [A] / [B]`) forms collapse to bare typenames.
+                    $bracketPattern = '(?m)^(###[ \t]+[^\r\n]*?)\[\s*([^\]\r\n]+?)\s*\]'
+                    while ([regex]::IsMatch($content, $bracketPattern)) {
+                        $content = [regex]::Replace($content, $bracketPattern, '$1$2')
+                    }
+                    $tmp = Join-Path $tempDocsDir $mdFile.Name
+                    [System.IO.File]::WriteAllText($tmp, $content)
+                    Get-Item $tmp
+                }
+
+                try {
+                    $commandHelp = @($patchedFiles | Import-MarkdownCommandHelp)
+                    Assert-True ($commandHelp.Count -eq $commandHelpFiles.Count) "Imported $($commandHelp.Count) command help objects but expected $($commandHelpFiles.Count) (one per markdown file)."
+                }
+                finally {
+                    Remove-Item $tempDocsDir -Recurse -Force -ErrorAction SilentlyContinue
+                }
+
+                # Index the parsed CommandHelp objects by command name so the
+                # MAML repair pass can look up INPUTS/OUTPUTS typenames and
+                # documentary default values without re-parsing the markdown.
+                $commandHelpMap = @{}
+                foreach ($help in $commandHelp) { $commandHelpMap[$help.Title] = $help }
+
                 $commandHelp | Export-MamlCommandHelp -OutputFolder $outputPath -Force
+
                 # Move from nested module folder to output path
                 $nestedPath = Join-Path $outputPath $env:BHProjectName
                 if (Test-Path $nestedPath) {
@@ -232,58 +410,81 @@ Task GenerateExternalHelp {
                     Remove-Item $nestedPath -Recurse -Force
                 }
 
-                # Post-process MAML to fix example structure (PlatyPS 1.0 compatibility)
                 $mamlFile = Join-Path $outputPath "$env:BHProjectName-help.xml"
-                if (Test-Path $mamlFile) {
-                    $xml = [xml](Get-Content $mamlFile -Raw)
-                    $nsmgr = [System.Xml.XmlNamespaceManager]::new($xml.NameTable)
-                    $nsmgr.AddNamespace("command", "http://schemas.microsoft.com/maml/dev/command/2004/10")
-                    $nsmgr.AddNamespace("maml", "http://schemas.microsoft.com/maml/2004/10")
-                    $nsmgr.AddNamespace("dev", "http://schemas.microsoft.com/maml/dev/2004/10")
+                Assert-True (Test-Path $mamlFile) "Expected MAML help file was not created: $mamlFile"
 
-                    foreach ($example in $xml.SelectNodes("//command:example", $nsmgr)) {
-                        $intro = $example.SelectSingleNode("maml:introduction", $nsmgr)
-                        $code = $example.SelectSingleNode("dev:code", $nsmgr)
-                        $remarks = $example.SelectSingleNode("dev:remarks", $nsmgr)
+                $xml = [xml](Get-Content $mamlFile -Raw)
+                $nsmgr = [System.Xml.XmlNamespaceManager]::new($xml.NameTable)
+                $nsmgr.AddNamespace('command', 'http://schemas.microsoft.com/maml/dev/command/2004/10')
+                $nsmgr.AddNamespace('maml', 'http://schemas.microsoft.com/maml/2004/10')
+                $nsmgr.AddNamespace('dev', 'http://schemas.microsoft.com/maml/dev/2004/10')
 
-                        if ($intro -and $code -and $remarks) {
-                            $introText = ($intro.ChildNodes | ForEach-Object { $_.InnerText }) -join "`n"
-                            # Extract code from markdown fences
-                            if ($introText -match '```(?:powershell)?\r?\n([\s\S]*?)```') {
-                                $codeContent = $Matches[1].Trim()
-                                $code.InnerText = $codeContent
+                # Re-inject parameter metadata that PlatyPS 1.0 drops on every
+                # Export-MamlCommandHelp call (aliases, pipelineInput, defaults).
+                # Reflection against the live source module is the source of truth.
+                $sourceModule = Import-Module "$env:BHProjectPath/$env:BHProjectName/$env:BHProjectName.psd1" -Force -PassThru -DisableNameChecking
+                try {
+                    Repair-MamlMetadata -Xml $xml -Module $sourceModule -CommandHelpMap $commandHelpMap
+                }
+                finally {
+                    Remove-Module $sourceModule -Force -ErrorAction SilentlyContinue
+                }
 
-                                # Extract remarks (everything after the code block)
-                                $remarksContent = ($introText -replace '```(?:powershell)?\r?\n[\s\S]*?```\r?\n?', '').Trim()
-                                $remarksContent = $remarksContent -replace '_([^_]+)_', '$1'  # Remove markdown italic
-                                if ($remarksContent) {
-                                    $para = $xml.CreateElement("maml", "para", "http://schemas.microsoft.com/maml/2004/10")
-                                    $para.InnerText = $remarksContent
-                                    $remarks.AppendChild($para) | Out-Null
-                                }
+                # Restructure examples: PlatyPS 1.0 emits the original markdown source
+                # (fenced code block + prose) inside maml:introduction; split it into
+                # dev:code + dev:remarks/maml:para so Get-Help renders correctly.
+                $fencePattern = '```([\w-]*)\r?\n([\s\S]*?)```'
+                # Strip markdown italics, but only at word boundaries so paths and
+                # identifiers like `non_unique_id` or `$_var_` are not mangled.
+                $italicPattern = '(?<![\w/\\])_([^_\n]{1,200}?)_(?![\w/\\])'
 
-                                # Clear introduction
-                                $intro.RemoveAll()
-                            }
-                        }
+                foreach ($example in $xml.SelectNodes('//command:example', $nsmgr)) {
+                    $intro = $example.SelectSingleNode('maml:introduction', $nsmgr)
+                    $code = $example.SelectSingleNode('dev:code', $nsmgr)
+                    $remarks = $example.SelectSingleNode('dev:remarks', $nsmgr)
+                    if (-not ($intro -and $code -and $remarks)) { continue }
+
+                    $introText = ($intro.ChildNodes | ForEach-Object { $_.InnerText }) -join "`n"
+                    $fenceMatches = [regex]::Matches($introText, $fencePattern)
+                    if ($fenceMatches.Count -lt 1) { continue }
+
+                    if ($fenceMatches.Count -gt 1) {
+                        $owningCommand = $example.SelectSingleNode('ancestor::command:command/command:details/command:name', $nsmgr)
+                        $owningName = if ($owningCommand) { $owningCommand.InnerText.Trim() } else { '<unknown>' }
+                        Write-Warning "Example for $owningName contains $($fenceMatches.Count) fenced code blocks; only the first is captured as code."
                     }
 
-                    $xml.Save($mamlFile)
+                    $code.InnerText = $fenceMatches[0].Groups[2].Value.Trim()
+
+                    $remarksContent = ($introText -replace $fencePattern, '').Trim()
+                    $remarksContent = $remarksContent -replace $italicPattern, '$1'
+                    if ($remarksContent) {
+                        $para = $xml.CreateElement('maml', 'para', 'http://schemas.microsoft.com/maml/2004/10')
+                        $para.InnerText = $remarksContent
+                        $null = $remarks.AppendChild($para)
+                    }
+
+                    $intro.RemoveAll()
                 }
+
+                $xml.Save($mamlFile)
+            }
+
+            # Copy about topics as help text files. UTF-8 with BOM for PowerShell 5
+            # compatibility (matches the CompileModule convention introduced in 3107e3a).
+            $utf8Bom = [System.Text.UTF8Encoding]::new($true)
+            Get-ChildItem "$($locale.FullName)/about_*.md" -File | ForEach-Object {
+                $helpTxtName = $_.BaseName + '.help.txt'
+                $content = [System.IO.File]::ReadAllText($_.FullName)
+                # Tolerate files where the closing `---` is the final line (no trailing newline).
+                $content = $content -replace '\A---\r?\n[\s\S]*?\r?\n---\r?\n?', ''
+                [System.IO.File]::WriteAllText((Join-Path $outputPath $helpTxtName), $content, $utf8Bom)
             }
         }
-
-        # Copy about topics as help text files
-        Get-ChildItem "$($locale.FullName)/about_*.md" -File | ForEach-Object {
-            $helpTxtName = $_.BaseName + '.help.txt'
-            $content = Get-Content $_.FullName -Raw
-            # Remove YAML frontmatter if present
-            $content = $content -replace '^---[\s\S]*?---\r?\n', ''
-            Set-Content -Path (Join-Path $outputPath $helpTxtName) -Value $content -Encoding UTF8
-        }
     }
-
-    Remove-Module Microsoft.PowerShell.PlatyPS
+    finally {
+        Remove-Module Microsoft.PowerShell.PlatyPS -ErrorAction SilentlyContinue
+    }
 }
 
 # Synopsis: Update the manifest of the module

--- a/JiraPS/Public/Invoke-JiraMethod.ps1
+++ b/JiraPS/Public/Invoke-JiraMethod.ps1
@@ -48,12 +48,12 @@
         [System.Management.Automation.Credential()]
         $Credential = [System.Management.Automation.PSCredential]::Empty,
 
-        # [Parameter( DontShow )]
+        [Parameter( DontShow )]
         [ValidateNotNullOrEmpty()]
         [System.Management.Automation.PSCmdlet]
         $Cmdlet = $PSCmdlet,
 
-        # [Parameter( DontShow )]
+        [Parameter( DontShow )]
         [int]
         $_RetryCount = 0,
 

--- a/Tests/Help.Tests.ps1
+++ b/Tests/Help.Tests.ps1
@@ -55,8 +55,15 @@ Describe "Help tests" -Tag "Documentation", "Build" {
     Describe "Public Functions" {
         Context "Command <_.CommandName>" -ForEach $commands {
             BeforeDiscovery {
-                # Exclude default params and internal params (starting with underscore)
-                $script:parameters = $_.Command.Parameters.Keys | Where-Object { $_ -notin $DefaultParams -and $_ -notmatch '^_' }
+                # Exclude default params and any parameter marked [Parameter(DontShow)],
+                # which is the principled signal for "internal, not part of the public surface".
+                $cmd = $_.Command
+                $isDontShow = {
+                    param($name)
+                    $paramAttr = $cmd.Parameters[$name].Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] }
+                    return ($paramAttr.DontShow -contains $true)
+                }
+                $script:parameters = $cmd.Parameters.Keys | Where-Object { $_ -notin $DefaultParams -and -not (& $isDontShow $_) }
             }
             BeforeAll {
                 $script:command = $_.Command
@@ -146,6 +153,24 @@ Describe "Help tests" -Tag "Documentation", "Build" {
                     $command.HelpUri | Should -Match $pattern
                 }
 
+                It "does not emit mangled input/output type names" {
+                    # Regression guard for the PlatyPS 1.0 input/output heading parser bug:
+                    # bracketed headings like '### [JiraPS.Issue[]]' would yield single-character
+                    # type names such as '[', ']', or 'e'. Anything <= 1 char or starting with a
+                    # bracket character is almost certainly a regression.
+                    $typeNames = @(
+                        @($help.inputTypes.inputType) +
+                        @($help.returnValues.returnValue)
+                    ) | Where-Object { $_ } | ForEach-Object {
+                        if ($_.type -and $_.type.name) { ($_.type.name -as [String]).Trim() }
+                    }
+                    foreach ($typeName in $typeNames) {
+                        if ([string]::IsNullOrEmpty($typeName)) { continue }
+                        $typeName | Should -Not -Match '^[\[\]]$' -Because "type names should never be a stray bracket character"
+                        $typeName.Length | Should -BeGreaterThan 1 -Because "single-character type names indicate a parser regression in INPUTS/OUTPUTS"
+                    }
+                }
+
                 # It "does not define parameter position for functions with only one ParameterSet" {
                 #     if ($command.ParameterSets.Count -eq 1) {
                 #         $command.Parameters.Keys | Foreach-Object {
@@ -188,6 +213,34 @@ Describe "Help tests" -Tag "Documentation", "Build" {
                         if ($helpType -eq "Switch") { $helpType = "SwitchParameter" }
 
                         $helpType | Should -Be $codeType
+                    }
+
+                    It "preserves alias metadata in help" {
+                        # Regression guard for the PlatyPS 1.0 MAML round-trip dropping every
+                        # parameter's alias attribute. Compare reflected aliases against help.
+                        $codeAliases = @($parameterCode.Aliases | Sort-Object)
+                        if ($codeAliases.Count -eq 0) { return }
+
+                        $helpAliasField = ($parameterHelp.aliases -as [String]).Trim()
+                        $helpAliases = @()
+                        if ($helpAliasField -and $helpAliasField -ne 'None' -and $helpAliasField -ne 'none') {
+                            $helpAliases = @($helpAliasField -split '[,\s]+' | Where-Object { $_ } | Sort-Object)
+                        }
+
+                        $helpAliases | Should -Be $codeAliases -Because "every alias declared on the parameter must be reachable through Get-Help"
+                    }
+
+                    It "preserves pipeline input flag in help" {
+                        # Regression guard for the PlatyPS 1.0 round-trip dropping the
+                        # pipelineInput attribute (every parameter ended up with "false").
+                        $byValue = $parameterCode.ParameterSets.Values.ValueFromPipeline -contains $true
+                        $byProperty = $parameterCode.ParameterSets.Values.ValueFromPipelineByPropertyName -contains $true
+                        $codeAcceptsPipeline = $byValue -or $byProperty
+
+                        $helpField = ($parameterHelp.pipelineInput -as [String]).Trim()
+                        $helpAcceptsPipeline = $helpField -match '^[Tt]rue'
+
+                        $helpAcceptsPipeline | Should -Be $codeAcceptsPipeline -Because "Get-Help must reflect the actual pipeline-input behaviour declared by [Parameter()]"
                     }
                 }
 


### PR DESCRIPTION
## Summary

Follow-up to #582 (PlatyPS 0.14 → 1.0.1 upgrade) and #587 (CI redesign).

`Microsoft.PowerShell.PlatyPS` 1.0.1's `Export-MamlCommandHelp` drops or mangles metadata on every build, regardless of source markdown:

| Symptom in `JiraPS-help.xml` | Effect on `Get-Help` |
| --- | --- |
| Every `<command:parameter>` gets `aliases=\"none\"` and `pipelineInput=\"false\"` | All parameter aliases and pipeline binding flags vanish |
| `<dev:defaultValue>` is never written | Default values disappear |
| `### [Type]` INPUTS/OUTPUTS headings collapse to a literal `[` | Typed pipeline I/O renders as `[` |
| Fenced example code stays inside `maml:introduction` | `Get-Help -Examples` shows raw markdown instead of split code/remarks |

These are repaired in a single post-processing pass in `GenerateExternalHelp`:

- **`Repair-MamlMetadata`** re-applies `aliases` and `pipelineInput` from **live reflection** (`Module.ExportedCommands[...].Parameters`), so the source code is the single source of truth and the markdown cannot drift out of sync.
- INPUTS/OUTPUTS typenames and `defaultValue` come from the **Markdig-parsed `CommandHelp` object**, whose parser strips the brackets correctly.
- Examples are split into `dev:code` (first fenced block) + `dev:remarks/maml:para` (surrounding prose); a warning is emitted when an example contains more than one fence.

Plus a few quality-of-life follow-ups:

- Hide the internal `-Cmdlet` and `-_RetryCount` parameters on \`Invoke-JiraMethod\` via \`[Parameter(DontShow)]\` (tab-completion only; \`Get-Help\` still documents \`-Cmdlet\` by design).
- Harden \`GenerateExternalHelp\`: assert imported-help count matches markdown count, assert the MAML file is produced, write about-topic files as UTF-8-with-BOM, tighten the italics regex to word boundaries, accept any language tag on code fences.
- Add regression tests in \`Help.Tests.ps1\` that fail loudly if aliases, pipeline binding, or bracket-free INPUTS/OUTPUTS ever go missing again, and filter \`[Parameter(DontShow)]\` parameters from the documented-parameter set.

## Why reflection over markdown patching

The first iteration patched the 60 markdown files to add \`Aliases:\` and \`Accept pipeline input:\` lines. That was reverted in favor of reflection because:

1. PlatyPS 1.0 ignores those markdown fields anyway — they always end up as \`aliases=\"none\"\` / \`pipelineInput=\"false\"\` in the MAML.
2. Reflection makes the **PowerShell source the single source of truth**; markdown can never drift.
3. Zero changes to \`docs/en-US/commands/*.md\` keeps the docs-site PR surface clean.

## Test plan

- [x] \`Invoke-Build -Task Lint\` — 6 style tests pass, 0 PSScriptAnalyzer findings
- [x] \`Invoke-Build -Task Build\` — clean MAML written
- [x] \`Invoke-Build -Task Test\` — **3662 passed / 0 failed / 65 skipped** (integration only)
- [x] \`Get-Help\` smoke test against the freshly-built module:
  - \`Invoke-JiraMethod\`: 19 documented parameters (no \`_RetryCount\` leak), \`OUTPUTS=System.Management.Automation.PSCustomObject\` (no brackets), 11 examples with split code/remarks
  - \`Get-JiraIssue -Key\`: \`aliases=Issue\`, \`pipelineInput=True (ByPropertyName)\`
- [ ] Reviewer: confirm the docs site renders unchanged (no markdown was modified)
- [ ] Reviewer: spot-check \`Get-Help -Full\` output for a few cmdlets you regularly use

## Follow-ups (not in this PR)

A future PR can regenerate \`docs/en-US/commands/*.md\` in PlatyPS 1.0 native schema using \`Import-MamlHelp\` → \`Export-MarkdownCommandHelp\`, preserve hand-authored prose and docs-site frontmatter, and then delete the post-processing here. Tracked separately so this fix can ship immediately.

Made with [Cursor](https://cursor.com)