### PR TITLE
ci: add scheduled stale-resource sweeper workflow

### DIFF
--- a/.github/workflows/stale_cleanup.yml
+++ b/.github/workflows/stale_cleanup.yml
@@ -1,0 +1,54 @@
+name: Stale Test Resource Cleanup
+
+on:
+  schedule:
+    # Daily at 04:00 UTC. This is intentionally offset from the 06:00 UTC
+    # nightly Integration Tests run in integration_tests.yml so the two jobs
+    # never overlap on the shared Cloud test instance.
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+env:
+  JIRA_CLOUD_URL: ${{ secrets.JIRA_CLOUD_URL }}
+  JIRA_CLOUD_USERNAME: ${{ secrets.JIRA_CLOUD_USERNAME }}
+  JIRA_CLOUD_PASSWORD: ${{ secrets.JIRA_CLOUD_PASSWORD }}
+  JIRA_TEST_PROJECT: ${{ secrets.JIRA_TEST_PROJECT }}
+  JIRA_TEST_ISSUE: ${{ secrets.JIRA_TEST_ISSUE }}
+  JIRA_TEST_USER: ${{ secrets.JIRA_TEST_USER }}
+  JIRA_TEST_GROUP: ${{ secrets.JIRA_TEST_GROUP }}
+  JIRA_TEST_FILTER: ${{ secrets.JIRA_TEST_FILTER }}
+  JIRA_TEST_VERSION: ${{ secrets.JIRA_TEST_VERSION }}
+
+jobs:
+  sweep:
+    name: Sweep stale test resources
+    runs-on: ubuntu-latest
+    # Defense in depth: a schedule-only + workflow_dispatch workflow cannot be
+    # triggered by Dependabot or fork PRs today, but this guard protects
+    # against future trigger additions (e.g. workflow_call or pull_request).
+    # Mirrors the secrets-availability guard in integration_tests.yml.
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-powershell
+
+      # Running the Smoke-tagged integration tests is the lightest path that
+      # also exercises Connect-JiraTestServer, which calls Remove-StaleTestResource
+      # as a side effect (see Tests/Helpers/IntegrationTestTools.ps1). This
+      # validates connectivity at the same time without adding a new build
+      # task or duplicating cleanup logic.
+      - name: Run smoke tests (triggers stale-resource sweep)
+        run: |
+          Invoke-Build -Task TestIntegration -Tag 'Smoke' -PesterVerbosity Detailed
+        shell: pwsh
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v7
+        with:
+          name: Stale-Cleanup-Results
+          path: IntegrationTests.xml
+        if: failure()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,8 @@ See [`about_JiraPS_MigrationV3`](https://atlassianps.org/docs/JiraPS/about/migra
   - Replaced `Get-Member -MemberType *Property` lookups with direct `PSObject.Properties` access in `Format-Jira`, `Add-JiraIssueLink`, `Remove-JiraIssueLink`, `Resolve-JiraError`, `Expand-Result`, `ConvertTo-JiraCreateMetaField`, and `ConvertTo-JiraEditMetaField`.
 - Extracted user-reference payload construction into a private `Resolve-JiraUserPayload` helper shared by `Set-JiraIssue`, `Invoke-JiraIssueTransition`, and `New-JiraIssue` (and reusable for any future cmdlet that needs to point at a Jira user — assignee, reporter, etc.). As a side-effect, `Invoke-JiraIssueTransition -Unassign` on Jira Cloud now correctly emits `{accountId: null}` instead of `{name: ""}`. The helper also throws explicitly when handed a Cloud user object that has no `AccountId`, instead of silently emitting an unassign payload.
 - `New-JiraIssue -Reporter` now resolves the user via `Resolve-JiraUser` on Jira Server / Data Center too (previously only resolved on Jira Cloud). Typo'd usernames are now caught client-side instead of producing an opaque server error from the create endpoint.
+- Added daily scheduled `stale_cleanup.yml` workflow that sweeps `JiraPS-IntTest-` resources from the Cloud test instance as a safety net for periods of low CI activity.
+  It runs at 04:00 UTC (offset from the existing 06:00 UTC nightly Integration Tests run) and triggers cleanup by invoking the `Smoke`-tagged integration tests, which call `Connect-JiraTestServer` → `Remove-StaleTestResource` as a side effect.
 
 ### Fixed
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds `.github/workflows/stale_cleanup.yml`, a scheduled (daily at 04:00 UTC) GitHub Actions workflow that sweeps stale `JiraPS-IntTest-` resources from the Jira Cloud test instance.

## Why

`Connect-JiraTestServer` already calls `Remove-StaleTestResource` as a side effect, and the existing nightly `integration_tests.yml` (06:00 UTC) provides cleanup-as-a-side-effect when the full suite runs.
This new workflow is a **safety net** for periods of low CI activity (or for forks where the full integration suite is not regularly run): it triggers `Invoke-Build -Task TestIntegration -Tag 'Smoke'`, which connects to the test instance and runs the cleanup pass, without adding new build infrastructure.

## How

- Reuses the existing `./.github/actions/setup-powershell` composite action.
- Mirrors the `env:` block from `integration_tests.yml` exactly.
- `Invoke-Build -Task TestIntegration -Tag 'Smoke'` was chosen instead of inventing a new `'Cleanup'` Pester tag, because the smoke tests already trigger `Connect-JiraTestServer` (which fires `Remove-StaleTestResource`) and validate connectivity at the same time.
- `concurrency:` group is workflow-scoped with `cancel-in-progress: false`, so two scheduled or dispatched runs cannot overlap on the shared Cloud test instance.
- Artifact upload uses `if: failure()` (vs. `if: always()` in the existing workflow) — successful sweeper runs would otherwise produce noise; the file is only useful for diagnostics when a smoke test fails to connect or the cleanup throws.

## Schedule

`0 4 * * *` — daily at **04:00 UTC**, intentionally offset two hours from the existing 06:00 UTC nightly Integration Tests so the two jobs cannot overlap.

## AGENTS.md compliance

- [x] **One Functionality Per Commit** — single commit, single workflow + matching CHANGELOG entry
- [x] **CHANGELOG updated** — one bullet appended under `## [Unreleased]` → `### Internal`, one sentence per line
- [x] **No module code touched** — pure CI change (only `.github/workflows/stale_cleanup.yml` and `CHANGELOG.md` modified)
- [x] **No raw HTTP, no hardcoded URLs** — N/A, no module code
- [x] **Validation** — limited to static review (`actionlint`, `yamllint`, end-to-end re-read) because PowerShell is not installed on the agent VM, so `Invoke-Build -Task Build, Test` could not be run locally. CI will exercise the full pipeline on PR open.

## Validation performed

| Tool | Result |
|------|--------|
| `python3 -c "import yaml; yaml.safe_load(...)"` | YAML OK |
| `yamllint` | clean (after CRLF→LF fix) |
| `actionlint` | clean |
| Manual review vs. `integration_tests.yml` | env block, setup action, guard pattern all consistent |
| `Invoke-Build -Task Build, Test` | skipped — PowerShell not installed on VM |

## Context

Part of the larger "JiraPS Integration Tests — Plan Reassessment" effort — Wave 1, Subagent A.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ed31763-4189-4f50-80fe-e4fd75bf3e2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ed31763-4189-4f50-80fe-e4fd75bf3e2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

