### PR TITLE
refactor: centralize Invoke-JiraMethod URI normalization and use relative REST paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ See [`about_JiraPS_MigrationV3`](https://atlassianps.org/docs/JiraPS/about/migra
   Update scripts to call `ConvertTo-JiraTable` directly.
 - `Get-JiraIssue -Key` now accepts pipeline input by property name, enabling `Get-JiraIssue TEST-1 | Get-JiraIssue` to refresh issue data. **Soft breaking change**: Objects with a `Key` property (e.g., `[PSCustomObject]@{ Key = 'TEST-1' }`) now bind to `-Key` instead of failing. Scripts relying on the previous failure behavior may need adjustment.
 - `Invoke-Build -Task Test` now excludes integration tests by default (use `-Tag 'Integration'` to include them)
+- `Invoke-JiraMethod` now supports Jira-doc style relative endpoint paths (for example, `/rest/api/2/issue/TEST-1`) and resolves them against `Get-JiraConfigServer`.
+  Relative paths must start with `/`, otherwise the cmdlet now throws a clear terminating argument error that includes the rejected path.
+  Absolute URLs are still supported for backward compatibility (including values coming from object `RestURL` properties).
+- Public cmdlets now pass relative `/rest/api/...` endpoints into `Invoke-JiraMethod` instead of concatenating `Get-JiraConfigServer` at each call site.
 - Enhanced `Test-ServerResponse` to handle HTTP 503 (Service Unavailable) with retry, jitter on backoff delays, and 60-second max delay cap (#576)
 - Enhanced `Resolve-JiraError` to parse all Jira error response formats: `message`, `errorMessage`, `errorMessages` array, and `errors` dictionary (#576)
 - Hid internal `-Cmdlet` and `-_RetryCount` parameters on `Invoke-JiraMethod` from tab-completion via `[Parameter(DontShow)]` (follow-up to #582)

--- a/JiraPS/Public/Add-JiraGroupMember.ps1
+++ b/JiraPS/Public/Add-JiraGroupMember.ps1
@@ -29,10 +29,9 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
         $isCloud = Test-JiraCloudServer -Credential $Credential
 
-        $resourceURi = "$server/rest/api/2/group/user?groupname={0}"
+        $resourceURi = "/rest/api/2/group/user?groupname={0}"
     }
 
     process {

--- a/JiraPS/Public/Add-JiraIssueAttachment.ps1
+++ b/JiraPS/Public/Add-JiraIssueAttachment.ps1
@@ -83,7 +83,7 @@
         }
 
         # Find the proper object for the Issue
-        $issueObj = Resolve-JiraIssueObject -InputObject $Issue -Credential $Credential
+        $issueObj = Resolve-JiraIssueObject -InputObject $Issue -Credential $Credential -ErrorAction Stop
 
         foreach ($file in $FilePath) {
             $file = Resolve-FilePath -Path $file

--- a/JiraPS/Public/Add-JiraIssueLink.ps1
+++ b/JiraPS/Public/Add-JiraIssueLink.ps1
@@ -70,9 +70,7 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/2/issueLink"
+        $resourceURi = "/rest/api/2/issueLink"
     }
 
     process {

--- a/JiraPS/Public/Find-JiraFilter.ps1
+++ b/JiraPS/Public/Find-JiraFilter.ps1
@@ -76,9 +76,7 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $searchURi = "$server/rest/api/2/filter/search"
+        $searchURi = "/rest/api/2/filter/search"
 
         [String]$Fields = $Fields -join ','
     }

--- a/JiraPS/Public/Get-JiraComponent.ps1
+++ b/JiraPS/Public/Get-JiraComponent.ps1
@@ -45,9 +45,7 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/2{0}"
+        $resourceURi = "/rest/api/2{0}"
     }
 
     process {

--- a/JiraPS/Public/Get-JiraField.ps1
+++ b/JiraPS/Public/Get-JiraField.ps1
@@ -18,9 +18,7 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/2/field"
+        $resourceURi = "/rest/api/2/field"
     }
 
     process {

--- a/JiraPS/Public/Get-JiraFilter.ps1
+++ b/JiraPS/Public/Get-JiraFilter.ps1
@@ -51,9 +51,7 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/2/filter/{0}"
+        $resourceURi = "/rest/api/2/filter/{0}"
     }
 
     process {

--- a/JiraPS/Public/Get-JiraGroup.ps1
+++ b/JiraPS/Public/Get-JiraGroup.ps1
@@ -17,9 +17,7 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/2/group?groupname={0}"
+        $resourceURi = "/rest/api/2/group?groupname={0}"
     }
 
     process {

--- a/JiraPS/Public/Get-JiraGroupMember.ps1
+++ b/JiraPS/Public/Get-JiraGroupMember.ps1
@@ -42,9 +42,7 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/2/group/member"
+        $resourceURi = "/rest/api/2/group/member"
 
         if ($PageSize -gt 50) {
             Write-Warning "JIRA's API may not properly support MaxResults values higher than 50 for this method. If you receive inconsistent results, do not pass the MaxResults parameter to this function to return all results."

--- a/JiraPS/Public/Get-JiraIssue.ps1
+++ b/JiraPS/Public/Get-JiraIssue.ps1
@@ -84,12 +84,11 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
         $isCloud = Test-JiraCloudServer -Credential $Credential
 
-        $searchURi = "$server/rest/api/2/search"
-        $searchURi_v3 = "$server/rest/api/3/search/jql"
-        $resourceURi = "$server/rest/api/2/issue/{0}"
+        $searchURi = "/rest/api/2/search"
+        $searchURi_v3 = "/rest/api/3/search/jql"
+        $resourceURi = "/rest/api/2/issue/{0}"
 
         [String]$Fields = $Fields -join ","
     }

--- a/JiraPS/Public/Get-JiraIssueCreateMetadata.ps1
+++ b/JiraPS/Public/Get-JiraIssueCreateMetadata.ps1
@@ -20,9 +20,7 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/2/issue/createmeta/{0}/issuetypes/{1}"
+        $resourceURi = "/rest/api/2/issue/createmeta/{0}/issuetypes/{1}"
     }
 
     process {

--- a/JiraPS/Public/Get-JiraIssueEditMetadata.ps1
+++ b/JiraPS/Public/Get-JiraIssueEditMetadata.ps1
@@ -20,9 +20,7 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/2/issue/{0}/editmeta"
+        $resourceURi = "/rest/api/2/issue/{0}/editmeta"
     }
 
     process {

--- a/JiraPS/Public/Get-JiraIssueLink.ps1
+++ b/JiraPS/Public/Get-JiraIssueLink.ps1
@@ -15,9 +15,7 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/2/issueLink/{0}"
+        $resourceURi = "/rest/api/2/issueLink/{0}"
     }
 
     process {

--- a/JiraPS/Public/Get-JiraIssueLinkType.ps1
+++ b/JiraPS/Public/Get-JiraIssueLinkType.ps1
@@ -36,9 +36,7 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/2/issueLinkType{0}"
+        $resourceURi = "/rest/api/2/issueLinkType{0}"
     }
 
     process {

--- a/JiraPS/Public/Get-JiraIssueType.ps1
+++ b/JiraPS/Public/Get-JiraIssueType.ps1
@@ -19,9 +19,7 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/2/issuetype"
+        $resourceURi = "/rest/api/2/issuetype"
     }
 
     process {

--- a/JiraPS/Public/Get-JiraPriority.ps1
+++ b/JiraPS/Public/Get-JiraPriority.ps1
@@ -19,9 +19,7 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/2/priority{0}"
+        $resourceURi = "/rest/api/2/priority{0}"
     }
 
     process {

--- a/JiraPS/Public/Get-JiraProject.ps1
+++ b/JiraPS/Public/Get-JiraProject.ps1
@@ -15,9 +15,7 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/2/project{0}?expand=description,lead,issueTypes,url,projectKeys"
+        $resourceURi = "/rest/api/2/project{0}?expand=description,lead,issueTypes,url,projectKeys"
     }
 
     process {

--- a/JiraPS/Public/Get-JiraServerInformation.ps1
+++ b/JiraPS/Public/Get-JiraServerInformation.ps1
@@ -14,9 +14,7 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/2/serverInfo"
+        $resourceURi = "/rest/api/2/serverInfo"
     }
 
     process {

--- a/JiraPS/Public/Get-JiraUser.ps1
+++ b/JiraPS/Public/Get-JiraUser.ps1
@@ -45,18 +45,17 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
         $isCloud = Test-JiraCloudServer -Credential $Credential
 
-        $selfResourceUri = "$server/rest/api/2/myself"
+        $selfResourceUri = "/rest/api/2/myself"
 
         if ($isCloud) {
-            $searchResourceUri = "$server/rest/api/2/user/search?query={0}"
-            $exactResourceUri = "$server/rest/api/2/user?accountId={0}"
+            $searchResourceUri = "/rest/api/2/user/search?query={0}"
+            $exactResourceUri = "/rest/api/2/user?accountId={0}"
         }
         else {
-            $searchResourceUri = "$server/rest/api/2/user/search?username={0}"
-            $exactResourceUri = "$server/rest/api/2/user?username={0}"
+            $searchResourceUri = "/rest/api/2/user/search?username={0}"
+            $exactResourceUri = "/rest/api/2/user?username={0}"
         }
 
         if ($IncludeInactive) {

--- a/JiraPS/Public/Get-JiraVersion.ps1
+++ b/JiraPS/Public/Get-JiraVersion.ps1
@@ -47,9 +47,7 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/2/{0}"
+        $resourceURi = "/rest/api/2/{0}"
     }
 
     process {

--- a/JiraPS/Public/Invoke-JiraMethod.ps1
+++ b/JiraPS/Public/Invoke-JiraMethod.ps1
@@ -78,6 +78,55 @@
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] ParameterSetName: $($PsCmdlet.ParameterSetName)"
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] PSBoundParameters: $($PSBoundParameters | Out-String)"
 
+        #region Manage URI
+        $providedUriValue = $Uri.OriginalString
+        if (-not $Uri.IsAbsoluteUri) {
+            if (-not $providedUriValue.StartsWith('/')) {
+                $errorParameter = @{
+                    Cmdlet       = $PSCmdlet
+                    Exception    = [System.ArgumentException]::new("Invalid URI path '$providedUriValue'. Relative URIs must start with '/'.")
+                    ErrorId      = 'ParameterValue.UriPathMustStartWithSlash'
+                    Category     = [System.Management.Automation.ErrorCategory]::InvalidArgument
+                    TargetObject = $providedUriValue
+                }
+                ThrowError @errorParameter
+            }
+
+            $server = Get-JiraConfigServer -ErrorAction SilentlyContinue
+            if ([String]::IsNullOrWhiteSpace($server)) {
+                $errorParameter = @{
+                    Cmdlet       = $PSCmdlet
+                    Exception    = [System.ArgumentException]::new("Cannot resolve relative URI '$providedUriValue' because no Jira server is configured. Use Set-JiraConfigServer first.")
+                    ErrorId      = 'ParameterValue.JiraServerNotConfigured'
+                    Category     = [System.Management.Automation.ErrorCategory]::InvalidArgument
+                    TargetObject = $providedUriValue
+                }
+                ThrowError @errorParameter
+            }
+
+            [Uri]$Uri = "{0}{1}" -f $server.TrimEnd('/'), $providedUriValue
+        }
+
+        if (-not $Uri.IsAbsoluteUri) {
+            $errorParameter = @{
+                Cmdlet       = $PSCmdlet
+                Exception    = [System.ArgumentException]::new("Invoke-JiraMethod: -Uri must be an absolute URI. Got '$providedUriValue'.")
+                ErrorId      = 'ParameterValue.UriMustBeAbsolute'
+                Category     = [System.Management.Automation.ErrorCategory]::InvalidArgument
+                TargetObject = $providedUriValue
+            }
+            ThrowError @errorParameter
+        }
+
+        # Amend query from URI with GetParameter
+        $uriQuery = ConvertTo-ParameterHash -Uri $Uri
+        $internalGetParameter = Join-Hashtable $uriQuery, $GetParameter
+
+        # And remove it from URI
+        [Uri]$Uri = $Uri.GetLeftPart("Path")
+        $PaginatedUri = $Uri
+        #endregion Manage URI
+
         #region Cache Check
         if ($CacheKey -and $Method -eq 'GET' -and -not $BypassCache) {
             if (-not $script:JiraCache) {
@@ -106,15 +155,6 @@
         $_headers = Join-Hashtable -Hashtable $script:DefaultHeaders, $PSDefaultParameterValues["Invoke-WebRequest:Headers"], $Headers
         #endregion Headers
 
-        #region Manage URI
-        # Amend query from URI with GetParameter
-        $uriQuery = ConvertTo-ParameterHash -Uri $Uri
-        $internalGetParameter = Join-Hashtable $uriQuery, $GetParameter
-
-        # And remove it from URI
-        [Uri]$Uri = $Uri.GetLeftPart("Path")
-        $PaginatedUri = $Uri
-
         # Use default PageSize
         if (-not $internalGetParameter.ContainsKey("maxResults")) {
             $internalGetParameter["maxResults"] = $script:DefaultPageSize
@@ -131,7 +171,6 @@
         }
 
         [Uri]$PaginatedUri = "{0}{1}" -f $PaginatedUri, (ConvertTo-GetParameter $internalGetParameter)
-        #endregion Manage URI
 
         #region Constructe IWR Parameter
         $splatParameters = @{

--- a/JiraPS/Public/Move-JiraVersion.ps1
+++ b/JiraPS/Public/Move-JiraVersion.ps1
@@ -65,9 +65,7 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $versionResourceUri = "$server/rest/api/2/version/{0}/move"
+        $versionResourceUri = "/rest/api/2/version/{0}/move"
     }
 
     process {

--- a/JiraPS/Public/New-JiraFilter.ps1
+++ b/JiraPS/Public/New-JiraFilter.ps1
@@ -30,9 +30,7 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/2/filter"
+        $resourceURi = "/rest/api/2/filter"
     }
 
     process {

--- a/JiraPS/Public/New-JiraGroup.ps1
+++ b/JiraPS/Public/New-JiraGroup.ps1
@@ -16,9 +16,7 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/2/group"
+        $resourceURi = "/rest/api/2/group"
     }
 
     process {

--- a/JiraPS/Public/New-JiraIssue.ps1
+++ b/JiraPS/Public/New-JiraIssue.ps1
@@ -88,11 +88,9 @@
     }
 
     process {
-        $server = Get-JiraConfigServer -ErrorAction Stop -Debug:$false
-
         $createmeta = Get-JiraIssueCreateMetadata -Project $Project -IssueType $IssueType -Credential $Credential -ErrorAction Stop -Debug:$false
 
-        $resourceURi = "$server/rest/api/2/issue"
+        $resourceURi = "/rest/api/2/issue"
 
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] ParameterSetName: $($PsCmdlet.ParameterSetName)"
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] PSBoundParameters: $($PSBoundParameters | Out-String)"

--- a/JiraPS/Public/New-JiraSession.ps1
+++ b/JiraPS/Public/New-JiraSession.ps1
@@ -28,9 +28,7 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/2/myself"
+        $resourceURi = "/rest/api/2/myself"
     }
 
     process {

--- a/JiraPS/Public/New-JiraUser.ps1
+++ b/JiraPS/Public/New-JiraUser.ps1
@@ -26,9 +26,7 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/2/user"
+        $resourceURi = "/rest/api/2/user"
     }
 
     process {

--- a/JiraPS/Public/New-JiraVersion.ps1
+++ b/JiraPS/Public/New-JiraVersion.ps1
@@ -88,9 +88,7 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/2/version"
+        $resourceURi = "/rest/api/2/version"
     }
 
     process {

--- a/JiraPS/Public/Remove-JiraGroup.ps1
+++ b/JiraPS/Public/Remove-JiraGroup.ps1
@@ -40,9 +40,7 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/2/group?groupname={0}"
+        $resourceURi = "/rest/api/2/group?groupname={0}"
 
         if ($Force) {
             Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] -Force was passed. Backing up current ConfirmPreference [$ConfirmPreference] and setting to None"

--- a/JiraPS/Public/Remove-JiraGroupMember.ps1
+++ b/JiraPS/Public/Remove-JiraGroupMember.ps1
@@ -69,14 +69,13 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
         $isCloud = Test-JiraCloudServer -Credential $Credential
 
         if ($isCloud) {
-            $resourceURi = "$server/rest/api/2/group/user?groupname={0}&accountId={1}"
+            $resourceURi = "/rest/api/2/group/user?groupname={0}&accountId={1}"
         }
         else {
-            $resourceURi = "$server/rest/api/2/group/user?groupname={0}&username={1}"
+            $resourceURi = "/rest/api/2/group/user?groupname={0}&username={1}"
         }
 
         if ($Force) {

--- a/JiraPS/Public/Remove-JiraIssue.ps1
+++ b/JiraPS/Public/Remove-JiraIssue.ps1
@@ -49,9 +49,7 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/2/issue/{0}?deleteSubtasks={1}"
+        $resourceURi = "/rest/api/2/issue/{0}?deleteSubtasks={1}"
 
         if ($Force) {
             Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] -Force was passed. Backing up current ConfirmPreference [$ConfirmPreference] and setting to None"

--- a/JiraPS/Public/Remove-JiraIssueAttachment.ps1
+++ b/JiraPS/Public/Remove-JiraIssueAttachment.ps1
@@ -50,9 +50,7 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/2/attachment/{0}"
+        $resourceURi = "/rest/api/2/attachment/{0}"
 
         if ($Force) {
             Write-DebugMessage "[Remove-JiraGroupMember] -Force was passed. Backing up current ConfirmPreference [$ConfirmPreference] and setting to None"

--- a/JiraPS/Public/Remove-JiraIssueLink.ps1
+++ b/JiraPS/Public/Remove-JiraIssueLink.ps1
@@ -39,9 +39,7 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/2/issueLink/{0}"
+        $resourceURi = "/rest/api/2/issueLink/{0}"
     }
 
     process {

--- a/JiraPS/Public/Remove-JiraRemoteLink.ps1
+++ b/JiraPS/Public/Remove-JiraRemoteLink.ps1
@@ -44,9 +44,7 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
-
-        $resourceURi = "$server/rest/api/2/issue/{0}/remotelink/{1}"
+        $resourceURi = "/rest/api/2/issue/{0}/remotelink/{1}"
 
         if ($Force) {
             Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] -Force was passed. Backing up current ConfirmPreference [$ConfirmPreference] and setting to None"

--- a/JiraPS/Public/Remove-JiraUser.ps1
+++ b/JiraPS/Public/Remove-JiraUser.ps1
@@ -40,14 +40,13 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
         $isCloud = Test-JiraCloudServer -Credential $Credential
 
         if ($isCloud) {
-            $resourceURi = "$server/rest/api/2/user?accountId={0}"
+            $resourceURi = "/rest/api/2/user?accountId={0}"
         }
         else {
-            $resourceURi = "$server/rest/api/2/user?username={0}"
+            $resourceURi = "/rest/api/2/user?username={0}"
         }
 
         if ($Force) {

--- a/JiraPS/Public/Set-JiraUser.ps1
+++ b/JiraPS/Public/Set-JiraUser.ps1
@@ -75,14 +75,13 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
-        $server = Get-JiraConfigServer -ErrorAction Stop
         $isCloud = Test-JiraCloudServer -Credential $Credential
 
         if ($isCloud) {
-            $resourceURi = "$server/rest/api/2/user?accountId={0}"
+            $resourceURi = "/rest/api/2/user?accountId={0}"
         }
         else {
-            $resourceURi = "$server/rest/api/2/user?username={0}"
+            $resourceURi = "/rest/api/2/user?username={0}"
         }
     }
 

--- a/Tests/Functions/Public/Add-JiraIssueLink.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Add-JiraIssueLink.Unit.Tests.ps1
@@ -46,7 +46,7 @@ InModuleScope JiraPS {
 
             Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {
                 $Method -eq 'POST' -and
-                $URI -eq "$jiraServer/rest/api/2/issueLink"
+                $URI -eq "/rest/api/2/issueLink"
             } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri', 'Body'
                 return $true

--- a/Tests/Functions/Public/Find-JiraFilter.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Find-JiraFilter.Unit.Tests.ps1
@@ -76,7 +76,7 @@ InModuleScope JiraPS {
 
             Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {
                 $Method -eq 'Get' -and
-                $URI -like "$jiraServer/rest/api/*/filter/search*"
+                $URI -like "*rest/api/*/filter/search*"
             } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                 ConvertFrom-Json $response
@@ -122,7 +122,7 @@ InModuleScope JiraPS {
 
                     Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {
                         $Method -eq 'Get' -and
-                        $URI -like '*/rest/api/*/filter/search*'
+                        $URI -like '*rest/api/*/filter/search*'
                     } -Exactly 1
                 }
 
@@ -131,7 +131,7 @@ InModuleScope JiraPS {
 
                     Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {
                         $Method -eq 'Get' -and
-                        $URI -like '*/rest/api/*/filter/search*' -and
+                        $URI -like '*rest/api/*/filter/search*' -and
                         $GetParameter['accountId'] -eq $mockOwner.AccountId
                     } -Exactly 1
                 }
@@ -141,7 +141,7 @@ InModuleScope JiraPS {
 
                     Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {
                         $Method -eq 'Get' -and
-                        $URI -like '*/rest/api/*/filter/search*' -and
+                        $URI -like '*rest/api/*/filter/search*' -and
                         $GetParameter['groupName'] -eq $groupEscaped
                     } -Exactly 1
                 }
@@ -151,7 +151,7 @@ InModuleScope JiraPS {
 
                     Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {
                         $Method -eq 'Get' -and
-                        $URI -like '*/rest/api/*/filter/search*' -and
+                        $URI -like '*rest/api/*/filter/search*' -and
                         $GetParameter['projectId'] -eq '1'
                     } -Exactly 1
                 }
@@ -161,7 +161,7 @@ InModuleScope JiraPS {
 
                     Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {
                         $Method -eq 'Get' -and
-                        $URI -like '*/rest/api/*/filter/search*' -and
+                        $URI -like '*rest/api/*/filter/search*' -and
                         $GetParameter['orderBy'] -eq 'name'
                     } -Exactly 1
                 }
@@ -172,13 +172,13 @@ InModuleScope JiraPS {
 
                     Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {
                         $Method -eq 'Get' -and
-                        $URI -like '*/rest/api/*/filter/search*' -and
+                        $URI -like '*rest/api/*/filter/search*' -and
                         $GetParameter['expand'] -eq 'description,favourite,favouritedCount,jql,owner,searchUrl,sharePermissions,subscriptions,viewUrl'
                     } -Exactly 1
 
                     Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {
                         $Method -eq 'Get' -and
-                        $URI -like '*/rest/api/*/filter/search*' -and
+                        $URI -like '*rest/api/*/filter/search*' -and
                         $GetParameter['expand'] -eq 'description'
                     } -Exactly 1
                 }
@@ -192,7 +192,7 @@ InModuleScope JiraPS {
 
                     Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {
                         $Method -eq 'Get' -and
-                        $URI -like '*/rest/api/*/filter/search*' -and
+                        $URI -like '*rest/api/*/filter/search*' -and
                         $GetParameter['projectId'] -eq '1'
                     } -Exactly 1
                 }
@@ -208,7 +208,7 @@ InModuleScope JiraPS {
 
                     Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {
                         $Method -eq 'Get' -and
-                        $URI -like '*/rest/api/*/filter/search*' -and
+                        $URI -like '*rest/api/*/filter/search*' -and
                         $GetParameter['accountId'] -eq $mockowner.AccountId -and
                         $GetParameter['groupName'] -eq $groupEscaped -and
                         $GetParameter['projectId'] -eq '1'
@@ -220,7 +220,7 @@ InModuleScope JiraPS {
 
                     Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {
                         $Method -eq 'Get' -and
-                        $URI -like '*/rest/api/*/filter/search*'
+                        $URI -like '*rest/api/*/filter/search*'
                     } -Exactly 1
 
                     Should -Invoke Get-JiraUser -ModuleName JiraPS -ParameterFilter {

--- a/Tests/Functions/Public/Get-JiraComponent.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraComponent.Unit.Tests.ps1
@@ -59,7 +59,7 @@ InModuleScope JiraPS {
                 Write-Output $jiraServer
             }
 
-            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -eq "$jiraServer/rest/api/2/component/$componentId" } {
+            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -eq "/rest/api/2/component/$componentId" } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                 ConvertFrom-Json $restResultOne
             }

--- a/Tests/Functions/Public/Get-JiraField.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraField.Unit.Tests.ps1
@@ -149,7 +149,7 @@ InModuleScope JiraPS {
                 Write-Output $jiraServer
             }
 
-            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $Uri -eq "$jiraServer/rest/api/2/field" } {
+            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $Uri -eq "/rest/api/2/field" } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                 ConvertFrom-Json $restResult
             }

--- a/Tests/Functions/Public/Get-JiraFilter.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraFilter.Unit.Tests.ps1
@@ -100,22 +100,22 @@ InModuleScope JiraPS {
                 }
             }
 
-            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/*/filter/12345" } {
+            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "/rest/api/*/filter/12345" } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                 ConvertFrom-Json $responseFilter
             }
 
-            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/*/filter/67890" } {
+            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "/rest/api/*/filter/67890" } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                 ConvertFrom-Json $responseFilter
             }
 
-            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/*/filter/favourite" } {
+            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "/rest/api/*/filter/favourite" } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                 ConvertFrom-Json $responseFilterCollection
             }
 
-            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/*/filter/*" } {
+            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "/rest/api/*/filter/*" } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                 ConvertFrom-Json $responseFilter
             }

--- a/Tests/Functions/Public/Get-JiraGroup.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraGroup.Unit.Tests.ps1
@@ -52,7 +52,7 @@ InModuleScope JiraPS {
 
             Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {
                 $Method -eq 'Get' -and
-                $URI -eq "$jiraServer/rest/api/2/group?groupname=$testGroupNameEscaped"
+                $URI -eq "/rest/api/2/group?groupname=$testGroupNameEscaped"
             } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                 ConvertFrom-Json -InputObject $restResult
@@ -114,7 +114,7 @@ InModuleScope JiraPS {
 
                     Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -ParameterFilter {
                         $Method -eq 'Get' -and
-                        $URI -eq "$jiraServer/rest/api/2/group?groupname=$testGroupNameEscaped"
+                        $URI -eq "/rest/api/2/group?groupname=$testGroupNameEscaped"
                     }
                 }
             }

--- a/Tests/Functions/Public/Get-JiraIssue.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraIssue.Unit.Tests.ps1
@@ -61,7 +61,7 @@ InModuleScope JiraPS {
 
             Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {
                 $Method -eq 'Get' -and
-                $URI -like "$jiraServer/rest/api/*/issue/TEST-001*"
+                $URI -like "/rest/api/*/issue/TEST-001*"
             } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                 ConvertFrom-Json $response
@@ -69,7 +69,7 @@ InModuleScope JiraPS {
 
             Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {
                 $Method -eq 'Get' -and
-                $URI -like "$jiraServer/rest/api/*/search" -and
+                $URI -like "/rest/api/*/search" -and
                 $GetParameter["jql"] -eq $jqlEscaped
             } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
@@ -78,7 +78,7 @@ InModuleScope JiraPS {
 
             Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {
                 $Method -eq 'Get' -and
-                $URI -like "$jiraServer/rest/api/*/filter/*"
+                $URI -like "*rest/api/*/filter/*"
             } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                 ConvertFrom-Json $response
@@ -301,7 +301,7 @@ InModuleScope JiraPS {
 
                 Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {
                     $Method -eq 'Get' -and
-                    $URI -like "$jiraServer/rest/api/3/search/jql*"
+                    $URI -like "/rest/api/3/search/jql*"
                 } {
                     Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                     ConvertFrom-Json $response
@@ -318,7 +318,7 @@ InModuleScope JiraPS {
 
                 Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Exactly 1 -ParameterFilter {
                     $Method -eq 'Get' -and
-                    $URI -like "$jiraServer/rest/api/3/search/jql*"
+                    $URI -like "/rest/api/3/search/jql*"
                 }
             }
         }

--- a/Tests/Functions/Public/Get-JiraIssueCreateMetadata.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraIssueCreateMetadata.Unit.Tests.ps1
@@ -124,7 +124,7 @@ InModuleScope JiraPS {
                 BeforeAll {
                     # Default mock: Invoke-JiraMethod -Paging would yield the
                     # expanded field items, so the mock returns values directly.
-                    Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/*/issue/createmeta/*/issuetypes/*" } {
+                    Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "/rest/api/*/issue/createmeta/*/issuetypes/*" } {
                         Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                         (ConvertFrom-Json $restResult).values
                     }
@@ -140,7 +140,7 @@ InModuleScope JiraPS {
 
                     Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {
                         $Method -eq 'Get' -and
-                        $URI -like "$jiraServer/rest/api/*/issue/createmeta/*/issuetypes/*" -and
+                        $URI -like "/rest/api/*/issue/createmeta/*/issuetypes/*" -and
                         $Paging -eq $true
                     } -Exactly -Times 1
                 }

--- a/Tests/Functions/Public/Get-JiraIssueLink.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraIssueLink.Unit.Tests.ps1
@@ -40,7 +40,7 @@ InModuleScope JiraPS {
                 throw "Unidentified call to Invoke-JiraMethod"
             }
 
-            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -eq "$jiraServer/rest/api/2/issueLink/1234" } {
+            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -eq "/rest/api/2/issueLink/1234" } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                 ConvertFrom-Json $resultsJson
             }

--- a/Tests/Functions/Public/Get-JiraIssueLinkType.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraIssueLinkType.Unit.Tests.ps1
@@ -18,8 +18,8 @@ InModuleScope JiraPS {
 
 
             #region Mocks
-            $filterAll = { $Method -eq 'Get' -and $Uri -ceq "$jiraServer/rest/api/2/issueLinkType" }
-            $filterOne = { $Method -eq 'Get' -and $Uri -ceq "$jiraServer/rest/api/2/issueLinkType/10000" }
+            $filterAll = { $Method -eq 'Get' -and $Uri -ceq "/rest/api/2/issueLinkType" }
+            $filterOne = { $Method -eq 'Get' -and $Uri -ceq "/rest/api/2/issueLinkType/10000" }
 
             Mock Get-JiraConfigServer -ModuleName JiraPS {
                 Write-MockDebugInfo 'Get-JiraConfigServer'

--- a/Tests/Functions/Public/Get-JiraIssueType.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraIssueType.Unit.Tests.ps1
@@ -97,7 +97,7 @@ InModuleScope JiraPS {
                 $inputObject
             }
 
-            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $Uri -eq "$jiraServer/rest/api/2/issuetype" } {
+            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $Uri -eq "/rest/api/2/issuetype" } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                 ConvertFrom-Json $restResult
             }

--- a/Tests/Functions/Public/Get-JiraPriority.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraPriority.Unit.Tests.ps1
@@ -76,12 +76,12 @@ InModuleScope JiraPS {
                 $InputObject
             }
 
-            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -eq "$jiraServer/rest/api/2/priority" } {
+            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -eq "/rest/api/2/priority" } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                 ConvertFrom-Json $restResultAll
             }
 
-            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -eq "$jiraServer/rest/api/2/priority/1" } {
+            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -eq "/rest/api/2/priority/1" } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                 ConvertFrom-Json $restResultOne
             }

--- a/Tests/Functions/Public/Get-JiraProject.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraProject.Unit.Tests.ps1
@@ -73,12 +73,12 @@ InModuleScope JiraPS {
                 Write-Output $jiraServer
             }
 
-            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/*/project*" } {
+            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "/rest/api/*/project*" } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                 ConvertFrom-Json $restResultAll
             }
 
-            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/*/project/$projectKey?*" } {
+            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "/rest/api/*/project/$projectKey?*" } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                 ConvertFrom-Json $restResultOne
             }

--- a/Tests/Functions/Public/Get-JiraServerInformation.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraServerInformation.Unit.Tests.ps1
@@ -36,7 +36,7 @@ InModuleScope JiraPS {
                 Write-Output $jiraServer
             }
 
-            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -eq "$jiraServer/rest/api/2/serverInfo" } {
+            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -eq "/rest/api/2/serverInfo" } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                 ConvertFrom-Json $restResult
             }

--- a/Tests/Functions/Public/Get-JiraUser.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraUser.Unit.Tests.ps1
@@ -72,29 +72,29 @@ InModuleScope JiraPS {
             }
 
             # Return information of the current user
-            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/*/myself" } {
+            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "*rest/api/*/myself" } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                 ConvertFrom-Json -InputObject $restResult
             }
 
             # Searching for a user.
-            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/*/user/search?*username=$testUsername*" } {
+            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "*rest/api/*/user/search?*username=$testUsername*" } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                 ConvertFrom-Json -InputObject $restResult
             }
