### PR TITLE
test(help): add reverse-direction parameter drift guard

### DIFF
--- a/Tests/Help.Tests.ps1
+++ b/Tests/Help.Tests.ps1
@@ -273,12 +273,9 @@ Describe "Help tests" -Tag "Documentation", "Build" {
                 }
 
                 It "documents every public parameter exposed by the code" {
-                    # Reverse-direction drift guard: catches new parameters added
-                    # to a function whose markdown was never updated. The
-                    # existing "...not in the code" test only catches the other
-                    # direction (orphan doc entries). Re-derive the public
-                    # surface here so the It block does not depend on
-                    # discovery-phase script state ($parameters, $DefaultParams).
+                    # Re-derive the public surface from $command instead of
+                    # reusing $parameters / $DefaultParams: those are set in
+                    # BeforeDiscovery and not reliably visible from It blocks.
                     $help = $_.Help
 
                     $documented = @()
@@ -293,16 +290,12 @@ Describe "Help tests" -Tag "Documentation", "Build" {
                         'WhatIf', 'Confirm'
                     )
 
-                    $publicCodeParams = $command.Parameters.Keys | Where-Object {
-                        $_ -notin $commonParams -and
-                        -not (
-                            $command.Parameters[$_].Attributes |
-                                Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.DontShow }
-                        )
-                    }
+                    foreach ($paramName in $command.Parameters.Keys) {
+                        if ($paramName -in $commonParams) { continue }
+                        $paramAttr = $command.Parameters[$paramName].Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] }
+                        if ($paramAttr.DontShow -contains $true) { continue }
 
-                    foreach ($codeParm in $publicCodeParams) {
-                        $documented | Should -Contain $codeParm -Because "every public parameter must be documented in docs/en-US/commands/$($command.Name).md (or marked [Parameter(DontShow)] if it is internal)"
+                        $documented | Should -Contain $paramName -Because "every public parameter must be documented in docs/en-US/commands/$($command.Name).md (or marked [Parameter(DontShow)] if it is internal)"
                     }
                 }
             }

--- a/Tests/Help.Tests.ps1
+++ b/Tests/Help.Tests.ps1
@@ -273,9 +273,6 @@ Describe "Help tests" -Tag "Documentation", "Build" {
                 }
 
                 It "documents every public parameter exposed by the code" {
-                    # Re-derive the public surface from $command instead of
-                    # reusing $parameters / $DefaultParams: those are set in
-                    # BeforeDiscovery and not reliably visible from It blocks.
                     $help = $_.Help
 
                     $documented = @()
@@ -283,15 +280,8 @@ Describe "Help tests" -Tag "Documentation", "Build" {
                         $documented = @($help.Parameters.Parameter.Name)
                     }
 
-                    $commonParams = @(
-                        'Verbose', 'Debug', 'ErrorAction', 'WarningAction', 'InformationAction'
-                        'ErrorVariable', 'WarningVariable', 'InformationVariable'
-                        'OutVariable', 'OutBuffer', 'PipelineVariable', 'ProgressAction'
-                        'WhatIf', 'Confirm'
-                    )
-
                     foreach ($paramName in $command.Parameters.Keys) {
-                        if ($paramName -in $commonParams) { continue }
+                        if ($paramName -in $DefaultParams) { continue }
                         $paramAttr = $command.Parameters[$paramName].Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] }
                         if ($paramAttr.DontShow -contains $true) { continue }
 

--- a/Tests/Help.Tests.ps1
+++ b/Tests/Help.Tests.ps1
@@ -271,6 +271,40 @@ Describe "Help tests" -Tag "Documentation", "Build" {
                         $command.Parameters.Keys | Should -Contain $helpParm
                     }
                 }
+
+                It "documents every public parameter exposed by the code" {
+                    # Reverse-direction drift guard: catches new parameters added
+                    # to a function whose markdown was never updated. The
+                    # existing "...not in the code" test only catches the other
+                    # direction (orphan doc entries). Re-derive the public
+                    # surface here so the It block does not depend on
+                    # discovery-phase script state ($parameters, $DefaultParams).
+                    $help = $_.Help
+
+                    $documented = @()
+                    if ($help.Parameters | Get-Member -Name Parameter) {
+                        $documented = @($help.Parameters.Parameter.Name)
+                    }
+
+                    $commonParams = @(
+                        'Verbose', 'Debug', 'ErrorAction', 'WarningAction', 'InformationAction'
+                        'ErrorVariable', 'WarningVariable', 'InformationVariable'
+                        'OutVariable', 'OutBuffer', 'PipelineVariable', 'ProgressAction'
+                        'WhatIf', 'Confirm'
+                    )
+
+                    $publicCodeParams = $command.Parameters.Keys | Where-Object {
+                        $_ -notin $commonParams -and
+                        -not (
+                            $command.Parameters[$_].Attributes |
+                                Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.DontShow }
+                        )
+                    }
+
+                    foreach ($codeParm in $publicCodeParams) {
+                        $documented | Should -Contain $codeParm -Because "every public parameter must be documented in docs/en-US/commands/$($command.Name).md (or marked [Parameter(DontShow)] if it is internal)"
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
`Tests/Help.Tests.ps1` enforces **markdown ⊆ code** (the existing `does not have parameters that are not in the code`) but not the reverse. A parameter added to a public function whose markdown was never updated would ship undocumented.

Add the inverse assertion in the same `Parameter` context. "Public" matches the per-parameter discovery filter at lines 58–66: skip `$DefaultParams` (the 14 common parameters plus `-WhatIf` / `-Confirm`), skip anything marked `[Parameter(DontShow)]`. The `-Because` clause names both fix paths — update the markdown, or mark the parameter `[Parameter(DontShow)]` if it is internal.

## Test plan

- [x] `Invoke-Build -Task Lint, Build, Test` — 3799 passed, 0 failed.
- [x] New `It` fires 64× (once per public command), all pass against current docs — no existing drift.