### PR TITLE
Add opt-in response-header logging for Jira diagnostic headers (#536)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ See [`about_JiraPS_MigrationV3`](https://atlassianps.org/docs/JiraPS/about/migra
 - Added `-CacheKey`, `-CacheExpiry` (as `[TimeSpan]`), and `-BypassCache` parameters to `Invoke-JiraMethod` for built-in response caching (#576)
 - Added caching to `Get-JiraField`, `Get-JiraIssueType`, and `Get-JiraPriority` with a `-Force` parameter to bypass the cache (#576)
 - Added `Clear-JiraCache` public function to clear cached API responses by type (#576)
+- Added `Set-JiraResponseHeaderLogConfiguration` to opt into debug logging for selected Jira response headers, including Data Center diagnostic headers such as `X-AREQUESTID`, `X-ANODEID`, `X-ASESSIONID`, and `X-AUSERNAME` (#536)
+- Added `Get-JiraResponseHeaderLogConfiguration` to inspect the active response-header logging configuration (#536)
 - Added "Automation and CI/CD" section to authentication documentation with programmatic SecureString examples (#576)
 - Added `ConvertTo-JiraTable` as the descriptive replacement for `Format-Jira`.
   The new name reflects what the cmdlet actually does: it returns a `[String]` of Jira wiki-markup table syntax, not a host-only `Format-*` display object.

--- a/JiraPS/JiraPS.psm1
+++ b/JiraPS/JiraPS.psm1
@@ -46,6 +46,7 @@ $script:DefaultHeaders = @{
     "Accept-Charset" = "utf-8"
     "Accept"         = "application/json"
 }
+$script:JiraResponseHeaderLogConfiguration = $null
 $script:PagingContainers = @(
     "comments"
     "dashboards"

--- a/JiraPS/Private/Test-JiraResponseHeaderMatch.ps1
+++ b/JiraPS/Private/Test-JiraResponseHeaderMatch.ps1
@@ -1,0 +1,29 @@
+﻿function Test-JiraResponseHeaderMatch {
+    [CmdletBinding()]
+    [OutputType([Boolean])]
+    param(
+        [Parameter(Mandatory)]
+        [PSObject]
+        $Configuration,
+
+        [Parameter(Mandatory)]
+        [String]
+        $Name
+    )
+
+    if ($Configuration.Mode -eq 'Regex') {
+        return $Configuration.Pattern.IsMatch($Name)
+    }
+
+    $included = $false
+    foreach ($p in $Configuration.Include) {
+        if ($p.IsMatch($Name)) { $included = $true; break }
+    }
+    if (-not $included) { return $false }
+
+    foreach ($p in $Configuration.Exclude) {
+        if ($p.IsMatch($Name)) { return $false }
+    }
+
+    $true
+}

--- a/JiraPS/Private/Test-JiraResponseHeaderMatch.ps1
+++ b/JiraPS/Private/Test-JiraResponseHeaderMatch.ps1
@@ -15,14 +15,21 @@
         return $Configuration.Pattern.IsMatch($Name)
     }
 
+    $wildcardOptions = [System.Management.Automation.WildcardOptions]::IgnoreCase
+
     $included = $false
     foreach ($p in $Configuration.Include) {
-        if ($p.IsMatch($Name)) { $included = $true; break }
+        if ([System.Management.Automation.WildcardPattern]::new($p, $wildcardOptions).IsMatch($Name)) {
+            $included = $true
+            break
+        }
     }
     if (-not $included) { return $false }
 
     foreach ($p in $Configuration.Exclude) {
-        if ($p.IsMatch($Name)) { return $false }
+        if ([System.Management.Automation.WildcardPattern]::new($p, $wildcardOptions).IsMatch($Name)) {
+            return $false
+        }
     }
 
     $true

--- a/JiraPS/Private/Write-JiraResponseHeaderLog.ps1
+++ b/JiraPS/Private/Write-JiraResponseHeaderLog.ps1
@@ -26,7 +26,7 @@ function Write-JiraResponseHeaderLog {
     $matched = @{}
     foreach ($key in @($InputObject.Headers.Keys)) {
         if ($key -in $script:AlwaysSuppressedResponseHeaders) { continue }
-        if (-not (& $config.Match $key)) { continue }
+        if (-not (Test-JiraResponseHeaderMatch -Configuration $config -Name $key)) { continue }
 
         $value = $InputObject.Headers[$key]
         if ($value -is [System.Collections.IEnumerable] -and $value -isnot [String]) {

--- a/JiraPS/Private/Write-JiraResponseHeaderLog.ps1
+++ b/JiraPS/Private/Write-JiraResponseHeaderLog.ps1
@@ -1,0 +1,40 @@
+﻿$script:AlwaysSuppressedResponseHeaders = @(
+    'Set-Cookie'
+    'Set-Cookie2'
+    'Authorization'
+    'Proxy-Authorization'
+)
+
+function Write-JiraResponseHeaderLog {
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [AllowNull()]
+        [PSObject]
+        $InputObject
+    )
+
+    if (-not $InputObject -or -not $InputObject.Headers) {
+        return
+    }
+
+    $config = $script:JiraResponseHeaderLogConfiguration
+    if (-not $config) {
+        return
+    }
+
+    $matched = @{}
+    foreach ($key in @($InputObject.Headers.Keys)) {
+        if ($key -in $script:AlwaysSuppressedResponseHeaders) { continue }
+        if (-not (& $config.Match $key)) { continue }
+
+        $value = $InputObject.Headers[$key]
+        if ($value -is [System.Collections.IEnumerable] -and $value -isnot [String]) {
+            $value = ($value | ForEach-Object { [String]$_ }) -join ', '
+        }
+
+        $matched[$key] = $value
+    }
+
+    Write-DebugMessage ($matched | Out-String)
+}

--- a/JiraPS/Public/Get-JiraResponseHeaderLogConfiguration.ps1
+++ b/JiraPS/Public/Get-JiraResponseHeaderLogConfiguration.ps1
@@ -1,0 +1,7 @@
+﻿function Get-JiraResponseHeaderLogConfiguration {
+    # .ExternalHelp ..\JiraPS-help.xml
+    [CmdletBinding()]
+    param()
+
+    $script:JiraResponseHeaderLogConfiguration
+}

--- a/JiraPS/Public/Invoke-JiraMethod.ps1
+++ b/JiraPS/Public/Invoke-JiraMethod.ps1
@@ -250,6 +250,11 @@
             Invoke-JiraMethod @PSBoundParameters
             return
         }
+        if ($script:JiraResponseHeaderLogConfiguration) {
+            Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] Jira response headers"
+            try { Write-JiraResponseHeaderLog -InputObject $webResponse }
+            catch { Write-Debug "[$($MyInvocation.MyCommand.Name)] Failed to log response headers: $_" }
+        }
         #endregion Execute the actual query
     }
 

--- a/JiraPS/Public/Set-JiraResponseHeaderLogConfiguration.ps1
+++ b/JiraPS/Public/Set-JiraResponseHeaderLogConfiguration.ps1
@@ -39,11 +39,10 @@
         }
     }
     else {
-        $wildcardOptions = [System.Management.Automation.WildcardOptions]::IgnoreCase
         [PSCustomObject]@{
             Mode    = 'Wildcard'
-            Include = @($Include | ForEach-Object { [System.Management.Automation.WildcardPattern]::new($_, $wildcardOptions) })
-            Exclude = @($Exclude | ForEach-Object { [System.Management.Automation.WildcardPattern]::new($_, $wildcardOptions) })
+            Include = [String[]]$Include
+            Exclude = [String[]]$Exclude
         }
     }
 

--- a/JiraPS/Public/Set-JiraResponseHeaderLogConfiguration.ps1
+++ b/JiraPS/Public/Set-JiraResponseHeaderLogConfiguration.ps1
@@ -1,0 +1,69 @@
+﻿function Set-JiraResponseHeaderLogConfiguration {
+    # .ExternalHelp ..\JiraPS-help.xml
+    [CmdletBinding(DefaultParameterSetName = 'Wildcard')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSUseShouldProcessForStateChangingFunctions', '',
+        Justification = 'Sets in-memory module configuration; nothing to confirm or undo.'
+    )]
+    param(
+        [Parameter(Mandatory, ParameterSetName = 'Wildcard')]
+        [ValidateNotNullOrEmpty()]
+        [String[]]
+        $Include,
+
+        [Parameter(ParameterSetName = 'Wildcard')]
+        [ValidateNotNull()]
+        [String[]]
+        $Exclude = @(),
+
+        [Parameter(Mandatory, ParameterSetName = 'Regex')]
+        [ValidateNotNull()]
+        [Regex]
+        $Pattern,
+
+        [Parameter(Mandatory, ParameterSetName = 'Disabled')]
+        [Switch]
+        $Disable
+    )
+
+    if ($Disable) {
+        $script:JiraResponseHeaderLogConfiguration = $null
+        return
+    }
+
+    $matcher = if ($PSCmdlet.ParameterSetName -eq 'Regex') {
+        $regex = [Regex]::new(
+            $Pattern.ToString(),
+            ($Pattern.Options -bor [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+        )
+        { param($name) $regex.IsMatch($name) }.GetNewClosure()
+    }
+    else {
+        $wildcardOptions = [System.Management.Automation.WildcardOptions]::IgnoreCase
+        $includes = @($Include | ForEach-Object { [System.Management.Automation.WildcardPattern]::new($_, $wildcardOptions) })
+        $excludes = @($Exclude | ForEach-Object { [System.Management.Automation.WildcardPattern]::new($_, $wildcardOptions) })
+        {
+            param($name)
+            $included = $false
+            foreach ($p in $includes) { if ($p.IsMatch($name)) { $included = $true; break } }
+            if (-not $included) { return $false }
+            foreach ($p in $excludes) { if ($p.IsMatch($name)) { return $false } }
+            $true
+        }.GetNewClosure()
+    }
+
+    # X-Auth-Token is in the warn list (not the unconditional suppress list)
+    # because users may legitimately want to inspect their own custom auth-style
+    # response headers; the warning gives them a chance to add an explicit Exclude.
+    $sensitiveSamples = @($script:AlwaysSuppressedResponseHeaders) + 'X-Auth-Token'
+    foreach ($name in $sensitiveSamples) {
+        if (& $matcher $name) {
+            Write-Warning "[$($MyInvocation.MyCommand.Name)] The configured response-header patterns may match sensitive headers. Cookie and Authorization headers are always suppressed, but review debug logs before sharing them."
+            break
+        }
+    }
+
+    $script:JiraResponseHeaderLogConfiguration = [PSCustomObject]@{
+        Match = $matcher
+    }
+}

--- a/JiraPS/Public/Set-JiraResponseHeaderLogConfiguration.ps1
+++ b/JiraPS/Public/Set-JiraResponseHeaderLogConfiguration.ps1
@@ -31,25 +31,20 @@
         return
     }
 
-    $matcher = if ($PSCmdlet.ParameterSetName -eq 'Regex') {
-        $regex = [Regex]::new(
-            $Pattern.ToString(),
-            ($Pattern.Options -bor [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
-        )
-        { param($name) $regex.IsMatch($name) }.GetNewClosure()
+    $config = if ($PSCmdlet.ParameterSetName -eq 'Regex') {
+        $regexOptions = [System.Text.RegularExpressions.RegexOptions]($Pattern.Options -bor [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+        [PSCustomObject]@{
+            Mode    = 'Regex'
+            Pattern = [Regex]::new($Pattern.ToString(), $regexOptions)
+        }
     }
     else {
         $wildcardOptions = [System.Management.Automation.WildcardOptions]::IgnoreCase
-        $includes = @($Include | ForEach-Object { [System.Management.Automation.WildcardPattern]::new($_, $wildcardOptions) })
-        $excludes = @($Exclude | ForEach-Object { [System.Management.Automation.WildcardPattern]::new($_, $wildcardOptions) })
-        {
-            param($name)
-            $included = $false
-            foreach ($p in $includes) { if ($p.IsMatch($name)) { $included = $true; break } }
-            if (-not $included) { return $false }
-            foreach ($p in $excludes) { if ($p.IsMatch($name)) { return $false } }
-            $true
-        }.GetNewClosure()
+        [PSCustomObject]@{
+            Mode    = 'Wildcard'
+            Include = @($Include | ForEach-Object { [System.Management.Automation.WildcardPattern]::new($_, $wildcardOptions) })
+            Exclude = @($Exclude | ForEach-Object { [System.Management.Automation.WildcardPattern]::new($_, $wildcardOptions) })
+        }
     }
 
     # X-Auth-Token is in the warn list (not the unconditional suppress list)
@@ -57,13 +52,11 @@
     # response headers; the warning gives them a chance to add an explicit Exclude.
     $sensitiveSamples = @($script:AlwaysSuppressedResponseHeaders) + 'X-Auth-Token'
     foreach ($name in $sensitiveSamples) {
-        if (& $matcher $name) {
+        if (Test-JiraResponseHeaderMatch -Configuration $config -Name $name) {
             Write-Warning "[$($MyInvocation.MyCommand.Name)] The configured response-header patterns may match sensitive headers. Cookie and Authorization headers are always suppressed, but review debug logs before sharing them."
             break
         }
     }
 
-    $script:JiraResponseHeaderLogConfiguration = [PSCustomObject]@{
-        Match = $matcher
-    }
+    $script:JiraResponseHeaderLogConfiguration = $config
 }

--- a/Tests/Functions/Private/Test-JiraResponseHeaderMatch.Unit.Tests.ps1
+++ b/Tests/Functions/Private/Test-JiraResponseHeaderMatch.Unit.Tests.ps1
@@ -1,0 +1,62 @@
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+
+BeforeDiscovery {
+    . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+
+    $script:moduleToTest = Initialize-TestEnvironment
+}
+
+InModuleScope JiraPS {
+    Describe "Test-JiraResponseHeaderMatch" -Tag 'Unit' {
+        BeforeAll {
+            $wildcardOptions = [System.Management.Automation.WildcardOptions]::IgnoreCase
+
+            $script:wildcardConfig = [PSCustomObject]@{
+                Mode    = 'Wildcard'
+                Include = @(
+                    [System.Management.Automation.WildcardPattern]::new('X-A*', $wildcardOptions)
+                )
+                Exclude = @(
+                    [System.Management.Automation.WildcardPattern]::new('X-Auth*', $wildcardOptions)
+                )
+            }
+
+            $script:regexConfig = [PSCustomObject]@{
+                Mode    = 'Regex'
+                Pattern = [Regex]::new('^x-a(?!uth)', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+            }
+        }
+
+        Context "Wildcard mode" {
+            It "returns true when Include matches and Exclude does not" {
+                Test-JiraResponseHeaderMatch -Configuration $wildcardConfig -Name 'X-AREQUESTID' | Should -BeTrue
+            }
+
+            It "returns false when Exclude matches an Include hit" {
+                Test-JiraResponseHeaderMatch -Configuration $wildcardConfig -Name 'X-Auth-Token' | Should -BeFalse
+            }
+
+            It "returns false when no Include pattern matches" {
+                Test-JiraResponseHeaderMatch -Configuration $wildcardConfig -Name 'Server' | Should -BeFalse
+            }
+
+            It "matches case-insensitively" {
+                Test-JiraResponseHeaderMatch -Configuration $wildcardConfig -Name 'x-anodeid' | Should -BeTrue
+            }
+        }
+
+        Context "Regex mode" {
+            It "returns true when the pattern matches" {
+                Test-JiraResponseHeaderMatch -Configuration $regexConfig -Name 'X-AREQUESTID' | Should -BeTrue
+            }
+
+            It "returns false when the pattern excludes via lookahead" {
+                Test-JiraResponseHeaderMatch -Configuration $regexConfig -Name 'X-Auth-Token' | Should -BeFalse
+            }
+
+            It "matches case-insensitively" {
+                Test-JiraResponseHeaderMatch -Configuration $regexConfig -Name 'x-anodeid' | Should -BeTrue
+            }
+        }
+    }
+}

--- a/Tests/Functions/Private/Test-JiraResponseHeaderMatch.Unit.Tests.ps1
+++ b/Tests/Functions/Private/Test-JiraResponseHeaderMatch.Unit.Tests.ps1
@@ -9,16 +9,10 @@ BeforeDiscovery {
 InModuleScope JiraPS {
     Describe "Test-JiraResponseHeaderMatch" -Tag 'Unit' {
         BeforeAll {
-            $wildcardOptions = [System.Management.Automation.WildcardOptions]::IgnoreCase
-
             $script:wildcardConfig = [PSCustomObject]@{
                 Mode    = 'Wildcard'
-                Include = @(
-                    [System.Management.Automation.WildcardPattern]::new('X-A*', $wildcardOptions)
-                )
-                Exclude = @(
-                    [System.Management.Automation.WildcardPattern]::new('X-Auth*', $wildcardOptions)
-                )
+                Include = @('X-A*')
+                Exclude = @('X-Auth*')
             }
 
             $script:regexConfig = [PSCustomObject]@{

--- a/Tests/Functions/Private/Write-JiraResponseHeaderLog.Unit.Tests.ps1
+++ b/Tests/Functions/Private/Write-JiraResponseHeaderLog.Unit.Tests.ps1
@@ -14,12 +14,11 @@ InModuleScope JiraPS {
 
         BeforeAll {
             Mock Write-DebugMessage -ModuleName 'JiraPS' {}
+            Mock Test-JiraResponseHeaderMatch -ModuleName 'JiraPS' { $true }
         }
 
         It "returns silently when InputObject is null" {
-            $script:JiraResponseHeaderLogConfiguration = [PSCustomObject]@{
-                Match = { param($name) $true }
-            }
+            $script:JiraResponseHeaderLogConfiguration = [PSCustomObject]@{ Mode = 'Wildcard' }
 
             { Write-JiraResponseHeaderLog -InputObject $null } | Should -Not -Throw
 
@@ -27,9 +26,7 @@ InModuleScope JiraPS {
         }
 
         It "returns silently when InputObject has no Headers property" {
-            $script:JiraResponseHeaderLogConfiguration = [PSCustomObject]@{
-                Match = { param($name) $true }
-            }
+            $script:JiraResponseHeaderLogConfiguration = [PSCustomObject]@{ Mode = 'Wildcard' }
             $response = [PSCustomObject]@{ StatusCode = 200 }
 
             { Write-JiraResponseHeaderLog -InputObject $response } | Should -Not -Throw
@@ -48,9 +45,9 @@ InModuleScope JiraPS {
         }
 
         It "writes a debug message containing matched headers" {
-            $script:JiraResponseHeaderLogConfiguration = [PSCustomObject]@{
-                Match = { param($name) $name -like 'X-A*' }
-            }
+            $script:JiraResponseHeaderLogConfiguration = [PSCustomObject]@{ Mode = 'Wildcard' }
+            Mock Test-JiraResponseHeaderMatch -ModuleName 'JiraPS' { $Name -like 'X-A*' }
+
             $response = [PSCustomObject]@{
                 Headers = @{
                     'X-AREQUESTID' = 'request-123'
@@ -67,9 +64,7 @@ InModuleScope JiraPS {
         }
 
         It "always suppresses cookie and authorization headers regardless of matcher" {
-            $script:JiraResponseHeaderLogConfiguration = [PSCustomObject]@{
-                Match = { param($name) $true }
-            }
+            $script:JiraResponseHeaderLogConfiguration = [PSCustomObject]@{ Mode = 'Wildcard' }
             $response = [PSCustomObject]@{
                 Headers = @{
                     'Set-Cookie'          = 'sid=cookie-secret'
@@ -92,9 +87,7 @@ InModuleScope JiraPS {
         }
 
         It "flattens IEnumerable[string] header values into a comma-separated list" {
-            $script:JiraResponseHeaderLogConfiguration = [PSCustomObject]@{
-                Match = { param($name) $true }
-            }
+            $script:JiraResponseHeaderLogConfiguration = [PSCustomObject]@{ Mode = 'Wildcard' }
             $response = [PSCustomObject]@{
                 Headers = @{
                     'X-AREQUESTID' = @('request-123', 'request-456')

--- a/Tests/Functions/Private/Write-JiraResponseHeaderLog.Unit.Tests.ps1
+++ b/Tests/Functions/Private/Write-JiraResponseHeaderLog.Unit.Tests.ps1
@@ -1,0 +1,111 @@
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+
+BeforeDiscovery {
+    . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+
+    $script:moduleToTest = Initialize-TestEnvironment
+}
+
+InModuleScope JiraPS {
+    Describe "Write-JiraResponseHeaderLog" -Tag 'Unit' {
+        BeforeEach {
+            $script:JiraResponseHeaderLogConfiguration = $null
+        }
+
+        BeforeAll {
+            Mock Write-DebugMessage -ModuleName 'JiraPS' {}
+        }
+
+        It "returns silently when InputObject is null" {
+            $script:JiraResponseHeaderLogConfiguration = [PSCustomObject]@{
+                Match = { param($name) $true }
+            }
+
+            { Write-JiraResponseHeaderLog -InputObject $null } | Should -Not -Throw
+
+            Should -Invoke -CommandName Write-DebugMessage -ModuleName 'JiraPS' -Exactly -Times 0 -Scope It
+        }
+
+        It "returns silently when InputObject has no Headers property" {
+            $script:JiraResponseHeaderLogConfiguration = [PSCustomObject]@{
+                Match = { param($name) $true }
+            }
+            $response = [PSCustomObject]@{ StatusCode = 200 }
+
+            { Write-JiraResponseHeaderLog -InputObject $response } | Should -Not -Throw
+
+            Should -Invoke -CommandName Write-DebugMessage -ModuleName 'JiraPS' -Exactly -Times 0 -Scope It
+        }
+
+        It "returns silently when no configuration is set" {
+            $response = [PSCustomObject]@{
+                Headers = @{ 'X-AREQUESTID' = 'request-123' }
+            }
+
+            Write-JiraResponseHeaderLog -InputObject $response
+
+            Should -Invoke -CommandName Write-DebugMessage -ModuleName 'JiraPS' -Exactly -Times 0 -Scope It
+        }
+
+        It "writes a debug message containing matched headers" {
+            $script:JiraResponseHeaderLogConfiguration = [PSCustomObject]@{
+                Match = { param($name) $name -like 'X-A*' }
+            }
+            $response = [PSCustomObject]@{
+                Headers = @{
+                    'X-AREQUESTID' = 'request-123'
+                    'Server'       = 'jira'
+                }
+            }
+
+            Write-JiraResponseHeaderLog -InputObject $response
+
+            Should -Invoke -CommandName Write-DebugMessage -ModuleName 'JiraPS' -ParameterFilter {
+                $Message -like '*X-AREQUESTID*request-123*' -and
+                $Message -notlike '*Server*'
+            } -Exactly -Times 1 -Scope It
+        }
+
+        It "always suppresses cookie and authorization headers regardless of matcher" {
+            $script:JiraResponseHeaderLogConfiguration = [PSCustomObject]@{
+                Match = { param($name) $true }
+            }
+            $response = [PSCustomObject]@{
+                Headers = @{
+                    'Set-Cookie'          = 'sid=cookie-secret'
+                    'Set-Cookie2'         = 'session=cookie2-secret'
+                    'Authorization'       = 'Bearer auth-secret'
+                    'Proxy-Authorization' = 'Basic proxy-secret'
+                    'X-ANODEID'           = 'node-1'
+                }
+            }
+
+            Write-JiraResponseHeaderLog -InputObject $response
+
+            Should -Invoke -CommandName Write-DebugMessage -ModuleName 'JiraPS' -ParameterFilter {
+                $Message -like '*X-ANODEID*node-1*' -and
+                $Message -notlike '*cookie-secret*' -and
+                $Message -notlike '*cookie2-secret*' -and
+                $Message -notlike '*auth-secret*' -and
+                $Message -notlike '*proxy-secret*'
+            } -Exactly -Times 1 -Scope It
+        }
+
+        It "flattens IEnumerable[string] header values into a comma-separated list" {
+            $script:JiraResponseHeaderLogConfiguration = [PSCustomObject]@{
+                Match = { param($name) $true }
+            }
+            $response = [PSCustomObject]@{
+                Headers = @{
+                    'X-AREQUESTID' = @('request-123', 'request-456')
+                }
+            }
+
+            Write-JiraResponseHeaderLog -InputObject $response
+
+            Should -Invoke -CommandName Write-DebugMessage -ModuleName 'JiraPS' -ParameterFilter {
+                $Message -like '*request-123, request-456*'
+            } -Exactly -Times 1 -Scope It
+        }
+    }
+}

--- a/Tests/Functions/Public/Get-JiraResponseHeaderLogConfiguration.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraResponseHeaderLogConfiguration.Unit.Tests.ps1
@@ -1,0 +1,37 @@
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+
+BeforeDiscovery {
+    . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+
+    $script:moduleToTest = Initialize-TestEnvironment
+}
+
+InModuleScope JiraPS {
+    Describe "Get-JiraResponseHeaderLogConfiguration" -Tag 'Unit' {
+        BeforeEach {
+            $script:JiraResponseHeaderLogConfiguration = $null
+        }
+
+        It "returns null when no configuration has been set" {
+            Get-JiraResponseHeaderLogConfiguration | Should -BeNullOrEmpty
+        }
+
+        It "returns the configuration object set by Set-JiraResponseHeaderLogConfiguration" {
+            Set-JiraResponseHeaderLogConfiguration -Include 'X-A*'
+
+            $config = Get-JiraResponseHeaderLogConfiguration
+
+            $config | Should -Not -BeNullOrEmpty
+            $config.Match | Should -Not -BeNullOrEmpty
+            (& $config.Match 'X-AREQUESTID') | Should -BeTrue
+        }
+
+        It "returns null after Set-JiraResponseHeaderLogConfiguration -Disable" {
+            Set-JiraResponseHeaderLogConfiguration -Include 'X-A*'
+
+            Set-JiraResponseHeaderLogConfiguration -Disable
+
+            Get-JiraResponseHeaderLogConfiguration | Should -BeNullOrEmpty
+        }
+    }
+}

--- a/Tests/Functions/Public/Get-JiraResponseHeaderLogConfiguration.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraResponseHeaderLogConfiguration.Unit.Tests.ps1
@@ -22,8 +22,8 @@ InModuleScope JiraPS {
             $config = Get-JiraResponseHeaderLogConfiguration
 
             $config | Should -Not -BeNullOrEmpty
-            $config.Match | Should -Not -BeNullOrEmpty
-            (& $config.Match 'X-AREQUESTID') | Should -BeTrue
+            $config.Mode | Should -Be 'Wildcard'
+            Test-JiraResponseHeaderMatch -Configuration $config -Name 'X-AREQUESTID' | Should -BeTrue
         }
 
         It "returns null after Set-JiraResponseHeaderLogConfiguration -Disable" {

--- a/Tests/Functions/Public/Invoke-JiraMethod.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Invoke-JiraMethod.Unit.Tests.ps1
@@ -103,7 +103,8 @@ InModuleScope JiraPS {
                     [Parameter(Mandatory)][uri] $Uri,
                     [string] $Method,
                     $Body,
-                    [hashtable] $Headers
+                    [hashtable] $Headers,
+                    [hashtable] $ResponseHeaders = @{}
                 )
 
                 $statusCode = if ($Uri.AbsolutePath -match '/status/(\d+)') {
@@ -136,7 +137,7 @@ InModuleScope JiraPS {
                     StatusCode       = $statusCode
                     Content          = $json
                     RawContentStream = [System.IO.MemoryStream]::new($bytes)
-                    Headers          = $Headers
+                    Headers          = $ResponseHeaders
                 }
             }
 
@@ -226,6 +227,98 @@ InModuleScope JiraPS {
                 Invoke-JiraMethod -URI "https://postman-echo.com/get?test=123" -ErrorAction Stop
 
                 Should -Invoke -CommandName Resolve-DefaultParameterValue -ModuleName 'JiraPS' -Exactly -Times 1
+            }
+
+            It "does not log response headers before logging is configured" {
+                Mock Invoke-WebRequest -ModuleName 'JiraPS' {
+                    New-FakeEchoResponse -Uri $Uri -Method $Method -Body $Body -Headers $Headers -ResponseHeaders @{
+                        'X-AREQUESTID' = 'request-123'
+                    }
+                }
+                Mock Write-DebugMessage -ModuleName 'JiraPS' {}
+
+                $script:JiraResponseHeaderLogConfiguration = $null
+                Invoke-JiraMethod -URI "https://postman-echo.com/get?test=123" -ErrorAction Stop
+
+                Should -Invoke -CommandName Write-DebugMessage -ModuleName 'JiraPS' -ParameterFilter {
+                    $Message -like '*Jira response headers*'
+                } -Exactly -Times 0
+            }
+
+            It "logs configured response headers from successful responses" {
+                Mock Invoke-WebRequest -ModuleName 'JiraPS' {
+                    New-FakeEchoResponse -Uri $Uri -Method $Method -Body $Body -Headers $Headers -ResponseHeaders @{
+                        'X-AREQUESTID' = 'request-123'
+                        'X-Auth-Token' = 'secret'
+                        'Set-Cookie'   = 'cookie=value'
+                    }
+                }
+                Mock Write-DebugMessage -ModuleName 'JiraPS' {}
+
+                Set-JiraResponseHeaderLogConfiguration -Include 'X-A*' -Exclude 'X-Auth*'
+                Invoke-JiraMethod -URI "https://postman-echo.com/get?test=123" -ErrorAction Stop
+
+                Should -Invoke -CommandName Write-DebugMessage -ModuleName 'JiraPS' -ParameterFilter {
+                    $Message -like '*Jira response headers*'
+                } -Exactly -Times 1
+                Should -Invoke -CommandName Write-DebugMessage -ModuleName 'JiraPS' -ParameterFilter {
+                    $Message -like '*X-AREQUESTID*request-123*' -and
+                    $Message -notlike '*secret*' -and
+                    $Message -notlike '*cookie=value*'
+                } -Exactly -Times 1
+            }
+
+            It "logs configured response headers from terminal error responses" {
+                Mock Invoke-WebRequest -ModuleName 'JiraPS' {
+                    New-FakeEchoResponse -Uri ([Uri]'https://postman-echo.com/status/400') -Method $Method -Body $Body -Headers $Headers -ResponseHeaders @{
+                        'X-AREQUESTID' = 'failed-request-123'
+                    }
+                }
+                Mock Write-DebugMessage -ModuleName 'JiraPS' {}
+
+                Set-JiraResponseHeaderLogConfiguration -Pattern '^X-A(?!uth)'
+                Invoke-JiraMethod -URI "https://postman-echo.com/status/400" -ErrorAction Stop
+
+                Should -Invoke -CommandName Write-DebugMessage -ModuleName 'JiraPS' -ParameterFilter {
+                    $Message -like '*X-AREQUESTID*failed-request-123*'
+                } -Exactly -Times 1
+            }
+
+            It "always suppresses cookie and authorization response headers even when configured" {
+                Mock Invoke-WebRequest -ModuleName 'JiraPS' {
+                    New-FakeEchoResponse -Uri $Uri -Method $Method -Body $Body -Headers $Headers -ResponseHeaders @{
+                        'Set-Cookie'          = 'sid=cookie-secret'
+                        'Set-Cookie2'         = 'session=cookie2-secret'
+                        'Authorization'       = 'Bearer auth-secret'
+                        'Proxy-Authorization' = 'Basic proxy-secret'
+                        'X-ANODEID'           = 'node-1'
+                    }
+                }
+                Mock Write-DebugMessage -ModuleName 'JiraPS' {}
+
+                Set-JiraResponseHeaderLogConfiguration -Include '*'
+                Invoke-JiraMethod -URI "https://postman-echo.com/get?test=123" -ErrorAction Stop
+
+                Should -Invoke -CommandName Write-DebugMessage -ModuleName 'JiraPS' -ParameterFilter {
+                    $Message -like '*X-ANODEID*node-1*' -and
+                    $Message -notlike '*cookie-secret*' -and
+                    $Message -notlike '*cookie2-secret*' -and
+                    $Message -notlike '*auth-secret*' -and
+                    $Message -notlike '*proxy-secret*'
+                } -Exactly -Times 1
+            }
+
+            It "does not derail the main flow when response-header logging fails" {
+                Mock Invoke-WebRequest -ModuleName 'JiraPS' {
+                    New-FakeEchoResponse -Uri $Uri -Method $Method -Body $Body -Headers $Headers -ResponseHeaders @{
+                        'X-ANODEID' = 'node-1'
+                    }
+                }
+                Mock Write-JiraResponseHeaderLog -ModuleName 'JiraPS' { throw 'boom' }
+
+                Set-JiraResponseHeaderLogConfiguration -Include '*'
+
+                { Invoke-JiraMethod -URI "https://postman-echo.com/get?test=123" -ErrorAction Stop } | Should -Not -Throw
             }
         }
 

--- a/Tests/Functions/Public/Set-JiraResponseHeaderLogConfiguration.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Set-JiraResponseHeaderLogConfiguration.Unit.Tests.ps1
@@ -34,22 +34,23 @@ InModuleScope JiraPS {
         }
 
         Describe "Wildcard Configuration" {
-            It "stores a matcher that respects Include and Exclude" {
+            It "stores precompiled Include and Exclude patterns" {
                 Set-JiraResponseHeaderLogConfiguration -Include 'X-A*' -Exclude 'X-Auth*'
 
-                $match = $script:JiraResponseHeaderLogConfiguration.Match
-                (& $match 'X-AREQUESTID') | Should -BeTrue
-                (& $match 'X-Auth-Token') | Should -BeFalse
-                (& $match 'Server') | Should -BeFalse
+                $config = $script:JiraResponseHeaderLogConfiguration
+                $config.Mode | Should -Be 'Wildcard'
+                Test-JiraResponseHeaderMatch -Configuration $config -Name 'X-AREQUESTID' | Should -BeTrue
+                Test-JiraResponseHeaderMatch -Configuration $config -Name 'X-Auth-Token' | Should -BeFalse
+                Test-JiraResponseHeaderMatch -Configuration $config -Name 'Server' | Should -BeFalse
             }
 
             It "accepts multiple Include patterns" {
                 Set-JiraResponseHeaderLogConfiguration -Include 'X-A*', 'X-Trace-*'
 
-                $match = $script:JiraResponseHeaderLogConfiguration.Match
-                (& $match 'X-AREQUESTID') | Should -BeTrue
-                (& $match 'X-Trace-Id') | Should -BeTrue
-                (& $match 'Server') | Should -BeFalse
+                $config = $script:JiraResponseHeaderLogConfiguration
+                Test-JiraResponseHeaderMatch -Configuration $config -Name 'X-AREQUESTID' | Should -BeTrue
+                Test-JiraResponseHeaderMatch -Configuration $config -Name 'X-Trace-Id' | Should -BeTrue
+                Test-JiraResponseHeaderMatch -Configuration $config -Name 'Server' | Should -BeFalse
             }
 
             It "warns when Include may log sensitive headers" {
@@ -72,12 +73,13 @@ InModuleScope JiraPS {
         }
 
         Describe "Regex Configuration" {
-            It "stores a case-insensitive matcher" {
+            It "stores a case-insensitive Regex configuration" {
                 Set-JiraResponseHeaderLogConfiguration -Pattern '^x-a(?!uth)'
 
-                $match = $script:JiraResponseHeaderLogConfiguration.Match
-                (& $match 'X-AREQUESTID') | Should -BeTrue
-                (& $match 'X-Auth-Token') | Should -BeFalse
+                $config = $script:JiraResponseHeaderLogConfiguration
+                $config.Mode | Should -Be 'Regex'
+                Test-JiraResponseHeaderMatch -Configuration $config -Name 'X-AREQUESTID' | Should -BeTrue
+                Test-JiraResponseHeaderMatch -Configuration $config -Name 'X-Auth-Token' | Should -BeFalse
             }
 
             It "warns when the pattern may log sensitive headers" {

--- a/Tests/Functions/Public/Set-JiraResponseHeaderLogConfiguration.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Set-JiraResponseHeaderLogConfiguration.Unit.Tests.ps1
@@ -34,7 +34,7 @@ InModuleScope JiraPS {
         }
 
         Describe "Wildcard Configuration" {
-            It "stores precompiled Include and Exclude patterns" {
+            It "stores Include and Exclude patterns that drive the matcher" {
                 Set-JiraResponseHeaderLogConfiguration -Include 'X-A*' -Exclude 'X-Auth*'
 
                 $config = $script:JiraResponseHeaderLogConfiguration
@@ -42,6 +42,14 @@ InModuleScope JiraPS {
                 Test-JiraResponseHeaderMatch -Configuration $config -Name 'X-AREQUESTID' | Should -BeTrue
                 Test-JiraResponseHeaderMatch -Configuration $config -Name 'X-Auth-Token' | Should -BeFalse
                 Test-JiraResponseHeaderMatch -Configuration $config -Name 'Server' | Should -BeFalse
+            }
+
+            It "exposes the original Include and Exclude strings on the configuration" {
+                Set-JiraResponseHeaderLogConfiguration -Include 'X-A*', 'X-Trace-*' -Exclude 'X-Auth*'
+
+                $config = $script:JiraResponseHeaderLogConfiguration
+                $config.Include | Should -Be @('X-A*', 'X-Trace-*')
+                $config.Exclude | Should -Be @('X-Auth*')
             }
 
             It "accepts multiple Include patterns" {
@@ -80,6 +88,13 @@ InModuleScope JiraPS {
                 $config.Mode | Should -Be 'Regex'
                 Test-JiraResponseHeaderMatch -Configuration $config -Name 'X-AREQUESTID' | Should -BeTrue
                 Test-JiraResponseHeaderMatch -Configuration $config -Name 'X-Auth-Token' | Should -BeFalse
+            }
+
+            It "exposes the regex pattern on the configuration via ToString" {
+                Set-JiraResponseHeaderLogConfiguration -Pattern '^X-A'
+
+                $config = $script:JiraResponseHeaderLogConfiguration
+                $config.Pattern.ToString() | Should -Be '^X-A'
             }
 
             It "warns when the pattern may log sensitive headers" {

--- a/Tests/Functions/Public/Set-JiraResponseHeaderLogConfiguration.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Set-JiraResponseHeaderLogConfiguration.Unit.Tests.ps1
@@ -1,0 +1,100 @@
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+
+BeforeDiscovery {
+    . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+
+    $script:moduleToTest = Initialize-TestEnvironment
+}
+
+InModuleScope JiraPS {
+    Describe "Set-JiraResponseHeaderLogConfiguration" -Tag 'Unit' {
+        BeforeEach {
+            $script:JiraResponseHeaderLogConfiguration = $null
+        }
+
+        Describe "Signature" {
+            BeforeAll {
+                $script:command = Get-Command -Name Set-JiraResponseHeaderLogConfiguration
+            }
+
+            It "has a parameter '<parameter>'" -TestCases @(
+                @{ parameter = 'Include' }
+                @{ parameter = 'Exclude' }
+                @{ parameter = 'Pattern' }
+                @{ parameter = 'Disable' }
+            ) {
+                param($parameter)
+
+                $command | Should -HaveParameter $parameter
+            }
+
+            It "uses a Regex parameter for Pattern" {
+                $command.Parameters.Pattern.ParameterType.FullName | Should -Be 'System.Text.RegularExpressions.Regex'
+            }
+        }
+
+        Describe "Wildcard Configuration" {
+            It "stores a matcher that respects Include and Exclude" {
+                Set-JiraResponseHeaderLogConfiguration -Include 'X-A*' -Exclude 'X-Auth*'
+
+                $match = $script:JiraResponseHeaderLogConfiguration.Match
+                (& $match 'X-AREQUESTID') | Should -BeTrue
+                (& $match 'X-Auth-Token') | Should -BeFalse
+                (& $match 'Server') | Should -BeFalse
+            }
+
+            It "accepts multiple Include patterns" {
+                Set-JiraResponseHeaderLogConfiguration -Include 'X-A*', 'X-Trace-*'
+
+                $match = $script:JiraResponseHeaderLogConfiguration.Match
+                (& $match 'X-AREQUESTID') | Should -BeTrue
+                (& $match 'X-Trace-Id') | Should -BeTrue
+                (& $match 'Server') | Should -BeFalse
+            }
+
+            It "warns when Include may log sensitive headers" {
+                $warning = Set-JiraResponseHeaderLogConfiguration -Include '*' 3>&1
+
+                ($warning | Out-String) | Should -Match 'sensitive headers'
+            }
+
+            It "warns when Include matches Authorization" {
+                $warning = Set-JiraResponseHeaderLogConfiguration -Include 'Auth*' 3>&1
+
+                ($warning | Out-String) | Should -Match 'sensitive headers'
+            }
+
+            It "does not warn when Exclude removes the sensitive match" {
+                $warning = Set-JiraResponseHeaderLogConfiguration -Include 'X-A*' -Exclude 'X-Auth*' 3>&1
+
+                $warning | Should -BeNullOrEmpty
+            }
+        }
+
+        Describe "Regex Configuration" {
+            It "stores a case-insensitive matcher" {
+                Set-JiraResponseHeaderLogConfiguration -Pattern '^x-a(?!uth)'
+
+                $match = $script:JiraResponseHeaderLogConfiguration.Match
+                (& $match 'X-AREQUESTID') | Should -BeTrue
+                (& $match 'X-Auth-Token') | Should -BeFalse
+            }
+
+            It "warns when the pattern may log sensitive headers" {
+                $warning = Set-JiraResponseHeaderLogConfiguration -Pattern '^Set-Cookie' 3>&1
+
+                ($warning | Out-String) | Should -Match 'sensitive headers'
+            }
+        }
+
+        Describe "Disable Configuration" {
+            It "clears the module-scoped configuration" {
+                Set-JiraResponseHeaderLogConfiguration -Include 'X-Trace-*'
+
+                Set-JiraResponseHeaderLogConfiguration -Disable
+
+                $script:JiraResponseHeaderLogConfiguration | Should -BeNullOrEmpty
+            }
+        }
+    }
+}

--- a/docs/en-US/commands/Get-JiraResponseHeaderLogConfiguration.md
+++ b/docs/en-US/commands/Get-JiraResponseHeaderLogConfiguration.md
@@ -1,0 +1,69 @@
+---
+external help file: JiraPS-help.xml
+Module Name: JiraPS
+online version: https://atlassianps.org/docs/JiraPS/commands/Get-JiraResponseHeaderLogConfiguration/
+locale: en-US
+layout: documentation
+permalink: /docs/JiraPS/commands/Get-JiraResponseHeaderLogConfiguration/
+---
+# Get-JiraResponseHeaderLogConfiguration
+
+## SYNOPSIS
+
+Returns the current Jira response-header logging configuration.
+
+## SYNTAX
+
+```powershell
+Get-JiraResponseHeaderLogConfiguration [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+Returns the configuration object set by `Set-JiraResponseHeaderLogConfiguration`, or `$null` when response-header logging is disabled.
+
+The configuration is stored in module-scoped memory.
+It survives normal cmdlet calls in the current module instance and is cleared when the module is forcefully reloaded.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+Set-JiraResponseHeaderLogConfiguration -Include 'X-A*'
+Get-JiraResponseHeaderLogConfiguration
+```
+
+Returns the active configuration object.
+
+### EXAMPLE 2
+
+```powershell
+Get-JiraResponseHeaderLogConfiguration
+```
+
+Returns `$null` when response-header logging has not been configured or has been disabled.
+
+## PARAMETERS
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+The configuration affects only the current module instance.
+Forcefully reloading the module clears the setting.
+
+## RELATED LINKS
+
+[Set-JiraResponseHeaderLogConfiguration](../Set-JiraResponseHeaderLogConfiguration/)
+
+[Invoke-JiraMethod](../Invoke-JiraMethod/)

--- a/docs/en-US/commands/Invoke-JiraMethod.md
+++ b/docs/en-US/commands/Invoke-JiraMethod.md
@@ -32,6 +32,10 @@ It handles the authentication, parses the response, handles exceptions from Jira
 When you pass a relative URI path, it must start with `/` and JiraPS resolves it against `Get-JiraConfigServer`.
 Absolute URIs are also accepted for compatibility with object properties like `RestURL`.
 
+Use `Set-JiraResponseHeaderLogConfiguration` to opt into response-header logging on the debug stream.
+This is useful when troubleshooting Jira Data Center diagnostic headers such as `X-AREQUESTID`, `X-ANODEID`, `X-ASESSIONID`, and `X-AUSERNAME`.
+Debug output can include diagnostic metadata such as Jira usernames, so review logs before sharing them.
+
 JiraPS does not support any third-party plugins on Jira.
 This cmdlet can be used to interact with REST Api enpoints which are not already coverted in JiraPS.
 It allows for anyone to use the same technics as JiraPS uses internally for creating their own functions or modules.

--- a/docs/en-US/commands/Set-JiraResponseHeaderLogConfiguration.md
+++ b/docs/en-US/commands/Set-JiraResponseHeaderLogConfiguration.md
@@ -1,0 +1,188 @@
+---
+external help file: JiraPS-help.xml
+Module Name: JiraPS
+online version: https://atlassianps.org/docs/JiraPS/commands/Set-JiraResponseHeaderLogConfiguration/
+locale: en-US
+layout: documentation
+permalink: /docs/JiraPS/commands/Set-JiraResponseHeaderLogConfiguration/
+---
+# Set-JiraResponseHeaderLogConfiguration
+
+## SYNOPSIS
+
+Configures Jira response headers that `Invoke-JiraMethod` writes to the debug stream.
+
+## SYNTAX
+
+```powershell
+Set-JiraResponseHeaderLogConfiguration -Include <string[]> [-Exclude <string[]>] [<CommonParameters>]
+```
+
+```powershell
+Set-JiraResponseHeaderLogConfiguration -Pattern <regex> [<CommonParameters>]
+```
+
+```powershell
+Set-JiraResponseHeaderLogConfiguration -Disable [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+`Set-JiraResponseHeaderLogConfiguration` configures which HTTP response headers JiraPS logs when `Invoke-JiraMethod` receives a response from Jira.
+The configuration is disabled by default.
+After you configure it, matching headers are written to the debug stream when callers use `-Debug`.
+
+The configuration is stored in module-scoped memory, like the JiraPS response cache.
+It survives normal cmdlet calls in the current module instance and is cleared when the module is forcefully reloaded.
+It is not written to disk or user profile storage.
+
+`Set-Cookie`, `Set-Cookie2`, `Authorization`, and `Proxy-Authorization` response headers are always suppressed even when patterns would match them.
+Debug output can still include diagnostic metadata such as Jira usernames, request IDs, node IDs, or session IDs, so review logs before sharing them.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+Set-JiraResponseHeaderLogConfiguration -Include 'X-A*'
+Invoke-JiraMethod -Uri '/rest/api/2/serverInfo' -Debug
+```
+
+Logs Jira Data Center diagnostic response headers such as `X-AREQUESTID`, `X-ANODEID`, `X-ASESSIONID`, and `X-AUSERNAME` to the debug stream.
+`Authorization` and cookie response headers are always suppressed regardless of the `-Include` pattern.
+
+### EXAMPLE 2
+
+```powershell
+Set-JiraResponseHeaderLogConfiguration -Include 'X-A*', 'X-Trace-*' -Exclude 'X-Auth*'
+```
+
+Logs response headers matching either `X-A*` or `X-Trace-*` and excludes any header matching `X-Auth*` (for example, custom `X-Auth-Token` headers).
+The `-Include` and `-Exclude` parameters accept an array of wildcard patterns.
+
+### EXAMPLE 3
+
+```powershell
+Set-JiraResponseHeaderLogConfiguration -Pattern '^X-A(?!uth)'
+Invoke-JiraMethod -Uri '/rest/api/2/serverInfo' -Debug
+```
+
+Uses a regular expression to log `X-A*` response headers while avoiding any `X-Auth*` headers.
+Regex matching is case-insensitive.
+
+### EXAMPLE 4
+
+```powershell
+Set-JiraResponseHeaderLogConfiguration -Disable
+```
+
+Disables response-header logging for the current module instance.
+
+## PARAMETERS
+
+### -Disable
+
+Disables response-header logging by clearing the module-scoped configuration.
+
+```yaml
+Type: SwitchParameter
+DefaultValue: False
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: Disabled
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Exclude
+
+Wildcard patterns for response header names to exclude after `-Include` has matched.
+Matching is case-insensitive.
+
+```yaml
+Type: String[]
+DefaultValue: ''
+SupportsWildcards: true
+Aliases: []
+ParameterSets:
+- Name: Wildcard
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Include
+
+Wildcard patterns for response header names to log.
+Matching is case-insensitive.
+
+```yaml
+Type: String[]
+DefaultValue: ''
+SupportsWildcards: true
+Aliases: []
+ParameterSets:
+- Name: Wildcard
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Pattern
+
+Regular expression used to select response header names to log.
+Regex matching is case-insensitive.
+
+```yaml
+Type: Regex
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: Regex
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+The configuration affects only the current module instance.
+Forcefully reloading the module clears the setting.
+
+## RELATED LINKS
+
+[Invoke-JiraMethod](../Invoke-JiraMethod/)


### PR DESCRIPTION
Closes #536.

## Summary

Adds an opt-in debug-stream log of Jira response headers from `Invoke-JiraMethod`, primarily aimed at troubleshooting Jira Data Center diagnostic headers (`X-AREQUESTID`, `X-ANODEID`, `X-ASESSIONID`, `X-AUSERNAME`) that are otherwise invisible to JiraPS users.

Logging is **disabled by default**. Two new public cmdlets:

- **`Set-JiraResponseHeaderLogConfiguration`** configures which response headers to log:
  - Wildcard mode: `-Include <String[]>` and optional `-Exclude <String[]>` (case-insensitive)
  - Regex mode: `-Pattern <Regex>` (case-insensitive)
  - `-Disable` clears the configuration.
- **`Get-JiraResponseHeaderLogConfiguration`** returns the active configuration object or `$null` when logging is disabled.

Configuration lives in module-scoped memory like the JiraPS response cache: it survives normal cmdlet calls in the current module instance and is cleared when the module is forcefully reloaded. It is never written to disk or user profile storage.

## Safety

- `Set-Cookie`, `Set-Cookie2`, `Authorization`, and `Proxy-Authorization` response headers are **always suppressed** regardless of the configured pattern.
- The setter emits a `Write-Warning` when the configured pattern would match those names or `X-Auth-Token`-style custom headers, so users can add an explicit `-Exclude` before sharing debug output.
- The log call is wrapped in `try/catch` at the `Invoke-JiraMethod` call site, so a misbehaving matcher cannot derail the underlying HTTP call.

## Implementation

- The setter compiles the matcher into a `[scriptblock]` once, so wildcard / regex matching does not repeat per request.
- `Write-JiraResponseHeaderLog` (private) iterates the response headers, skips the always-suppressed list, runs the matcher, flattens `IEnumerable[string]` values (PS 7's response shape), and emits a single `hashtable | Out-String` debug message.
- `Invoke-JiraMethod` logs the announcement and calls the helper after the retry decision, covering both successful and terminal-error responses.

## Test plan

- [x] `Invoke-Build -Task Lint` — clean.
- [x] `Invoke-Build -Task Build, Test` — 4040 passed, 67 skipped, 0 failed.
- [x] `Invoke-Build -Task TestIntegration -Tag Smoke` — 62 passed, 1 skipped (against live Jira Cloud).
- [x] Full `Invoke-Build -Task TestIntegration` — 224 passed, 4 skipped, 3 failed (pre-existing failures unrelated to this change: #621 issue-link descriptions, #635 version-by-name fixture, transitions assumption).

## Usage

```powershell
# Log Jira Data Center diagnostic headers
Set-JiraResponseHeaderLogConfiguration -Include 'X-A*'
Invoke-JiraMethod -Uri '/rest/api/2/serverInfo' -Debug

# Multiple include patterns and an explicit exclude for custom auth headers
Set-JiraResponseHeaderLogConfiguration -Include 'X-A*', 'X-Trace-*' -Exclude 'X-Auth*'

# Inspect the active configuration
Get-JiraResponseHeaderLogConfiguration

# Disable logging
Set-JiraResponseHeaderLogConfiguration -Disable
```


Made with [Cursor](https://cursor.com)