-            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/*/user/search?*username=%25*" } {
+            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "*rest/api/*/user/search?*username=%*" } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                 ConvertFrom-Json -InputObject $restResult
             }
 
             # Get exact user
-            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/*/user?username=$testUsername" } {
+            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "*rest/api/*/user?username=$testUsername" } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                 ConvertFrom-Json -InputObject $restResult
             }
 
             # Viewing a specific user. The main difference here is that this includes groups, and the first does not.
-            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/*/user?username=$testUsername&expand=groups" } {
+            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "*rest/api/*/user?username=$testUsername&expand=groups" } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                 ConvertFrom-Json -InputObject $restResult2
             }
@@ -123,8 +123,8 @@ InModuleScope JiraPS {
 
                 $getResult | Should -Not -BeNullOrEmpty
 
-                Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Exactly 1 -ParameterFilter { $URI -like "$jiraServer/rest/api/*/myself" }
-                Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Exactly 1 -ParameterFilter { $URI -like "$jiraServer/rest/api/*/user?username=$testUsername&expand=groups" }
+                Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Exactly 1 -ParameterFilter { $URI -like "*rest/api/*/myself" }
+                Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Exactly 1 -ParameterFilter { $URI -like "*rest/api/*/user?username=$testUsername&expand=groups" }
             }
 
             It "Gets information about a provided Jira user" {
@@ -132,8 +132,8 @@ InModuleScope JiraPS {
 
                 $getResult | Should -Not -BeNullOrEmpty
 
-                Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Exactly 1 -ParameterFilter { $URI -like "$jiraServer/rest/api/*/user/search?*username=$testUsername*" }
-                Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Exactly 1 -ParameterFilter { $URI -like "$jiraServer/rest/api/*/user?username=$testUsername&expand=groups" }
+                Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Exactly 1 -ParameterFilter { $URI -like "*rest/api/*/user/search?*username=$testUsername*" }
+                Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Exactly 1 -ParameterFilter { $URI -like "*rest/api/*/user?username=$testUsername&expand=groups" }
             }
 
             It "Gets information about a provided Jira exact user" {
@@ -141,8 +141,8 @@ InModuleScope JiraPS {
 
                 $getResult | Should -Not -BeNullOrEmpty
 
-                Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Exactly 1 -ParameterFilter { $Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/*/user?username=$testUsername" }
-                Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Exactly 1 -ParameterFilter { $URI -like "$jiraServer/rest/api/*/user?username=$testUsername&expand=groups" }
+                Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Exactly 1 -ParameterFilter { $Method -eq 'Get' -and $URI -like "*rest/api/*/user?username=$testUsername" }
+                Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Exactly 1 -ParameterFilter { $URI -like "*rest/api/*/user?username=$testUsername&expand=groups" }
             }
 
             It "Returns all available properties about the returned user object" {
@@ -155,7 +155,7 @@ InModuleScope JiraPS {
                 $getResult.DisplayName | Should -Be $restObj.displayName
                 $getResult.Active | Should -Be $restObj.active
 
-                Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Exactly 1 -ParameterFilter { $URI -like "$jiraServer/rest/api/*/user?username=$testUsername&expand=groups" }
+                Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Exactly 1 -ParameterFilter { $URI -like "*rest/api/*/user?username=$testUsername&expand=groups" }
             }
 
             It "Gets information for a provided Jira user if a JiraPS.User object is provided to the InputObject parameter" {
@@ -165,14 +165,14 @@ InModuleScope JiraPS {
                 $result2 | Should -Not -BeNullOrEmpty
                 $result2.Name | Should -Be $testUsername
 
-                Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Exactly 2 -ParameterFilter { $URI -like "$jiraServer/rest/api/*/user?username=$testUsername&expand=groups" }
+                Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Exactly 2 -ParameterFilter { $URI -like "*rest/api/*/user?username=$testUsername&expand=groups" }
             }
 
             It "Allow it search for multiple users" {
                 Get-JiraUser -UserName "%"
 
                 Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Exactly 1 -ParameterFilter {
-                    $URI -like "$jiraServer/rest/api/*/user/search?*username=%25*"
+                    $URI -like "*rest/api/*/user/search?*username=%*"
                 }
             }
 
@@ -180,7 +180,8 @@ InModuleScope JiraPS {
                 Get-JiraUser -UserName "%" -MaxResults 100
 
                 Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Exactly 1 -ParameterFilter {
-                    $URI -like "$jiraServer/rest/api/*/user/search?*maxResults=100*"
+                    $URI -like "*rest/api/*/user/search?*username=%*" -and
+                    $URI -like "*rest/api/*/user/search?*maxResults=100*"
                 }
             }
 
@@ -188,7 +189,8 @@ InModuleScope JiraPS {
                 Get-JiraUser -UserName "%" -Skip 10
 
                 Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Exactly 1 -ParameterFilter {
-                    $URI -like "$jiraServer/rest/api/*/user/search?*startAt=10*"
+                    $URI -like "*rest/api/*/user/search?*username=%*" -and
+                    $URI -like "*rest/api/*/user/search?*startAt=10*"
                 }
             }
 
@@ -220,21 +222,21 @@ InModuleScope JiraPS {
                 $script:testAccountId = '5b10ac8d82e05b22cc7d4ef5'
 
                 Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {
-                    $Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/*/user/search?*query=*"
+                    $Method -eq 'Get' -and $URI -like "/rest/api/*/user/search?*query=*"
                 } {
                     Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                     ConvertFrom-Json -InputObject $restResult
                 }
 
                 Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {
-                    $Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/*/user?accountId=*"
+                    $Method -eq 'Get' -and $URI -like "/rest/api/*/user?accountId=*"
                 } {
                     Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                     ConvertFrom-Json -InputObject $restResult2
                 }
 
                 Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {
-                    $Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/*/myself"
+                    $Method -eq 'Get' -and $URI -like "/rest/api/*/myself"
                 } {
                     Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                     $obj = ConvertFrom-Json -InputObject $restResult
@@ -252,7 +254,7 @@ InModuleScope JiraPS {
                 Get-JiraUser -UserName $testUsername
 
                 Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Exactly 1 -ParameterFilter {
-                    $URI -like "$jiraServer/rest/api/*/user/search?*query=*"
+                    $URI -like "*rest/api/*/user/search?*query=*"
                 }
             }
 
@@ -260,7 +262,7 @@ InModuleScope JiraPS {
                 Get-JiraUser -AccountId $testAccountId -Exact
 
                 Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Exactly 1 -ParameterFilter {
-                    $URI -like "$jiraServer/rest/api/*/user?accountId=$testAccountId*"
+                    $URI -like "*rest/api/*/user?accountId=$testAccountId*"
                 }
             }
 
@@ -268,10 +270,10 @@ InModuleScope JiraPS {
                 Get-JiraUser
 
                 Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Exactly 1 -ParameterFilter {
-                    $URI -like "$jiraServer/rest/api/*/myself"
+                    $URI -like "*rest/api/*/myself"
                 }
                 Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Exactly 1 -ParameterFilter {
-                    $URI -like "$jiraServer/rest/api/*/user?accountId=$testAccountId*"
+                    $URI -like "*rest/api/*/user?accountId=$testAccountId*"
                 }
             }
         }

--- a/Tests/Functions/Public/Get-JiraVersion.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraVersion.Unit.Tests.ps1
@@ -116,22 +116,22 @@ InModuleScope JiraPS {
                 $result
             }
 
-            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/2/version/$versionId1" } {
+            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "/rest/api/2/version/$versionId1" } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                 ConvertFrom-Json $testJson1
             }
 
-            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/*/version/$versionId2" } {
+            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "/rest/api/*/version/$versionId2" } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                 ConvertFrom-Json $testJson2
             }
 
-            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/*/version" } {
+            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "/rest/api/*/version" } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                 ConvertFrom-Json $testJsonAll
             }
 
-            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "$jiraServer/rest/api/*/project/*/version" } {
+            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Get' -and $URI -like "/rest/api/*/project/*/version" } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri', 'Paging'
                 ConvertFrom-Json $testJsonAll
             }

--- a/Tests/Functions/Public/Invoke-JiraMethod.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Invoke-JiraMethod.Unit.Tests.ps1
@@ -76,6 +76,9 @@ InModuleScope JiraPS {
                     WebSession = New-Object -TypeName Microsoft.PowerShell.Commands.WebRequestSession
                 }
             }
