### PR TITLE
test: harden header/components parameter behavior coverage

### DIFF
--- a/Tests/Functions/Public/Invoke-JiraMethod.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Invoke-JiraMethod.Unit.Tests.ps1
@@ -421,11 +421,71 @@ InModuleScope JiraPS {
                 Should -Invoke @assertMockCalledSplat
             }
 
-            It "overwrites module default headers with global PSDefaultParameterValues" {}
+            It "overwrites module default headers with global PSDefaultParameterValues" {
+                # Mock Resolve-DefaultParameterValue so it returns a known Invoke-WebRequest header
+                # without mutating the live $global:PSDefaultParameterValues (which conflicts with
+                # Pester's mock infrastructure when the dict contains an 'Invoke-WebRequest:Headers' entry).
+                Mock Resolve-DefaultParameterValue -ModuleName 'JiraPS' {
+                    @{ 'Invoke-WebRequest:Headers' = @{ 'X-From-Default' = 'default-value' } }
+                }
+                Mock Join-Hashtable -ModuleName 'JiraPS' {
+                    $table = @{}
+                    foreach ($item in $Hashtable) {
+                        if ($null -ne $item) {
+                            foreach ($key in $item.Keys) { $table[$key] = $item[$key] }
+                        }
+                    }
+                    $table
+                }
 
-            It "overwrites global PSDefaultParameterValues with -Headers" {}
+                $null = Invoke-JiraMethod -Method 'Get' -URI 'https://postman-echo.com/headers' -ErrorAction SilentlyContinue
 
-            It "overwrites module default headers with -Headers" {}
+                Should -Invoke -CommandName 'Invoke-WebRequest' -ModuleName 'JiraPS' -Exactly -Times 1 -ParameterFilter {
+                    $Headers.ContainsKey('X-From-Default') -and $Headers['X-From-Default'] -eq 'default-value'
+                }
+            }
+
+            It "overwrites global PSDefaultParameterValues with -Header" {
+                Mock Join-Hashtable -ModuleName 'JiraPS' {
+                    $table = @{}
+                    foreach ($item in $Hashtable) {
+                        if ($null -ne $item) {
+                            foreach ($key in $item.Keys) { $table[$key] = $item[$key] }
+                        }
+                    }
+                    $table
+                }
+
+                $global:PSDefaultParameterValues['Invoke-WebRequest:Headers'] = @{ 'X-Precedence' = 'from-global' }
+                try {
+                    $null = Invoke-JiraMethod -Method 'Get' -URI 'https://postman-echo.com/headers' -Header @{ 'X-Precedence' = 'from-param' } -ErrorAction SilentlyContinue
+
+                    Should -Invoke -CommandName 'Invoke-WebRequest' -ModuleName 'JiraPS' -Exactly -Times 1 -ParameterFilter {
+                        $Headers['X-Precedence'] -eq 'from-param'
+                    }
+                }
+                finally {
+                    $global:PSDefaultParameterValues.Remove('Invoke-WebRequest:Headers')
+                }
+            }
+
+            It "overwrites module default headers with -Header" {
+                Mock Join-Hashtable -ModuleName 'JiraPS' {
+                    $table = @{}
+                    foreach ($item in $Hashtable) {
+                        if ($null -ne $item) {
+                            foreach ($key in $item.Keys) { $table[$key] = $item[$key] }
+                        }
+                    }
+                    $table
+                }
+
+                $null = Invoke-JiraMethod -Method 'Get' -URI 'https://postman-echo.com/headers' -Header @{ 'X-Override' = 'caller-value' } -ErrorAction SilentlyContinue
+
+                Should -Invoke -CommandName 'Invoke-WebRequest' -ModuleName 'JiraPS' -Exactly -Times 1 -ParameterFilter {
+                    $Headers.ContainsKey('X-Override') -and $Headers['X-Override'] -eq 'caller-value'
+                }
+            }
 
             It "overwrites get parameters in the URI with -GetParameter values" {}
 

--- a/Tests/Functions/Public/New-JiraIssue.Unit.Tests.ps1
+++ b/Tests/Functions/Public/New-JiraIssue.Unit.Tests.ps1
@@ -126,6 +126,7 @@ InModuleScope JiraPS {
                     @{ parameter = 'Description'; type = 'String' }
                     @{ parameter = 'Reporter'; type = 'User' }
                     @{ parameter = 'Label'; type = 'String[]' }
+                    @{ parameter = 'Components'; type = 'String[]' }
                     @{ parameter = 'Fields'; type = 'PSObject' }
                     @{ parameter = 'Credential'; type = 'PSCredential' }
                 ) {
@@ -133,6 +134,7 @@ InModuleScope JiraPS {
                     $command | Should -HaveParameter $parameter
                     $command.Parameters[$parameter].ParameterType.Name | Should -Be $type
                 }
+
             }
 
             Context "Mandatory Parameters" {}
@@ -147,6 +149,28 @@ InModuleScope JiraPS {
                 # we should expect to see in the JSON that should be sent,
                 # including the summary provided in the test call above.
                 Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -ParameterFilter { $Method -eq 'Post' -and $URI -like "/rest/api/*/issue" }
+            }
+
+            It "populates components in the request body when -Components is supplied" {
+                { New-JiraIssue @newParams -Components '10001', '10002' } | Should -Not -Throw
+
+                Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -ParameterFilter {
+                    $Method -eq 'Post' -and
+                    $Body -match '"components"' -and
+                    $Body -match '10001' -and
+                    $Body -match '10002'
+                }
+            }
+
+            It "populates components in the request body when the -Component short form is supplied" {
+                { New-JiraIssue @newParams -Component '10003', '10004' } | Should -Not -Throw
+
+                Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraPS -Times 1 -ParameterFilter {
+                    $Method -eq 'Post' -and
+                    $Body -match '"components"' -and
+                    $Body -match '10003' -and
+                    $Body -match '10004'
+                }
             }
             It "Creates an issue in JIRA from pipeline" {
                 { $pipelineParams | New-JiraIssue } | Should -Not -Throw

--- a/Tests/Functions/Public/New-JiraSession.Unit.Tests.ps1
+++ b/Tests/Functions/Public/New-JiraSession.Unit.Tests.ps1
@@ -81,12 +81,12 @@ InModuleScope JiraPS {
                     $command.Parameters[$parameter].ParameterType.Name | Should -Be $type
                 }
 
-                It "supports '<alias>' as an alias for '-PersonalAccessToken'" -TestCases @(
-                    @{ alias = 'BearerToken' }
-                    @{ alias = 'PAT' }
+                It "supports '<alias>' as an alias for '-<parameter>'" -TestCases @(
+                    @{ parameter = 'PersonalAccessToken'; alias = 'BearerToken' }
+                    @{ parameter = 'PersonalAccessToken'; alias = 'PAT' }
                 ) {
-                    param($alias)
-                    $command.Parameters['PersonalAccessToken'].Aliases | Should -Contain $alias
+                    param($parameter, $alias)
+                    $command.Parameters[$parameter].Aliases | Should -Contain $alias
                 }
             }
 


### PR DESCRIPTION
## Summary
Improve unit-test coverage around parameter naming behavior and precedence for recent issue-523 decisions.

## What changed
- Add concrete  precedence tests for module defaults, global defaults, and explicit  input
- Add  signature assertion for 
- Add request-body behavior tests for both  and short-form 
- Refactor  alias assertion to a generic  pattern


Closes #523