### PR TITLE
build: exclude Tests/Integration from Test task discovery

### DIFF
--- a/JiraPS.build.ps1
+++ b/JiraPS.build.ps1
@@ -529,10 +529,9 @@ Task SetVersion {
 }
 
 Task Test {
-    # Exclude the Integration folder from discovery entirely (rather than just
-    # filtering by ExcludeTag) so Pester doesn't run their BeforeDiscovery
-    # blocks, import the module redundantly, or list skipped integration
-    # tests in the output. Use TestIntegration task to run integration tests.
+    # Skip the Integration folder at discovery time so Pester does not run
+    # its BeforeDiscovery blocks (which read .env and warn when integration
+    # secrets are missing). Use TestIntegration task to run them.
     $integrationPath = Join-Path $env:BHBuildOutput 'Tests/Integration'
 
     $pesterConfigHash = @{
@@ -550,14 +549,11 @@ Task Test {
             Verbosity = $PesterVerbosity
         }
         Filter     = @{
-            # Belt-and-braces: also exclude the Integration tag so any
-            # integration-tagged tests living outside Tests/Integration get
-            # filtered too.
-            #
-            # In Pester 5, ExcludeTag takes precedence over Tag. To make
-            # `Invoke-Build -Task Test -Tag 'Integration'` actually do something
-            # useful, the -Tag handling below removes any explicitly requested
-            # tags from this default exclusion list AND clears the ExcludePath.
+            # Also exclude by tag, in case any integration-tagged tests live
+            # outside Tests/Integration. In Pester 5, ExcludeTag takes
+            # precedence over Tag, so the -Tag handling below has to remove
+            # user-requested tags from this list (and clear ExcludePath) for
+            # `Invoke-Build -Task Test -Tag 'Integration'` to do anything.
             ExcludeTag = @('Integration')
         }
         <# CodeCoverage = @{
@@ -567,12 +563,7 @@ Task Test {
 
     if ($Tag) {
         $pesterConfigHash.Filter.Tag = $Tag
-        # Drop user-requested tags from the default exclusion list so that
-        # ExcludeTag's higher precedence in Pester 5 does not silently zero
-        # out the user's selection.
         $pesterConfigHash.Filter.ExcludeTag = @($pesterConfigHash.Filter.ExcludeTag | Where-Object { $_ -notin $Tag })
-        # If the user explicitly asked for Integration tests, allow discovery
-        # of the Integration folder again.
         if ('Integration' -in $Tag) {
             $pesterConfigHash.Run.ExcludePath = @()
         }

--- a/JiraPS.build.ps1
+++ b/JiraPS.build.ps1
@@ -529,10 +529,17 @@ Task SetVersion {
 }
 
 Task Test {
+    # Exclude the Integration folder from discovery entirely (rather than just
+    # filtering by ExcludeTag) so Pester doesn't run their BeforeDiscovery
+    # blocks, import the module redundantly, or list skipped integration
+    # tests in the output. Use TestIntegration task to run integration tests.
+    $integrationPath = Join-Path $env:BHBuildOutput 'Tests/Integration'
+
     $pesterConfigHash = @{
         Run        = @{
-            PassThru = $true
-            Path     = "$env:BHBuildOutput/Tests"
+            PassThru    = $true
+            Path        = "$env:BHBuildOutput/Tests"
+            ExcludePath = @($integrationPath)
         }
         TestResult = @{
             Enabled      = $true
@@ -543,13 +550,14 @@ Task Test {
             Verbosity = $PesterVerbosity
         }
         Filter     = @{
-            # Exclude integration tests by default - they require external configuration
-            # and have their own CI workflow. Use TestIntegration task to run them.
+            # Belt-and-braces: also exclude the Integration tag so any
+            # integration-tagged tests living outside Tests/Integration get
+            # filtered too.
             #
             # In Pester 5, ExcludeTag takes precedence over Tag. To make
             # `Invoke-Build -Task Test -Tag 'Integration'` actually do something
             # useful, the -Tag handling below removes any explicitly requested
-            # tags from this default exclusion list.
+            # tags from this default exclusion list AND clears the ExcludePath.
             ExcludeTag = @('Integration')
         }
         <# CodeCoverage = @{
@@ -563,6 +571,11 @@ Task Test {
         # ExcludeTag's higher precedence in Pester 5 does not silently zero
         # out the user's selection.
         $pesterConfigHash.Filter.ExcludeTag = @($pesterConfigHash.Filter.ExcludeTag | Where-Object { $_ -notin $Tag })
+        # If the user explicitly asked for Integration tests, allow discovery
+        # of the Integration folder again.
+        if ('Integration' -in $Tag) {
+            $pesterConfigHash.Run.ExcludePath = @()
+        }
         Write-Build Gray "Filtering tests by tag(s): $($Tag -join ', ')"
     }
 

--- a/Tests/Integration/Search.Integration.Tests.ps1
+++ b/Tests/Integration/Search.Integration.Tests.ps1
@@ -114,9 +114,6 @@ InModuleScope JiraPS {
             }
 
             Context "Pagination" {
-                # Get-JiraIssue uses [CmdletBinding(SupportsPaging)], which exposes the
-                # standard PowerShell paging parameters -First / -Skip / -IncludeTotalCount.
-                # There is no -MaxResults or -StartIndex parameter.
                 It "supports -First parameter" {
                     if ([string]::IsNullOrEmpty($fixtures.TestProject)) {
                         Set-ItResult -Skipped -Because "JIRA_TEST_PROJECT not configured"

--- a/Tests/Integration/Search.Integration.Tests.ps1
+++ b/Tests/Integration/Search.Integration.Tests.ps1
@@ -114,19 +114,22 @@ InModuleScope JiraPS {
             }
 
             Context "Pagination" {
-                It "supports -MaxResults parameter" {
+                # Get-JiraIssue uses [CmdletBinding(SupportsPaging)], which exposes the
+                # standard PowerShell paging parameters -First / -Skip / -IncludeTotalCount.
+                # There is no -MaxResults or -StartIndex parameter.
+                It "supports -First parameter" {
                     if ([string]::IsNullOrEmpty($fixtures.TestProject)) {
                         Set-ItResult -Skipped -Because "JIRA_TEST_PROJECT not configured"
                         return
                     }
                     $jql = "project = $($fixtures.TestProject)"
 
-                    $results = Get-JiraIssue -Query $jql -MaxResults 1
+                    $results = Get-JiraIssue -Query $jql -First 1
 
                     @($results).Count | Should -BeLessOrEqual 1
                 }
 
-                It "supports -StartIndex parameter" {
+                It "supports -Skip parameter" {
                     if ([string]::IsNullOrEmpty($fixtures.TestProject)) {
                         Set-ItResult -Skipped -Because "JIRA_TEST_PROJECT not configured"
                         return
@@ -135,14 +138,14 @@ InModuleScope JiraPS {
                     # Skip on Jira Cloud - the startAt parameter doesn't work reliably
                     # with small result sets on Cloud instances
                     if ($fixtures.CloudUrl -match 'atlassian\.net') {
-                        Set-ItResult -Skipped -Because "StartIndex pagination is unreliable on Jira Cloud"
+                        Set-ItResult -Skipped -Because "Skip-based pagination is unreliable on Jira Cloud"
                         return
                     }
 
                     $jql = "project = $($fixtures.TestProject) ORDER BY key ASC"
 
-                    $firstPage = Get-JiraIssue -Query $jql -MaxResults 1 -StartIndex 0
-                    $secondPage = Get-JiraIssue -Query $jql -MaxResults 1 -StartIndex 1
+                    $firstPage = Get-JiraIssue -Query $jql -First 1 -Skip 0
+                    $secondPage = Get-JiraIssue -Query $jql -First 1 -Skip 1
 
                     # If there's a second page with results, verify it's different from first
                     if ($secondPage -and @($secondPage).Count -gt 0) {
@@ -223,7 +226,7 @@ InModuleScope JiraPS {
                         return
                     }
                     # Limit to 1 result to avoid long pagination on filters with many matches
-                    $results = Get-JiraIssue -Filter $fixtures.TestFilter -MaxResults 1
+                    $results = Get-JiraIssue -Filter $fixtures.TestFilter -First 1
 
                     $results | Should -BeOfType [PSCustomObject]
                 }


### PR DESCRIPTION
## Summary

Two independent dev-only fixes around the unit-test task and the smoke integration tests.

### `Invoke-Build -Task Test` no longer touches integration test files

Pester's `Filter.ExcludeTag = @('Integration')` only filters at run time — it still **discovers** every file under `Tests/`, which means each `Tests/Integration/*.Integration.Tests.ps1` runs its `BeforeDiscovery` block. Those blocks call `Initialize-IntegrationEnvironment`, which reads `.env` and emits warnings on developer machines without integration secrets configured.

Add `Run.ExcludePath = @("$env:BHBuildOutput/Tests/Integration")` so the Integration folder is skipped at discovery time. The existing `ExcludeTag` filter is kept as a fallback in case any `Integration`-tagged tests live outside that folder. `Invoke-Build -Task Test -Tag 'Integration'` still works: when the user explicitly opts in to the `Integration` tag, both the path exclusion and the tag exclusion are cleared.

### Fix two failing smoke tests in `Search.Integration.Tests.ps1`

`Get-JiraIssue` declares `[CmdletBinding(SupportsPaging)]`, which exposes the standard PowerShell paging parameters `-First`, `-Skip`, `-IncludeTotalCount`. There is no `-MaxResults` or `-StartIndex`. Three call sites in `Search.Integration.Tests.ps1` were using the wrong parameter names; two of them (`supports -MaxResults parameter` and `retrieves issues using a saved filter ID`) failed every smoke run, the third (`supports -StartIndex parameter`) was masked by an existing Cloud-skip but would have failed on Server. All three call sites and the affected test names are updated to match the actual paging contract.

CI (smoke tests) still runs on every PR — that behaviour is intentional and unchanged.

## Test plan

- [x] `Invoke-Build -Task Build, Test` locally — green; 121 files / 4022 tests discovered (no integration files), 3735 passed, 0 failed, no `.env` warnings emitted.
- [x] Verified `-Tag 'Integration'` still clears the path exclusion (opt-in path).
- [x] `rg` confirms no remaining `-MaxResults` / `-StartIndex` call sites under `Tests/`.
- [ ] CI green (Lint + Test on the matrix, plus smoke tests).