+            Mock Get-JiraConfigServer -ModuleName 'JiraPS' {
+                'https://jira.example.com'
+            }
             Mock Test-ServerResponse -ModuleName 'JiraPS' {
                 Write-MockDebugInfo 'Test-ServerResponse'
             }
@@ -234,7 +237,32 @@ InModuleScope JiraPS {
                 { Invoke-JiraMethod -URI "https://postman-echo.com/get?test=123" -ErrorAction Stop } | Should -Not -Throw
                 { Invoke-JiraMethod -URI $Uri -ErrorAction Stop } | Should -Not -Throw
 
-                { Invoke-JiraMethod -URI "hello" -ErrorAction Stop } | Should -Throw -ExpectedMessage "*relative URI*"
+                { Invoke-JiraMethod -URI "hello" -ErrorAction Stop } | Should -Throw -ExpectedMessage "*must start with '/'*"
+            }
+
+            It "resolves relative URIs against configured Jira server" {
+                $null = Invoke-JiraMethod -URI "/rest/api/2/field" -ErrorAction Stop
+
+                Should -Invoke -CommandName Invoke-WebRequest -ModuleName 'JiraPS' -ParameterFilter {
+                    $Uri -like "https://jira.example.com/rest/api/2/field?*"
+                } -Exactly -Times 1
+            }
+
+            It "throws when relative URI is used without configured Jira server" {
+                Mock Get-JiraConfigServer -ModuleName 'JiraPS' { $null }
+
+                { Invoke-JiraMethod -URI "/rest/api/2/field" -ErrorAction Stop } | Should -Throw -ExpectedMessage "*no Jira server is configured*"
+            }
+
+            It "validates URI before returning cached data" {
+                $script:JiraCache = @{
+                    "TestCache:https://jira.example.com" = @{
+                        Data   = [PSCustomObject]@{ id = "cached-data" }
+                        Expiry = (Get-Date).AddMinutes(5)
+                    }
+                }
+
+                { Invoke-JiraMethod -URI "hello" -CacheKey 'TestCache' -ErrorAction Stop } | Should -Throw -ExpectedMessage "*must start with '/'*"
             }
 
             It "accepts [<_>] as HTTP method" -ForEach @('GET', 'POST', 'PUT', 'DELETE') {

--- a/Tests/Functions/Public/Move-JiraVersion.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Move-JiraVersion.Unit.Tests.ps1
@@ -63,11 +63,11 @@ InModuleScope JiraPS {
                 }
             }
 
