### PR TITLE
ci: extend Dependabot to track Docker images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,15 @@ updates:
     directory: "/.devcontainer"
     schedule:
       interval: weekly
+  - package-ecosystem: "docker"
+    directory: "/.devcontainer"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "⬆️ "
+  - package-ecosystem: "docker-compose"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "⬆️ "


### PR DESCRIPTION
## Summary

Add two new ecosystems to [`.github/dependabot.yml`](.github/dependabot.yml) so Docker base images stay up to date alongside the GitHub Actions and devcontainer dependencies that Dependabot already maintains:

| Ecosystem | Directory | Tracks |
|-----------|-----------|--------|
| `docker` | `/.devcontainer` | `mcr.microsoft.com/dotnet/sdk:${VARIANT}` in `.devcontainer/Dockerfile` |
| `docker-compose` | `/` | `addono/jira-software-standalone` in `docker-compose.yml` (added by #623) |

Both entries reuse the existing weekly cadence and the `⬆️ ` commit-message prefix already used for the `github-actions` ecosystem so version-bump PRs stay visually consistent in `git log`.

## Why now

PR #623 introduces a `docker-compose.yml` that pins a Jira Data Center image used for the new Server-track integration tests.
Without Dependabot coverage that pin will silently drift.
The `docker` entry is bonus value — it covers the .NET SDK base image in the devcontainer that has been on master for a while and was never tracked.

## Notes

- The `docker-compose` entry will be a no-op until #623 merges and the file lands on `master`.
  Dependabot logs a warning when a configured directory is missing and otherwise stays silent — no failure.
- Dependabot PRs are already exempted from the integration test workflow via `github.actor != 'dependabot[bot]'` in [`integration_tests.yml`](.github/workflows/integration_tests.yml), so no CI changes are required.
- Per [GitHub's Dependabot ecosystems reference](https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem-), `docker-compose.yml` files are scanned by the `docker-compose` ecosystem (added in 2025).
  Files must contain `compose` in the name to be picked up — which our `docker-compose.yml` does.

## Test plan

- [x] `git diff --check` — no whitespace issues
- [x] YAML parses cleanly (Ruby YAML loader)
- [ ] After merge: confirm Dependabot picks up the new ecosystems on the next scheduled run (or by triggering a manual check from the repo Insights tab)
- [ ] After #623 merges: confirm Dependabot opens a PR if a newer `addono/jira-software-standalone` tag becomes available

## Related

- #623 — adds the `docker-compose.yml` that the second entry will start tracking
- #591 — already excludes Dependabot PRs from the integration test runs

Made with [Cursor](https://cursor.com)