### PR TITLE
Fix garbled "No metadata found for project  and issueType ." error in Get-JiraIssueEditMetadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,10 @@ See [`about_JiraPS_MigrationV3`](https://atlassianps.org/docs/JiraPS/about/migra
 - Fixed config file parsing to handle both CRLF and LF line endings correctly
 - `Get-JiraIssueCreateMetadata` now walks all pages of the Jira Cloud createmeta response instead of truncating at the default page size. The cmdlet opts into `SupportsPaging`, so `-First`, `-Skip`, and `-IncludeTotalCount` are also supported.
 - Fixed stale documentation for `New-JiraIssue -Reporter`: the reference page reported `Accept pipeline input: False`, but the parameter has accepted `ValueFromPipelineByPropertyName` since v2. The Markdown source and regenerated `JiraPS-help.xml` now reflect the actual binding.
+- Fixed `Get-JiraIssueEditMetadata` emitting `"No metadata found for project  and issueType ."` (with empty interpolated values) when an issue lookup failed.
+  The null-result `ErrorRecord` interpolated `$Project` and `$IssueType`, neither of which is a parameter of this cmdlet, so the message was always garbled.
+  It now references the actual `-Issue` parameter and uses `$PSCmdlet.ThrowTerminatingError` to match other JiraPS cmdlets.
+  The same `if ($result)` block also carried four `Write-Error` branches that validated the createmeta envelope shape (`$result.fields.projects` / `.issuetypes`) — fields the editmeta endpoint never returns, so those branches were unreachable dead code copy-pasted from `Get-JiraIssueCreateMetadata` and have been removed.
 
 ## 3.0 - 2026-04-17
 

--- a/JiraPS/Public/Get-JiraIssueEditMetadata.ps1
+++ b/JiraPS/Public/Get-JiraIssueEditMetadata.ps1
@@ -44,50 +44,16 @@
         Write-Debug ($result | Out-String)
 
         if ($result) {
-            if (@($result.fields.projects).Count -eq 0) {
-                $errorMessage = @{
-                    Category         = "InvalidResult"
-                    CategoryActivity = "Validating response"
-                    Message          = "No projects were found for the given project [$Project]. Use Get-JiraProject for more details."
-                }
-                Write-Error @errorMessage
-            }
-            elseif (@($result.fields.projects).Count -gt 1) {
-                $errorMessage = @{
-                    Category         = "InvalidResult"
-                    CategoryActivity = "Validating response"
-                    Message          = "Multiple projects were found for the given project [$Project]. Refine the parameters to return only one project."
-                }
-                Write-Error @errorMessage
-            }
-
-            if (@($result.fields.projects.issuetypes) -eq 0) {
-                $errorMessage = @{
-                    Category         = "InvalidResult"
-                    CategoryActivity = "Validating response"
-                    Message          = "No issue types were found for the given issue type [$IssueType]. Use Get-JiraIssueType for more details."
-                }
-                Write-Error @errorMessage
-            }
-            elseif (@($result.fields.projects.issuetypes).Count -gt 1) {
-                $errorMessage = @{
-                    Category         = "InvalidResult"
-                    CategoryActivity = "Validating response"
-                    Message          = "Multiple issue types were found for the given issue type [$IssueType]. Refine the parameters to return only one issue type."
-                }
-                Write-Error @errorMessage
-            }
-
             Write-Output (ConvertTo-JiraEditMetaField -InputObject $result)
         }
         else {
             $exception = ([System.ArgumentException]"No results")
             $errorId = 'IssueMetadata.ObjectNotFound'
             $errorCategory = 'ObjectNotFound'
-            $errorTarget = $Project
+            $errorTarget = $Issue
             $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
-            $errorItem.ErrorDetails = "No metadata found for project $Project and issueType $IssueType."
-            throw $errorItem
+            $errorItem.ErrorDetails = "No edit metadata found for issue [$Issue]."
+            $PSCmdlet.ThrowTerminatingError($errorItem)
         }
     }
 