-            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'POST' -and $URI -like "$jiraServer/rest/api/*/version/$versionID1/move" } {
+            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'POST' -and $URI -like "/rest/api/*/version/$versionID1/move" } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             }
 
-            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'POST' -and $URI -like "$jiraServer/rest/api/*/version/$versionID2/move" } {
+            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'POST' -and $URI -like "/rest/api/*/version/$versionID2/move" } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             }
 
@@ -106,20 +106,20 @@ InModuleScope JiraPS {
                 It 'moves a Version using its ID and Last Position' {
                     { Move-JiraVersion -Version $versionID1 -Position Last -ErrorAction Stop } | Should -Not -Throw
                     Should -Invoke -CommandName 'Get-JiraVersion' -Times 0 -ModuleName JiraPS -Exactly
-                    Should -Invoke -CommandName 'Get-JiraConfigServer' -Times 1 -ModuleName JiraPS -Exactly
+                    Should -Invoke -CommandName 'Get-JiraConfigServer' -Times 0 -ModuleName JiraPS -Exactly
                     Should -Invoke -CommandName 'Invoke-JiraMethod' -Times 1 -ModuleName JiraPS -Exactly -ParameterFilter {
                         $Method -eq 'POST' -and
-                        $URI -like "$jiraServer/rest/api/2/version/$versionID1/move" -and
+                        $URI -like "/rest/api/2/version/$versionID1/move" -and
                         $Body -match '"position":\s*"Last"'
                     }
                 }
                 It 'moves a Version using its ID and Earlier Position' {
                     { Move-JiraVersion -Version $versionID1 -Position Earlier -ErrorAction Stop } | Should -Not -Throw
                     Should -Invoke -CommandName 'Get-JiraVersion' -Times 0 -ModuleName JiraPS -Exactly
-                    Should -Invoke -CommandName 'Get-JiraConfigServer' -Times 1 -ModuleName JiraPS -Exactly
+                    Should -Invoke -CommandName 'Get-JiraConfigServer' -Times 0 -ModuleName JiraPS -Exactly
                     Should -Invoke -CommandName 'Invoke-JiraMethod' -Times 1 -ModuleName JiraPS -Exactly -ParameterFilter {
                         $Method -eq 'POST' -and
-                        $URI -like "$jiraServer/rest/api/2/version/$versionID1/move" -and
+                        $URI -like "/rest/api/2/version/$versionID1/move" -and
                         $Body -match '"position":\s*"Earlier"'
                     }
                 }
@@ -129,10 +129,10 @@ InModuleScope JiraPS {
                         Move-JiraVersion -Version $version -Position Later -ErrorAction Stop
                     } | Should -Not -Throw
                     Should -Invoke -CommandName 'Get-JiraVersion' -Times 1 -ModuleName JiraPS -Exactly
-                    Should -Invoke -CommandName 'Get-JiraConfigServer' -Times 1 -ModuleName JiraPS -Exactly
+                    Should -Invoke -CommandName 'Get-JiraConfigServer' -Times 0 -ModuleName JiraPS -Exactly
                     Should -Invoke -CommandName 'Invoke-JiraMethod' -Times 1 -ModuleName JiraPS -Exactly -ParameterFilter {
                         $Method -eq 'POST' -and
-                        $URI -like "$jiraServer/rest/api/2/version/$versionID2/move" -and
+                        $URI -like "/rest/api/2/version/$versionID2/move" -and
                         $Body -match '"position":\s*"Later"'
                     }
                 }
