### PR TITLE
chore(infra): backlog issue template + AGENTS.md backlog handling rule

### DIFF
--- a/.github/ISSUE_TEMPLATE/backlog-idea.yml
+++ b/.github/ISSUE_TEMPLATE/backlog-idea.yml
@@ -1,0 +1,68 @@
+name: Backlog idea
+description: File a refactor / cleanup / follow-up that should live on the JiraPS Backlog board.
+title: "[Backlog] "
+labels: ["Backlog"]
+projects: ["AtlassianPS/2"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for ideas that come out of a chat, code review, or audit and that should be tracked on the **JiraPS Backlog** project board so they don't get lost between worktrees.
+        Active bugs go to *Bug report*; new user-facing features go to *Feature request*.
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: What did you observe and why does it matter?
+      placeholder: |
+        Linked transcript, PR, code path, audit finding, or chat log.
+        Plain prose is fine — one sentence per line.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: What is the change you have in mind?
+      placeholder: |
+        The shape of the work, not the implementation steps.
+        Mention the files / cmdlets / classes you expect to touch.
+    validations:
+      required: true
+  - type: textarea
+    id: tradeoffs
+    attributes:
+      label: Trade-offs
+      description: Why might we *not* do this, or do it differently?
+      placeholder: |
+        Backward-compat risk, scope creep, test cost, alternative designs.
+        "None" is a valid answer when it's truly trivial.
+    validations:
+      required: false
+  - type: textarea
+    id: related
+    attributes:
+      label: Related items
+      description: PRs, other issues, transcripts, or external docs that share context.
+      placeholder: |
+        - #NNN
+        - chat: <transcript link>
+        - upstream: https://...
+    validations:
+      required: false
+  - type: dropdown
+    id: theme
+    attributes:
+      label: Theme (set on the project board after triage)
+      description: Pick the closest fit. Triage may move this.
+      options:
+        - TypeSystem
+        - Docs
+        - Cmdlets
+        - API
+        - Tests
+        - Build
+        - Other
+      default: 6
+    validations:
+      required: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,11 @@ Invoke-Build -Task Build, Test
 ```
 Tests run against the built module in `Release/` — you must build before testing.
 
+### Backlog Handling
+- **Out-of-scope ideas go on the board, not into the current PR.**
+  File them as `Backlog idea` issues — see [Filing a Backlog Idea](#filing-a-backlog-idea).
+- Board: [`AtlassianPS/JiraPS` · Project 2 — *JiraPS Backlog*](https://github.com/orgs/AtlassianPS/projects/2)
+
 ---
 
 ## AI Tool Compatibility
@@ -388,6 +393,56 @@ function Get-JiraExample {
 ```
 
 6. **Build and test**: `Invoke-Build -Task Build, Test`
+
+### Filing a Backlog Idea
+
+> **RULE**: When a chat, code review, or audit produces a follow-up that does not belong in the current PR, file it as a `Backlog idea` issue **before** the conversation ends.
+> Worktrees and chat transcripts are not durable backlog storage.
+
+The repository ships a dedicated GitHub issue form (`.github/ISSUE_TEMPLATE/backlog-idea.yml`) and a repo-scoped GitHub Project board for triage.
+The form auto-applies the `Backlog` label and adds the issue to the project on submit, so the only manual triage step is setting `Theme`, `Effort`, and `Priority` on the board.
+
+| Where | What |
+|-------|------|
+| Issue template | `.github/ISSUE_TEMPLATE/backlog-idea.yml` (Context / Proposal / Trade-offs / Related items) |
+| Label | `Backlog` (applied automatically by the template) |
+| Theme labels | `Theme:TypeSystem` (more added as themes emerge) |
+| Project board | [AtlassianPS · Project 2 — *JiraPS Backlog*](https://github.com/orgs/AtlassianPS/projects/2) — custom fields: `Theme`, `Effort` (S/M/L/XL), `Priority` (P0–P3) |
+
+**File via UI:**
+
+1. Open *New issue* on `AtlassianPS/JiraPS` → choose **Backlog idea**.
+2. Fill in *Context*, *Proposal*, *Trade-offs* (optional), *Related items* (optional).
+3. Submit.
+   The `Backlog` label and the project board entry are applied automatically; pick `Theme`, `Effort`, and `Priority` on the board.
+
+**File via CLI** (one-shot, from any worktree):
+
+```bash
+gh issue create \
+    --repo AtlassianPS/JiraPS \
+    --title "[Backlog] <one-line summary>" \
+    --label Backlog \
+    --body "$(cat <<'EOF'
+## Context
+…
+
+## Proposal
+…
+
+## Trade-offs
+…
+
+## Related items
+…
+EOF
+)"
+
+# Then attach to the project board:
+gh project item-add 2 --owner AtlassianPS --url <issue-url>
+```
+
+When linking an idea that came out of a chat, paste the transcript link into *Related items* so the design rationale is one click away.
 
 ### Releasing a New Version
 


### PR DESCRIPTION
## Summary

Promote the chat-driven brainstorm workflow into a real, board-tracked one so out-of-scope ideas stop dying in worktrees and chat transcripts.

- New issue form `.github/ISSUE_TEMPLATE/backlog-idea.yml` with **Context / Proposal / Trade-offs / Related items**, auto-applies the `Backlog` label and auto-adds the issue to the *JiraPS Backlog* project (#2 on AtlassianPS).
- `AGENTS.md` gains a Quick Reference *Backlog Handling* pointer and a full *Filing a Backlog Idea* section under *Common Tasks & Solutions* with both UI and CLI flows. The intent is that every AI tool that reads `AGENTS.md` enforces the same rule: out-of-scope ideas leave the PR and land on the board before the chat ends.

Server-side bits already provisioned:

- Labels `Backlog` and `Theme:TypeSystem` on `AtlassianPS/JiraPS`.
- Project [*JiraPS Backlog*](https://github.com/orgs/AtlassianPS/projects/2) (number 2) with single-select fields `Theme` (TypeSystem/Docs/Cmdlets/API/Tests/Build), `Effort` (S/M/L/XL), `Priority` (P0/P1/P2/P3).

## Test plan

- [x] `gh label list` shows both new labels.
- [x] `gh project field-list 2 --owner AtlassianPS` shows Theme/Effort/Priority custom fields.
- [ ] After merge: open *New issue* on the repo, confirm **Backlog idea** appears in the picker, the form renders, and submitting auto-labels the issue and attaches it to project 2.
- [ ] After merge: triage the four follow-up issues (filed in a separate workflow) onto the board and confirm Theme / Effort / Priority dropdowns work as expected.

Docs-only PR — CI pipeline skips per the existing `paths-ignore` rules; only the `CI Result` sentinel runs.

Made with [Cursor](https://cursor.com)