--- a/Tests/Functions/Public/Get-JiraIssueEditMetadata.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraIssueEditMetadata.Unit.Tests.ps1
@@ -230,10 +230,45 @@ InModuleScope JiraPS {
                     { Get-JiraIssueEditMetadata -Issue $issueID } | Should -Not -Throw
                     Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1
 
-                    # There are 2 example fields in our mock above, but they should
-                    # be passed to Convert-JiraCreateMetaField as a single object.
-                    # The method should only be called once.
+                    # The editmeta endpoint returns a single envelope { fields: { fieldId: ... } }
+                    # which is forwarded to ConvertTo-JiraEditMetaField as one object,
+                    # so the converter is invoked exactly once per call.
                     Should -Invoke ConvertTo-JiraEditMetaField -ModuleName JiraPS -Exactly -Times 1
+                }
+
+                It "Does not write to the error stream on a successful call" {
+                    $errorsBefore = $global:Error.Count
+                    $null = Get-JiraIssueEditMetadata -Issue $issueID
+                    ($global:Error.Count - $errorsBefore) | Should -Be 0
+                }
+            }
+        }
+
+        Describe "Error handling" {
+            Context "When the API returns no body" {
+                BeforeAll {
+                    Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $URI -like "*$issueID/editmeta" } { $null }
+                }
+
+                It "Throws a terminating ObjectNotFound error when no metadata is returned" {
+                    { Get-JiraIssueEditMetadata -Issue $issueID -ErrorAction Stop } |
+                        Should -Throw -ErrorId 'IssueMetadata.ObjectNotFound,Get-JiraIssueEditMetadata'
+                }
+
+                It "References the -Issue parameter in the error message instead of the legacy 'project ... issueType ...' template" {
+                    $caught = $null
+                    try {
+                        Get-JiraIssueEditMetadata -Issue $issueID -ErrorAction Stop
+                    }
+                    catch {
+                        $caught = $_
+                    }
+
+                    $caught | Should -Not -BeNullOrEmpty
+                    $message = "$($caught.ErrorDetails)"
+                    $message | Should -Match ([regex]::Escape("$issueID"))
+                    $message | Should -Not -Match 'No metadata found for project'
+                    $message | Should -Not -Match 'and issueType'
                 }
             }
         }


### PR DESCRIPTION
## Summary

`Get-JiraIssueEditMetadata`'s null-result throw built an `ErrorRecord` whose message interpolated `$Project` and `$IssueType` — neither of which is a parameter of this cmdlet. When an issue lookup failed, users saw the literal string `"No metadata found for project  and issueType ."` with empty interpolated values instead of a useful error.

The fix:
- Null-result branch now references the actual `-Issue` parameter and uses `$PSCmdlet.ThrowTerminatingError` to match other JiraPS cmdlets.
- The same `if ($result) { ... } else { ... }` block also carried four post-call `Write-Error` branches that validated `$result.fields.projects` / `.issuetypes` — fields the editmeta endpoint never returns. The conditions (`@($null).Count -eq 0`, `@($null) -eq 0`, etc.) never matched on a real editmeta envelope, so the branches were unreachable dead code copy-pasted from `Get-JiraIssueCreateMetadata` that referenced the same nonexistent `$Project` / `$IssueType` variables; removed.

## Tests

- **Regression**: assert the new error message references the issue ID and does not contain the legacy `"No metadata found for project"` / `"and issueType"` template (would fail against pre-fix code).
- **Contract**: assert the error stream stays empty on a successful call.

## Test plan

- [x] `Invoke-Build -Task Lint` → PSScriptAnalyzer + style checks clean
- [x] `Invoke-Build -Task Build, Test` → 3738 passed, 0 failed
- [x] Targeted: `Invoke-Pester Release/Tests/Functions/Public/Get-JiraIssueEditMetadata.Unit.Tests.ps1` → 5/5 passed
- [x] Help tests: `Invoke-Pester Release/Tests/Help.Tests.ps1` → no regressions for `Get-JiraIssueEditMetadata`

## Cloud / Data Center

Both deployment types return the same flat `{ fields: { fieldId: ... } }` envelope from `/rest/api/2/issue/{key}/editmeta`, so the fix is deployment-agnostic.


Made with [Cursor](https://cursor.com)