@@ -142,10 +142,10 @@ InModuleScope JiraPS {
                         Move-JiraVersion -Version $version -Position First -ErrorAction Stop
                     } | Should -Not -Throw
                     Should -Invoke -CommandName 'Get-JiraVersion' -Times 1 -ModuleName JiraPS -Exactly
-                    Should -Invoke -CommandName 'Get-JiraConfigServer' -Times 1 -ModuleName JiraPS -Exactly
+                    Should -Invoke -CommandName 'Get-JiraConfigServer' -Times 0 -ModuleName JiraPS -Exactly
                     Should -Invoke -CommandName 'Invoke-JiraMethod' -Times 1 -ModuleName JiraPS -Exactly -ParameterFilter {
                         $Method -eq 'POST' -and
-                        $URI -like "$jiraServer/rest/api/2/version/$versionID2/move" -and
+                        $URI -like "/rest/api/2/version/$versionID2/move" -and
                         $Body -match '"position":\s*"First"'
                     }
                 }
@@ -155,10 +155,10 @@ InModuleScope JiraPS {
                         $version | Move-JiraVersion -Position First -ErrorAction Stop
                     } | Should -Not -Throw
                     Should -Invoke -CommandName 'Get-JiraVersion' -Times 1 -ModuleName JiraPS -Exactly
-                    Should -Invoke -CommandName 'Get-JiraConfigServer' -Times 1 -ModuleName JiraPS -Exactly
+                    Should -Invoke -CommandName 'Get-JiraConfigServer' -Times 0 -ModuleName JiraPS -Exactly
                     Should -Invoke -CommandName 'Invoke-JiraMethod' -Times 1 -ModuleName JiraPS -Exactly -ParameterFilter {
                         $Method -eq 'POST' -and
-                        $URI -like "$jiraServer/rest/api/2/version/$versionID2/move" -and
+                        $URI -like "/rest/api/2/version/$versionID2/move" -and
                         $Body -match '"position":\s*"First"'
                     }
                 }
@@ -167,10 +167,10 @@ InModuleScope JiraPS {
                         $versionID1 | Move-JiraVersion -Position First -ErrorAction Stop
                     } | Should -Not -Throw
                     Should -Invoke -CommandName 'Get-JiraVersion' -Times 0 -ModuleName JiraPS -Exactly
-                    Should -Invoke -CommandName 'Get-JiraConfigServer' -Times 1 -ModuleName JiraPS -Exactly
+                    Should -Invoke -CommandName 'Get-JiraConfigServer' -Times 0 -ModuleName JiraPS -Exactly
                     Should -Invoke -CommandName 'Invoke-JiraMethod' -Times 1 -ModuleName JiraPS -Exactly -ParameterFilter {
                         $Method -eq 'POST' -and
-                        $URI -like "$jiraServer/rest/api/2/version/$versionID1/move" -and
+                        $URI -like "/rest/api/2/version/$versionID1/move" -and
                         $Body -match '"position":\s*"First"'
                     }
                 }
@@ -180,10 +180,10 @@ InModuleScope JiraPS {
                     $restUrl = (Get-JiraVersion -Id $versionID2).RestUrl
                     { Move-JiraVersion -Version $versionID1 -After $versionID2 -ErrorAction Stop } | Should -Not -Throw
                     Should -Invoke -CommandName 'Get-JiraVersion' -Times 2 -ModuleName JiraPS -Exactly
-                    Should -Invoke -CommandName 'Get-JiraConfigServer' -Times 1 -ModuleName JiraPS -Exactly
+                    Should -Invoke -CommandName 'Get-JiraConfigServer' -Times 0 -ModuleName JiraPS -Exactly
                     Should -Invoke -CommandName 'Invoke-JiraMethod' -Times 1 -ModuleName JiraPS -Exactly -ParameterFilter {
                         $Method -eq 'POST' -and
-                        $URI -like "$jiraServer/rest/api/2/version/$versionID1/move" -and
+                        $URI -like "/rest/api/2/version/$versionID1/move" -and
                         $Body -match """after"":\s*""$restUrl"""
                     }
                 }
@@ -192,10 +192,10 @@ InModuleScope JiraPS {
                     $version1 = Get-JiraVersion -Id $versionID1
                     { Move-JiraVersion -Version $version1 -After $versionID2 -ErrorAction Stop } | Should -Not -Throw
                     Should -Invoke -CommandName 'Get-JiraVersion' -Times 3 -ModuleName JiraPS -Exactly
-                    Should -Invoke -CommandName 'Get-JiraConfigServer' -Times 1 -ModuleName JiraPS -Exactly
+                    Should -Invoke -CommandName 'Get-JiraConfigServer' -Times 0 -ModuleName JiraPS -Exactly
                     Should -Invoke -CommandName 'Invoke-JiraMethod' -Times 1 -ModuleName JiraPS -Exactly -ParameterFilter {
                         $Method -eq 'POST' -and
-                        $URI -like "$jiraServer/rest/api/2/version/$versionID1/move" -and
+                        $URI -like "/rest/api/2/version/$versionID1/move" -and
                         $Body -match """after"":\s*""$restUrl"""
                     }
                 }
@@ -203,10 +203,10 @@ InModuleScope JiraPS {
                     $version2 = Get-JiraVersion -Id $versionID2
                     { Move-JiraVersion -Version $versionID1 -After $version2 -ErrorAction Stop } | Should -Not -Throw
                     Should -Invoke -CommandName 'Get-JiraVersion' -Times 1 -ModuleName JiraPS -Exactly
-                    Should -Invoke -CommandName 'Get-JiraConfigServer' -Times 1 -ModuleName JiraPS -Exactly
+                    Should -Invoke -CommandName 'Get-JiraConfigServer' -Times 0 -ModuleName JiraPS -Exactly
                     Should -Invoke -CommandName 'Invoke-JiraMethod' -Times 1 -ModuleName JiraPS -Exactly -ParameterFilter {
                         $Method -eq 'POST' -and
-                        $URI -like "$jiraServer/rest/api/2/version/$versionID1/move" -and
+                        $URI -like "/rest/api/2/version/$versionID1/move" -and
                         $Body -match """after"":\s*""$($version2.RestUrl)"""
                     }
                 }
@@ -214,10 +214,10 @@ InModuleScope JiraPS {
                     $version2 = Get-JiraVersion -Id $versionID2
                     { $versionID1 | Move-JiraVersion -After $version2 -ErrorAction Stop } | Should -Not -Throw
                     Should -Invoke -CommandName 'Get-JiraVersion' -Times 1 -ModuleName JiraPS -Exactly
-                    Should -Invoke -CommandName 'Get-JiraConfigServer' -Times 1 -ModuleName JiraPS -Exactly
+                    Should -Invoke -CommandName 'Get-JiraConfigServer' -Times 0 -ModuleName JiraPS -Exactly
                     Should -Invoke -CommandName 'Invoke-JiraMethod' -Times 1 -ModuleName JiraPS -Exactly -ParameterFilter {
                         $Method -eq 'POST' -and
-                        $URI -like "$jiraServer/rest/api/2/version/$versionID1/move" -and
+                        $URI -like "/rest/api/2/version/$versionID1/move" -and
                         $Body -match """after"":\s*""$($version2.RestUrl)"""
                     }
                 }
@@ -226,10 +226,10 @@ InModuleScope JiraPS {
                     $version2 = Get-JiraVersion -Id $versionID2
                     { $version1 | Move-JiraVersion -After $version2 -ErrorAction Stop } | Should -Not -Throw
                     Should -Invoke -CommandName 'Get-JiraVersion' -Times 2 -ModuleName JiraPS -Exactly
-                    Should -Invoke -CommandName 'Get-JiraConfigServer' -Times 1 -ModuleName JiraPS -Exactly
+                    Should -Invoke -CommandName 'Get-JiraConfigServer' -Times 0 -ModuleName JiraPS -Exactly
                     Should -Invoke -CommandName 'Invoke-JiraMethod' -Times 1 -ModuleName JiraPS -Exactly -ParameterFilter {
                         $Method -eq 'POST' -and
-                        $URI -like "$jiraServer/rest/api/2/version/$versionID1/move" -and
+                        $URI -like "/rest/api/2/version/$versionID1/move" -and
                         $Body -match """after"":\s*""$($version2.RestUrl)"""
                     }
                 }

--- a/Tests/Functions/Public/New-JiraFilter.Unit.Tests.ps1
+++ b/Tests/Functions/Public/New-JiraFilter.Unit.Tests.ps1
@@ -45,7 +45,7 @@ InModuleScope JiraPS {
                 ConvertTo-JiraFilter
             }
 
-            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Post' -and $URI -like "$jiraServer/rest/api/*/filter" } {
+            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Post' -and $URI -like "/rest/api/*/filter" } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri', 'Body'
                 ConvertFrom-Json $responseFilter
             }

--- a/Tests/Functions/Public/New-JiraGroup.Unit.Tests.ps1
+++ b/Tests/Functions/Public/New-JiraGroup.Unit.Tests.ps1
@@ -38,7 +38,7 @@ InModuleScope JiraPS {
                 $jiraServer
             }
 
-            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'POST' -and $URI -eq "$jiraServer/rest/api/2/group" } {
+            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'POST' -and $URI -eq "/rest/api/2/group" } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                 ConvertFrom-Json $testJson
             }

--- a/Tests/Functions/Public/New-JiraIssue.Unit.Tests.ps1
+++ b/Tests/Functions/Public/New-JiraIssue.Unit.Tests.ps1
@@ -146,14 +146,14 @@ InModuleScope JiraPS {
                 # The String in the ParameterFilter is made from the keywords
                 # we should expect to see in the JSON that should be sent,
                 # including the summary provided in the test call above.
-                Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -ParameterFilter { $Method -eq 'Post' -and $URI -like "$jiraServer/rest/api/*/issue" }
+                Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -ParameterFilter { $Method -eq 'Post' -and $URI -like "/rest/api/*/issue" }
             }
             It "Creates an issue in JIRA from pipeline" {
                 { $pipelineParams | New-JiraIssue } | Should -Not -Throw
                 # The String in the ParameterFilter is made from the keywords
                 # we should expect to see in the JSON that should be sent,
                 # including the summary provided in the test call above.
-                Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -ParameterFilter { $Method -eq 'Post' -and $URI -like "$jiraServer/rest/api/*/issue" }
+                Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -ParameterFilter { $Method -eq 'Post' -and $URI -like "/rest/api/*/issue" }
             }
 
             Context "New-JiraIssue handles duplicate fields" {

--- a/Tests/Functions/Public/New-JiraUser.Unit.Tests.ps1
+++ b/Tests/Functions/Public/New-JiraUser.Unit.Tests.ps1
@@ -37,7 +37,7 @@ InModuleScope JiraPS {
                 $jiraServer
             }
 
-            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'POST' -and $URI -eq "$jiraServer/rest/api/2/user" } {
+            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'POST' -and $URI -eq "/rest/api/2/user" } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                 ConvertFrom-Json $testJson
             }

--- a/Tests/Functions/Public/New-JiraVersion.Unit.Tests.ps1
+++ b/Tests/Functions/Public/New-JiraVersion.Unit.Tests.ps1
@@ -85,7 +85,7 @@ InModuleScope JiraPS {
                 $result
             }
 
-            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Post' -and $URI -like "$jiraServer/rest/api/*/version" } {
+            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Post' -and $URI -like "/rest/api/*/version" } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                 ConvertFrom-Json $testJsonOne
             }
@@ -132,14 +132,14 @@ InModuleScope JiraPS {
                 $results = $version | New-JiraVersion -ErrorAction Stop
                 $results | Should -Not -BeNullOrEmpty
                 $results.PSObject.TypeNames[0] | Should -Be "JiraPS.Version"
-                Should -Invoke 'Invoke-JiraMethod' -Times 1 -Exactly -ModuleName JiraPS -ParameterFilter { $Method -eq 'Post' -and $URI -like "$jiraServer/rest/api/2/version" }
+                Should -Invoke 'Invoke-JiraMethod' -Times 1 -Exactly -ModuleName JiraPS -ParameterFilter { $Method -eq 'Post' -and $URI -like "/rest/api/2/version" }
                 Should -Invoke 'ConvertTo-JiraVersion' -Times 1 -Exactly -ModuleName JiraPS
             }
             It "creates a Version using parameters" {
                 $results = New-JiraVersion -Name $versionName -Project $projectKey -ErrorAction Stop
                 $results | Should -Not -BeNullOrEmpty
                 $results.PSObject.TypeNames[0] | Should -Be "JiraPS.Version"
-                Should -Invoke 'Invoke-JiraMethod' -Times 1 -Exactly -ModuleName JiraPS -ParameterFilter { $Method -eq 'Post' -and $URI -like "$jiraServer/rest/api/2/version" }
+                Should -Invoke 'Invoke-JiraMethod' -Times 1 -Exactly -ModuleName JiraPS -ParameterFilter { $Method -eq 'Post' -and $URI -like "/rest/api/2/version" }
                 Should -Invoke 'ConvertTo-JiraVersion' -Times 1 -Exactly -ModuleName JiraPS
             }
             It "creates a Version using splatting" {
@@ -158,7 +158,7 @@ InModuleScope JiraPS {
                 $results = New-JiraVersion @splat -ErrorAction Stop
                 $results | Should -Not -BeNullOrEmpty
                 $results.PSObject.TypeNames[0] | Should -Be "JiraPS.Version"
-                Should -Invoke 'Invoke-JiraMethod' -Times 1 -Exactly -ModuleName JiraPS -ParameterFilter { $Method -eq 'Post' -and $URI -like "$jiraServer/rest/api/2/version" }
+                Should -Invoke 'Invoke-JiraMethod' -Times 1 -Exactly -ModuleName JiraPS -ParameterFilter { $Method -eq 'Post' -and $URI -like "/rest/api/2/version" }
                 Should -Invoke 'ConvertTo-JiraVersion' -Times 1 -Exactly -ModuleName JiraPS
             }
         }

--- a/Tests/Functions/Public/Remove-JiraGroup.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Remove-JiraGroup.Unit.Tests.ps1
@@ -46,7 +46,7 @@ InModuleScope JiraPS {
                 return $object
             }
 
-            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'DELETE' -and $URI -like "$jiraServer/rest/api/*/group?groupname=$testGroupName" } {
+            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'DELETE' -and $URI -like "/rest/api/*/group?groupname=$testGroupName" } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                 # This REST method should produce no output
             }

--- a/Tests/Functions/Public/Remove-JiraGroupMember.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Remove-JiraGroupMember.Unit.Tests.ps1
@@ -107,7 +107,7 @@ InModuleScope JiraPS {
 
                     Should -Invoke -CommandName Invoke-JiraMethod -ModuleName "JiraPS" -ParameterFilter {
                         $Method -eq 'Delete' -and
-                        $URI -like "$jiraServer/rest/api/*/group/user?groupname=$testGroupName&username=$testUsername1"
+                        $URI -like "/rest/api/*/group/user?groupname=$testGroupName&username=$testUsername1"
                     } -Exactly -Times 1
                 }
 
@@ -130,7 +130,7 @@ InModuleScope JiraPS {
 
                     Should -Invoke -CommandName Invoke-JiraMethod -ModuleName "JiraPS" -ParameterFilter {
                         $Method -eq 'Delete' -and
-                        $URI -like "$jiraServer/rest/api/*/group/user?groupname=$testGroupName&username=*"
+                        $URI -like "/rest/api/*/group/user?groupname=$testGroupName&username=*"
                     } -Exactly -Times 2
                 }
             }

--- a/Tests/Functions/Public/Remove-JiraIssue.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Remove-JiraIssue.Unit.Tests.ps1
@@ -211,12 +211,12 @@ InModuleScope JiraPS {
                 return $obj
             }
 
-            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $URI -like "$jiraServer/rest/api/*/issue/TEST-1?*" -and $Method -eq "Delete" } {
+            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $URI -like "/rest/api/*/issue/TEST-1?*" -and $Method -eq "Delete" } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                 return $null
             }
 
-            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $URI -like "$jiraServer/rest/api/*/issue/TEST-2?deleteSubTasks=False" -and $Method -eq "Delete" } {
+            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $URI -like "/rest/api/*/issue/TEST-2?deleteSubTasks=False" -and $Method -eq "Delete" } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                 $MockedResponse = @"
             {
@@ -238,7 +238,7 @@ InModuleScope JiraPS {
                 $PSCmdlet.WriteError($errorItem)
             }
 
-            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $URI -like "$jiraServer/rest/api/*/issue/TEST-2?deleteSubTasks=True" -and $Method -eq "Delete" } {
+            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $URI -like "/rest/api/*/issue/TEST-2?deleteSubTasks=True" -and $Method -eq "Delete" } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                 return $null
             }

--- a/Tests/Functions/Public/Remove-JiraIssueAttachment.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Remove-JiraIssueAttachment.Unit.Tests.ps1
@@ -68,11 +68,11 @@ InModuleScope JiraPS {
                 Get-JiraIssue -Key $Issue
             }
 
-            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Delete' -and $URI -eq "$jiraServer/rest/api/2/attachment/$attachmentId1" } {
+            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Delete' -and $URI -eq "/rest/api/2/attachment/$attachmentId1" } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             }
 
-            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Delete' -and $URI -eq "$jiraServer/rest/api/2/attachment/$attachmentId2" } {
+            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Delete' -and $URI -eq "/rest/api/2/attachment/$attachmentId2" } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             }
 
@@ -133,8 +133,8 @@ InModuleScope JiraPS {
                     Should -Invoke 'Get-JiraIssueAttachment' -ModuleName JiraPS -Exactly -Times 3
                     Should -Invoke 'Invoke-JiraMethod' -ModuleName JiraPS -ParameterFilter { $Method -ne 'Delete' } -Exactly -Times 0
                     Should -Invoke 'Invoke-JiraMethod' -ModuleName JiraPS -ParameterFilter { $Method -eq 'Delete' } -Exactly -Times 8
-                    Should -Invoke 'Invoke-JiraMethod' -ModuleName JiraPS -ParameterFilter { $Method -eq 'Delete' -and $URI -like "$jiraServer/rest/api/2/attachment/$attachmentId1" } -Exactly -Times 5
-                    Should -Invoke 'Invoke-JiraMethod' -ModuleName JiraPS -ParameterFilter { $Method -eq 'Delete' -and $URI -like "$jiraServer/rest/api/2/attachment/$attachmentId2" } -Exactly -Times 3
+                    Should -Invoke 'Invoke-JiraMethod' -ModuleName JiraPS -ParameterFilter { $Method -eq 'Delete' -and $URI -like "/rest/api/2/attachment/$attachmentId1" } -Exactly -Times 5
+                    Should -Invoke 'Invoke-JiraMethod' -ModuleName JiraPS -ParameterFilter { $Method -eq 'Delete' -and $URI -like "/rest/api/2/attachment/$attachmentId2" } -Exactly -Times 3
                 }
 
                 It 'accepts positional parameters' {

--- a/Tests/Functions/Public/Remove-JiraIssueLink.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Remove-JiraIssueLink.Unit.Tests.ps1
@@ -45,7 +45,7 @@ InModuleScope JiraPS {
                 return $issue
             }
 
-            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Delete' -and $URI -like "$jiraServer/rest/api/*/issueLink/1234" } {
+            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Delete' -and $URI -like "/rest/api/*/issueLink/1234" } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             }
 

--- a/Tests/Functions/Public/Remove-JiraUser.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Remove-JiraUser.Unit.Tests.ps1
@@ -49,7 +49,7 @@ InModuleScope JiraPS {
 
             Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {
                 $Method -eq 'DELETE' -and
-                $URI -like "$jiraServer/rest/api/*/user?username=$testUsername"
+                $URI -like "/rest/api/*/user?username=$testUsername"
             } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                 # This REST method should produce no output
@@ -135,7 +135,7 @@ InModuleScope JiraPS {
 
                 Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {
                     $Method -eq 'DELETE' -and
-                    $URI -like "$jiraServer/rest/api/*/user?accountId=*"
+                    $URI -like "/rest/api/*/user?accountId=*"
                 } {
                     Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                 }

--- a/Tests/Functions/Public/Set-JiraUser.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Set-JiraUser.Unit.Tests.ps1
@@ -46,7 +46,7 @@ InModuleScope JiraPS {
                 return $object
             }
 
-            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Put' -and $URI -eq "$jiraServer/rest/api/2/user?username=$testUsername" } {
+            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Put' -and $URI -eq "/rest/api/2/user?username=$testUsername" } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                 ConvertFrom-Json $restResultGet
             }
@@ -144,7 +144,7 @@ InModuleScope JiraPS {
 
                 Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {
                     $Method -eq 'Put' -and
-                    $URI -like "$jiraServer/rest/api/2/user?accountId=*"
+                    $URI -like "/rest/api/2/user?accountId=*"
                 } {
                     Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
                     ConvertFrom-Json $restResultGet

--- a/docs/en-US/about_JiraPS_MigrationV3.md
+++ b/docs/en-US/about_JiraPS_MigrationV3.md
@@ -38,6 +38,7 @@ This guide lists every breaking change introduced in v3 and shows how to update 
 | `Set-JiraIssue -Assignee`    | No longer positional; must be supplied by name.                         |
 | `New-JiraIssue -Reporter`    | No longer accepts `$null`, empty, or whitespace-only strings.           |
 | `New-JiraIssue -Reporter`    | Now resolves the user via `Resolve-JiraUser` on Server / DC too.        |
+| `Invoke-JiraMethod -Uri`     | Relative endpoint paths are now first-class (`/rest/api/...`).          |
 | Minimum PowerShell version   | Raised from 3.0 to 5.1.                                                 |
 
 ## DEPRECATIONS (NON-BREAKING)
@@ -227,6 +228,21 @@ $comment = Get-Process powershell | ConvertTo-JiraTable
 `ConvertTo-JiraTable` produces Jira wiki markup, the native format for Jira Server / Data Center.
 On **Jira Cloud** REST v3 endpoints expect Atlassian Document Format (ADF) and render the resulting `||header||` / `|cell|` syntax as literal text rather than as a table.
 Wrapping the write-side text payloads (`Add-JiraIssueComment`, `Add-JiraIssueWorklog`, `New-JiraIssue -Description`, etc.) in ADF on Cloud is tracked in [#602](https://github.com/AtlassianPS/JiraPS/issues/602).
+
+### Endpoint Paths in `Invoke-JiraMethod`
+
+In v3, JiraPS standardizes internal REST calls on relative endpoint paths that match Atlassian documentation (for example, `/rest/api/2/project`).
+`Invoke-JiraMethod` resolves those relative paths against `Get-JiraConfigServer`.
+Relative paths must start with `/`.
+Calls like `Invoke-JiraMethod -Uri 'rest/api/2/project'` now throw a clear argument error.
+Absolute URLs are still accepted for backward compatibility and for object properties like `RestURL`.
+
+#### Recommended in v3
+
+```powershell
+Invoke-JiraMethod -Uri '/rest/api/2/project'
+Invoke-JiraMethod -Uri '/rest/api/2/issue/TEST-1'
+```
 
 ### Minimum PowerShell Version
 

--- a/docs/en-US/commands/Invoke-JiraMethod.md
+++ b/docs/en-US/commands/Invoke-JiraMethod.md
@@ -29,6 +29,8 @@ Make a call to a REST Api endpoint with all the benefits of JiraPS.
 
 This cmdlet is what the other cmdlets call under the hood.
 It handles the authentication, parses the response, handles exceptions from Jira, returns specific objects and handles the differences between versions of Powershell and Operating Systems.
+When you pass a relative URI path, it must start with `/` and JiraPS resolves it against `Get-JiraConfigServer`.
+Absolute URIs are also accepted for compatibility with object properties like `RestURL`.
 
 JiraPS does not support any third-party plugins on Jira.
 This cmdlet can be used to interact with REST Api enpoints which are not already coverted in JiraPS.
@@ -41,7 +43,7 @@ This will import the module if not already loaded or even download it from the P
 ### Example 1
 
 ```powershell
-Invoke-JiraMethod -URI "$(Get-JiraConfigServer)/rest/api/latest/project"
+Invoke-JiraMethod -URI "/rest/api/latest/project"
 ```
 
 Sends a GET request which will return all the projects on the Jira server.
@@ -50,7 +52,7 @@ This call would either be executed anonymously or require a session to be availa
 ### Example 2
 
 ```powershell
-Invoke-JiraMethod -URI "$(Get-JiraConfigServer)/rest/api/latest/project" -Credential (Get-Credential)
+Invoke-JiraMethod -URI "/rest/api/latest/project" -Credential (Get-Credential)
 ```
 
 Prompts the user for his Jira credentials and send a GET request,
@@ -60,7 +62,7 @@ which will return all the projects on the Jira server.
 
 ```powershell
 $parameter = @{
-    URI = "$(Get-JiraConfigServer)/rest/api/latest/project"
+    URI = "/rest/api/latest/project"
     Method = "POST"
     Credential = $cred
 }
@@ -78,7 +80,7 @@ See next example
 ```powershell
 $body = '{"name": "NewGroup"}'
 $params = @{
-    Uri = "$(Get-JiraConfigServer)/rest/api/latest/group"
+    Uri = "/rest/api/latest/group"
     Method = "POST"
     Body = $body
     Credential = $cred
@@ -92,7 +94,7 @@ Creates a new group named "NewGroup"
 
 ```powershell
 $params = @{
-    Uri = "$(Get-JiraConfigServer)/rest/api/latest/mypermissions"
+    Uri = "/rest/api/latest/mypermissions"
     Method = "GET"
     Body = $body
     StoreSession = $true
@@ -108,7 +110,7 @@ it returns a `[JiraPS.Session]` which contains the `[WebRequestSession]`.
 
 ```powershell
 $params = @{
-    Uri = "$(Get-JiraConfigServer)/rest/api/latest/issue/10000"
+    Uri = "/rest/api/latest/issue/10000"
     Method = "POST"
     InFile = "c:\temp\20001231_Connection.log"
     Credential = $cred
@@ -122,7 +124,7 @@ Executes a POST request on the defined URI and uploads the InFile with a multipa
 
 ```powershell
 $parameter = @{
-    URI = "$(Get-JiraConfigServer)/rest/api/latest/project"
+    URI = "/rest/api/latest/project"
     Method = "GET"
     OutFile = "c:\temp\jira_projects.json"
     Credential = $cred
@@ -136,7 +138,7 @@ Executes a GET request on all available projects and stores the response json in
 
 ```powershell
 $parameter = @{
-    URI = "$(Get-JiraConfigServer)/rest/api/latest/project"
+    URI = "/rest/api/latest/project"
     Method = "GET"
     Headers = @{"Accept" = "text/plain"}
     OutFile = "c:\temp\jira_projects.json"
@@ -152,7 +154,7 @@ It also uses the Headers to define what mimeTypes are expected in the response.
 
 ```powershell
 $parameter = @{
-    URI = "$(Get-JiraConfigServer)/rest/api/latest/field"
+    URI = "/rest/api/latest/field"
     Method = "GET"
     CacheKey = "Fields"
     CacheExpiry = [TimeSpan]::FromHours(1)
@@ -193,7 +195,7 @@ Use the form that best communicates the intended duration.
 
 ```powershell
 $parameter = @{
-    URI = "$(Get-JiraConfigServer)/rest/api/latest/field"
+    URI = "/rest/api/latest/field"
     CacheKey = "Fields"
     BypassCache = $true
 }
@@ -630,6 +632,9 @@ HelpMessage: ''
 ### -URI
 
 URI address of the REST API endpoint.
+Relative paths must start with `/`.
+When a relative path is used, JiraPS prefixes it with the configured Jira server URL.
+Absolute URLs are still supported.
 
 ```yaml
 Type: Uri


### PR DESCRIPTION
## Summary
- Centralize URI handling in `Invoke-JiraMethod`: relative paths are now resolved against `Get-JiraConfigServer`, must start with `/`, and throw clear terminating errors when invalid.
- Keep absolute URI support for backward compatibility (including existing `RestURL`-driven call sites), while migrating public cmdlets to pass Jira-doc style `/rest/api/...` endpoints.
- Update unit tests and docs (`Invoke-JiraMethod` command help, migration guide, changelog) to document the new URI contract and behavior.

## Test plan
- [x] `Invoke-Build -Task Build, Test`
- [x] Targeted `Invoke-Pester` runs for each edited public cmdlet test file during implementation.
- [x] `Invoke-Build -Task TestIntegration` with credentials from local `.env`
  - Result: failed on pre-existing environment/fixture assumptions unrelated to this change:
    - `Tests/Integration/IssueLinks.Integration.Tests.ps1` (`InwardDescription` assertions assume non-empty link descriptions)
    - `Tests/Integration/IssueWatchers.Integration.Tests.ps1` (watcher list/state timing assumptions)

Fixes #605

Made with [Cursor](https://cursor.com)