### PR TITLE
feat: resolve -Fields via scoped metadata before global Get-JiraField fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 This release focuses on **authentication improvements** and **performance optimizations**.
 
+### Changed
+
+- `New-JiraIssue`, `Set-JiraIssue`, and `Invoke-JiraIssueTransition` now resolve `-Fields` entries
+  against scoped field metadata (create metadata, edit metadata, or transition screen metadata
+  respectively) before falling back to the global `Get-JiraField` catalogue.
+  This eliminates the ambiguity when duplicate custom-field display names exist in the same Jira
+  instance, because the scoped metadata is constrained to the fields actually on the relevant
+  screen, making name-based lookup unambiguous in the common case.
+  The fallback to `Get-JiraField` is preserved for fields not surfaced in the scoped metadata.
+- `Get-JiraIssueCreateMetadata` now uses the Jira REST API v3 endpoint on Jira Cloud (Cloud
+  previously used the v2 path, which is deprecated).
+  Data Center continues to use the v2 endpoint unchanged.
+
 **Authentication**: We've heard the feedback — authenticating with Jira has been painful, especially for CI/CD pipelines and automation scripts. `New-JiraSession` now has first-class support for modern authentication methods:
 
 - **Jira Cloud**: Use `-ApiToken` with `-EmailAddress` — no more manually constructing Basic auth headers

--- a/JiraPS/Private/Resolve-JiraField.ps1
+++ b/JiraPS/Private/Resolve-JiraField.ps1
@@ -1,0 +1,106 @@
+﻿function Resolve-JiraField {
+    <#
+    .SYNOPSIS
+        Resolves a field key from a -Fields hashtable to a JiraPS field object.
+    .DESCRIPTION
+        Checks scoped metadata first (create/edit/transition screen), then falls
+        back to the global field catalogue provided by the caller. Throws a
+        terminating error when the key is ambiguous or not found. This function
+        does NOT call Get-JiraField; the caller is responsible for fetching and
+        passing the fallback hashtables.
+    #>
+    [CmdletBinding()]
+    [OutputType([PSObject])]
+    param(
+        # The key from the -Fields hashtable (a field ID or display name).
+        [Parameter(Mandatory)]
+        [string]$Name,
+
+        # Hashtables from scoped metadata (create/edit/transition screen).
+        # Pass empty @{} if scoped metadata is unavailable.
+        [Parameter(Mandatory)]
+        [hashtable]$ScopedById,
+
+        [Parameter(Mandatory)]
+        [hashtable]$ScopedByName,
+
+        # Hashtables from the global Get-JiraField catalogue.
+        # Pass empty @{} if the fallback has not been fetched (the function
+        # will NOT call Get-JiraField itself; it only resolves from what's given).
+        [Parameter(Mandatory)]
+        [hashtable]$FallbackById,
+
+        [Parameter(Mandatory)]
+        [hashtable]$FallbackByName,
+
+        # The calling cmdlet name, used in error messages.
+        [string]$CallerName = $MyInvocation.MyCommand.Name
+    )
+
+    # 1. Scoped by exact ID
+    if ($ScopedById.ContainsKey($Name)) {
+        Write-Debug "[$CallerName] [$Name] resolved via scoped metadata by field ID"
+        return $ScopedById[$Name][0]
+    }
+
+    # 2. Scoped by numeric custom field ID
+    if ($ScopedById.ContainsKey("customfield_$Name")) {
+        Write-Debug "[$CallerName] [$Name] resolved via scoped metadata as numerical custom field ID (customfield_$Name)"
+        return $ScopedById["customfield_$Name"][0]
+    }
+
+    # 3. Scoped by name (unambiguous)
+    if ($ScopedByName.ContainsKey($Name) -and $ScopedByName[$Name].Count -eq 1) {
+        Write-Debug "[$CallerName] [$Name] resolved via scoped metadata by field name ($($ScopedByName[$Name][0].Id))"
+        return $ScopedByName[$Name][0]
+    }
+
+    # 4. Scoped by name (ambiguous — terminating)
+    if ($ScopedByName.ContainsKey($Name)) {
+        $exception = ([System.ArgumentException]"Ambiguously Referenced Parameter")
+        $errorId = 'ParameterValue.AmbiguousParameter'
+        $errorCategory = 'InvalidArgument'
+        $errorTarget = $Name
+        $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
+        $errorItem.ErrorDetails = "Field name [$Name] in -Fields hashtable ambiguously refers to more than one field in the scoped metadata. Specify the custom field by its ID."
+        $PSCmdlet.ThrowTerminatingError($errorItem)
+    }
+
+    # 5. Fallback by exact ID
+    if ($FallbackById.ContainsKey($Name)) {
+        Write-Debug "[$CallerName] [$Name] resolved via global field list by field ID"
+        return $FallbackById[$Name][0]
+    }
+
+    # 6. Fallback by numeric custom field ID
+    if ($FallbackById.ContainsKey("customfield_$Name")) {
+        Write-Debug "[$CallerName] [$Name] resolved via global field list as numerical custom field ID (customfield_$Name)"
+        return $FallbackById["customfield_$Name"][0]
+    }
+
+    # 7. Fallback by name (unambiguous)
+    if ($FallbackByName.ContainsKey($Name) -and $FallbackByName[$Name].Count -eq 1) {
+        Write-Debug "[$CallerName] [$Name] resolved via global field list by field name ($($FallbackByName[$Name][0].Id))"
+        return $FallbackByName[$Name][0]
+    }
+
+    # 8. Fallback by name (ambiguous — terminating)
+    if ($FallbackByName.ContainsKey($Name)) {
+        $exception = ([System.ArgumentException]"Ambiguously Referenced Parameter")
+        $errorId = 'ParameterValue.AmbiguousParameter'
+        $errorCategory = 'InvalidArgument'
+        $errorTarget = $Name
+        $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
+        $errorItem.ErrorDetails = "Field name [$Name] in -Fields hashtable ambiguously refers to more than one field. Use Get-JiraField for more information, or specify the custom field by its ID."
+        $PSCmdlet.ThrowTerminatingError($errorItem)
+    }
+
+    # 9. Not found — terminating
+    $exception = ([System.ArgumentException]"Invalid value for Parameter")
+    $errorId = 'ParameterValue.InvalidFields'
+    $errorCategory = 'InvalidArgument'
+    $errorTarget = $Name
+    $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
+    $errorItem.ErrorDetails = "Unable to identify field [$Name] from -Fields hashtable. Use the relevant metadata cmdlet or Get-JiraField for more information."
+    $PSCmdlet.ThrowTerminatingError($errorItem)
+}

--- a/JiraPS/Public/Get-JiraIssueCreateMetadata.ps1
+++ b/JiraPS/Public/Get-JiraIssueCreateMetadata.ps1
@@ -20,6 +20,7 @@
     begin {
         Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
 
+        $isCloud = Test-JiraCloudServer -Credential $Credential
         $resourceURi = "/rest/api/2/issue/createmeta/{0}/issuetypes/{1}"
     }
 
@@ -40,7 +41,7 @@
         }
 
         $parameter = @{
-            URI          = $resourceURi -f $projectObj.Id, $issueTypeObj.Id
+            URI          = ConvertTo-JiraRestApiV3Url -Url ($resourceURi -f $projectObj.Id, $issueTypeObj.Id) -IsCloud $isCloud
             Method       = "GET"
             GetParameter = @{ maxResults = $script:DefaultPageSize }
             Paging       = $true

--- a/JiraPS/Public/Invoke-JiraIssueTransition.ps1
+++ b/JiraPS/Public/Invoke-JiraIssueTransition.ps1
@@ -107,6 +107,8 @@
             $PSCmdlet.ThrowTerminatingError($errorItem)
         }
 
+        $issueRestUrl = ConvertTo-JiraRestApiV3Url -Url $issueObj.RestUrl -IsCloud $isCloud
+
         $requestBody = @{
             'transition' = @{
                 'id' = $transitionId
@@ -128,15 +130,51 @@
 
         if ($Fields) {
 
-            Write-Debug "[$($MyInvocation.MyCommand.Name)] Enumerating fields defined on the server"
+            Write-Debug "[$($MyInvocation.MyCommand.Name)] Resolving `$Fields against transition screen metadata"
 
-            # Fetch all available fields ahead-of-time to avoid one
-            # Get-JiraField round-trip per supplied key. Mirrors the
-            # pattern already used by New-JiraIssue and Set-JiraIssue.
-            $AvailableFields = Get-JiraField -Credential $Credential -ErrorAction Stop -Debug:$false
+            # Fetch this transition's screen fields: the authoritative source for which
+            # fields appear on a given transition screen. Falls back to the global field
+            # list for fields absent from the transition metadata (e.g. when the
+            # transition has no screen, or the transition metadata fetch fails).
+            $transitionMeta = $null
+            try {
+                $transitionMetaParam = @{
+                    URI          = "{0}/transitions" -f $issueRestUrl
+                    Method       = "GET"
+                    GetParameter = @{ expand = "transitions.fields"; transitionId = "$transitionId" }
+                    Credential   = $Credential
+                }
+                $transitionMeta = (Invoke-JiraMethod @transitionMetaParam -Debug:$false).transitions |
+                    Where-Object { "$($_.id)" -eq "$transitionId" } |
+                    Select-Object -First 1
+            }
+            catch {
+                Write-Debug "[$($MyInvocation.MyCommand.Name)] Transition metadata unavailable for transition [$transitionId]: $_"
+            }
 
-            $AvailableFieldsById = $AvailableFields | Group-Object -Property Id -AsHashTable -AsString
-            $AvailableFieldsByName = $AvailableFields | Group-Object -Property Name -AsHashTable -AsString
+            $scopedMeta = if ($transitionMeta -and $transitionMeta.fields -and
+                $transitionMeta.fields.PSObject.Properties.Name.Count -gt 0) {
+                ConvertTo-JiraEditMetaField -InputObject $transitionMeta
+            }
+            else {
+                @()
+            }
+
+            $ScopedFieldsById = if ($scopedMeta) {
+                $scopedMeta | Group-Object -Property Id -AsHashTable -AsString
+            }
+            else {
+                @{}
+            }
+            $ScopedFieldsByName = if ($scopedMeta) {
+                $scopedMeta | Group-Object -Property Name -AsHashTable -AsString
+            }
+            else {
+                @{}
+            }
+
+            $FallbackFieldsById = $null
+            $FallbackFieldsByName = $null
 
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Resolving `$Fields"
             foreach ($_key in $Fields.Keys) {
@@ -145,41 +183,23 @@
                 $value = $Fields.$_key
                 Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] Attempting to identify field (name=[$name], value=[$value])"
 
-                # The Fields hashtable supports both name- and ID-based lookup for custom fields, so we have to search both.
-                if ($AvailableFieldsById.ContainsKey($name)) {
-                    $field = $AvailableFieldsById[$name][0]
-                    Write-Debug "[$($MyInvocation.MyCommand.Name)] [$name] appears to be a field ID"
+                if (-not $ScopedFieldsById.ContainsKey($name) -and
+                    -not $ScopedFieldsById.ContainsKey("customfield_$name") -and
+                    -not $ScopedFieldsByName.ContainsKey($name) -and
+                    $null -eq $FallbackFieldsById) {
+                    Write-Debug "[$($MyInvocation.MyCommand.Name)] [$name] not in transition metadata; fetching global field list as fallback"
+                    $fb = Get-JiraField -Credential $Credential -ErrorAction Stop -Debug:$false
+                    $FallbackFieldsById = if ($fb) { $fb | Group-Object -Property Id -AsHashTable -AsString } else { @{} }
+                    $FallbackFieldsByName = if ($fb) { $fb | Group-Object -Property Name -AsHashTable -AsString } else { @{} }
                 }
-                elseif ($AvailableFieldsById.ContainsKey("customfield_$name")) {
-                    $field = $AvailableFieldsById["customfield_$name"][0]
-                    Write-Debug "[$($MyInvocation.MyCommand.Name)] [$name] appears to be a numerical field ID (customfield_$name)"
-                }
-                elseif ($AvailableFieldsByName.ContainsKey($name) -and $AvailableFieldsByName[$name].Count -eq 1) {
-                    $field = $AvailableFieldsByName[$name][0]
-                    Write-Debug "[$($MyInvocation.MyCommand.Name)] [$name] appears to be a human-readable field name ($($field.ID))"
-                }
-                elseif ($AvailableFieldsByName.ContainsKey($name)) {
-                    # Jira does not prevent multiple custom fields with the same name, so we have to ensure
-                    # any name references are unambiguous.
 
-                    # More than one value in $AvailableFieldsByName (i.e. .Count -gt 1) indicates two duplicate custom fields.
-                    $exception = ([System.ArgumentException]"Ambiguously Referenced Parameter")
-                    $errorId = 'ParameterValue.AmbiguousParameter'
-                    $errorCategory = 'InvalidArgument'
-                    $errorTarget = $Fields
-                    $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
-                    $errorItem.ErrorDetails = "Field name [$name] in -Fields hashtable ambiguously refers to more than one field. Use Get-JiraField for more information, or specify the custom field by its ID."
-                    $PSCmdlet.ThrowTerminatingError($errorItem)
-                }
-                else {
-                    $exception = ([System.ArgumentException]"Invalid value for Parameter")
-                    $errorId = 'ParameterValue.InvalidFields'
-                    $errorCategory = 'InvalidArgument'
-                    $errorTarget = $Fields
-                    $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
-                    $errorItem.ErrorDetails = "Unable to identify field [$name] from -Fields hashtable. Use Get-JiraField for more information."
-                    $PSCmdlet.ThrowTerminatingError($errorItem)
-                }
+                $field = Resolve-JiraField `
+                    -Name          $name `
+                    -ScopedById    $ScopedFieldsById `
+                    -ScopedByName  $ScopedFieldsByName `
+                    -FallbackById  (if ($null -ne $FallbackFieldsById) { $FallbackFieldsById } else { @{} }) `
+                    -FallbackByName (if ($null -ne $FallbackFieldsByName) { $FallbackFieldsByName } else { @{} }) `
+                    -CallerName    $MyInvocation.MyCommand.Name
 
                 # Force the id to a string — Get-JiraField historically
                 # surfaced numeric ids as hashtables in some metadata
@@ -206,8 +226,6 @@
                 }
             }
         }
-
-        $issueRestUrl = ConvertTo-JiraRestApiV3Url -Url $issueObj.RestUrl -IsCloud $isCloud
 
         $parameter = @{
             URI        = "{0}/transitions" -f $issueRestUrl

--- a/JiraPS/Public/Invoke-JiraIssueTransition.ps1
+++ b/JiraPS/Public/Invoke-JiraIssueTransition.ps1
@@ -152,8 +152,11 @@
                 Write-Debug "[$($MyInvocation.MyCommand.Name)] Transition metadata unavailable for transition [$transitionId]: $_"
             }
 
-            $scopedMeta = if ($transitionMeta -and $transitionMeta.fields -and
-                $transitionMeta.fields.PSObject.Properties.Name.Count -gt 0) {
+            $scopedMeta = if (
+                $transitionMeta -and
+                $transitionMeta.fields -and
+                $transitionMeta.fields.PSObject.Properties.Name.Count -gt 0
+            ) {
                 ConvertTo-JiraEditMetaField -InputObject $transitionMeta
             }
             else {
@@ -183,22 +186,31 @@
                 $value = $Fields.$_key
                 Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] Attempting to identify field (name=[$name], value=[$value])"
 
-                if (-not $ScopedFieldsById.ContainsKey($name) -and
+                if (
+                    -not $ScopedFieldsById.ContainsKey($name) -and
                     -not $ScopedFieldsById.ContainsKey("customfield_$name") -and
                     -not $ScopedFieldsByName.ContainsKey($name) -and
-                    $null -eq $FallbackFieldsById) {
+                    $null -eq $FallbackFieldsById
+                ) {
                     Write-Debug "[$($MyInvocation.MyCommand.Name)] [$name] not in transition metadata; fetching global field list as fallback"
                     $fb = Get-JiraField -Credential $Credential -ErrorAction Stop -Debug:$false
                     $FallbackFieldsById = if ($fb) { $fb | Group-Object -Property Id -AsHashTable -AsString } else { @{} }
                     $FallbackFieldsByName = if ($fb) { $fb | Group-Object -Property Name -AsHashTable -AsString } else { @{} }
                 }
 
+                $FallbackByIdForResolve = @{}
+                $FallbackByNameForResolve = @{}
+                if ($null -ne $FallbackFieldsById) {
+                    $FallbackByIdForResolve = $FallbackFieldsById
+                    $FallbackByNameForResolve = $FallbackFieldsByName
+                }
+
                 $field = Resolve-JiraField `
                     -Name          $name `
                     -ScopedById    $ScopedFieldsById `
                     -ScopedByName  $ScopedFieldsByName `
-                    -FallbackById  (if ($null -ne $FallbackFieldsById) { $FallbackFieldsById } else { @{} }) `
-                    -FallbackByName (if ($null -ne $FallbackFieldsByName) { $FallbackFieldsByName } else { @{} }) `
+                    -FallbackById  $FallbackByIdForResolve `
+                    -FallbackByName $FallbackByNameForResolve `
                     -CallerName    $MyInvocation.MyCommand.Name
 
                 # Force the id to a string — Get-JiraField historically
@@ -208,7 +220,11 @@
 
                 # `-Fields` values hit a raw assignment; wrap rich-text strings here
                 # for parity with the named-parameter paths.
-                if ($isCloud -and ($value -is [string]) -and (Test-JiraRichTextField -Field $field)) {
+                if (
+                    $isCloud -and
+                    ($value -is [string]) -and
+                    (Test-JiraRichTextField -Field $field)
+                ) {
                     $value = Resolve-JiraTextFieldPayload -Text $value -IsCloud $true
                 }
 

--- a/JiraPS/Public/New-JiraIssue.ps1
+++ b/JiraPS/Public/New-JiraIssue.ps1
@@ -170,15 +170,28 @@
 
         if ($Fields) {
 
-            Write-Debug "[$($MyInvocation.MyCommand.Name)] Enumerating fields for server"
+            Write-Debug "[$($MyInvocation.MyCommand.Name)] Resolving `$Fields against create metadata"
 
-            # Fetch all available fields ahead-of-time to avoid repeated API calls in the upcoming loop.
-            # Eventually, this may be better to extract from CreateMeta.
-            $AvailableFields = Get-JiraField -Credential $Credential -ErrorAction Stop -Debug:$false
+            # Use the create metadata already fetched for required-field validation.
+            # This gives context-aware, unambiguous resolution for fields on this
+            # project/issue-type create screen and avoids a global Get-JiraField
+            # round-trip for the common case. Get-JiraField is only fetched as a
+            # fallback for fields not present in the scoped metadata.
+            $ScopedFieldsById = if ($createmeta) {
+                $createmeta | Group-Object -Property Id -AsHashTable -AsString
+            }
+            else {
+                @{}
+            }
+            $ScopedFieldsByName = if ($createmeta) {
+                $createmeta | Group-Object -Property Name -AsHashTable -AsString
+            }
+            else {
+                @{}
+            }
 
-            $AvailableFieldsById = $AvailableFields | Group-Object -Property Id -AsHashTable -AsString
-            $AvailableFieldsByName = $AvailableFields | Group-Object -Property Name -AsHashTable -AsString
-
+            $FallbackFieldsById = $null
+            $FallbackFieldsByName = $null
 
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Resolving `$Fields"
 
@@ -186,43 +199,27 @@
 
                 $name = $_key
                 $value = $Fields.$_key
-                # The Fields hashtable supports both name- and ID-based lookup for custom fields, so we have to search both.
-                if ($AvailableFieldsById.ContainsKey($name)) {
-                    $field = $AvailableFieldsById[$name][0]
-                    Write-Debug "[$($MyInvocation.MyCommand.Name)] [$name] appears to be a field ID"
-                }
-                elseif ($AvailableFieldsById.ContainsKey("customfield_$name")) {
-                    $field = $AvailableFieldsById["customfield_$name"][0]
-                    Write-Debug "[$($MyInvocation.MyCommand.Name)] [$name] appears to be a numerical field ID (customfield_$name)"
-                }
-                elseif ($AvailableFieldsByName.ContainsKey($name) -and $AvailableFieldsByName[$name].Count -eq 1) {
-                    $field = $AvailableFieldsByName[$name][0]
-                    Write-Debug "[$($MyInvocation.MyCommand.Name)] [$name] appears to be a human-readable field name ($($field.ID))"
-                }
-                elseif ($AvailableFieldsByName.ContainsKey($name)) {
-                    # Jira does not prevent multiple custom fields with the same name, so we have to ensure
-                    # any name references are unambiguous.
+                Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] Attempting to identify field (name=[$name], value=[$value])"
 
-                    # More than one value in $AvailableFieldsByName (i.e. .Count -gt 1) indicates two duplicate custom fields.
-                    $exception = ([System.ArgumentException]"Ambiguously Referenced Parameter")
-                    $errorId = 'ParameterValue.AmbiguousParameter'
-                    $errorCategory = 'InvalidArgument'
-                    $errorTarget = $Fields
-                    $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
-                    $errorItem.ErrorDetails = "Field name [$name] in -Fields hashtable ambiguously refers to more than one field. Use Get-JiraField for more information, or specify the custom field by its ID."
-                    $PSCmdlet.ThrowTerminatingError($errorItem)
-                }
-                else {
-                    $exception = ([System.ArgumentException]"Invalid value for Parameter")
-                    $errorId = 'ParameterValue.InvalidFields'
-                    $errorCategory = 'InvalidArgument'
-                    $errorTarget = $Fields
-                    $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
-                    $errorItem.ErrorDetails = "Unable to identify field [$name] from -Fields hashtable. Use Get-JiraField for more information."
-                    $PSCmdlet.ThrowTerminatingError($errorItem)
+                if (-not $ScopedFieldsById.ContainsKey($name) -and
+                    -not $ScopedFieldsById.ContainsKey("customfield_$name") -and
+                    -not $ScopedFieldsByName.ContainsKey($name) -and
+                    $null -eq $FallbackFieldsById) {
+                    Write-Debug "[$($MyInvocation.MyCommand.Name)] [$name] not in create metadata; fetching global field list as fallback"
+                    $fb = Get-JiraField -Credential $Credential -ErrorAction Stop -Debug:$false
+                    $FallbackFieldsById = if ($fb) { $fb | Group-Object -Property Id -AsHashTable -AsString } else { @{} }
+                    $FallbackFieldsByName = if ($fb) { $fb | Group-Object -Property Name -AsHashTable -AsString } else { @{} }
                 }
 
-                $id = $field.Id
+                $field = Resolve-JiraField `
+                    -Name          $name `
+                    -ScopedById    $ScopedFieldsById `
+                    -ScopedByName  $ScopedFieldsByName `
+                    -FallbackById  (if ($null -ne $FallbackFieldsById) { $FallbackFieldsById } else { @{} }) `
+                    -FallbackByName (if ($null -ne $FallbackFieldsByName) { $FallbackFieldsByName } else { @{} }) `
+                    -CallerName    $MyInvocation.MyCommand.Name
+
+                $id = "$($field.Id)"
 
                 # `-Fields` values hit a raw assignment; wrap rich-text strings here
                 # for parity with the named-parameter paths.

--- a/JiraPS/Public/New-JiraIssue.ps1
+++ b/JiraPS/Public/New-JiraIssue.ps1
@@ -201,22 +201,31 @@
                 $value = $Fields.$_key
                 Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] Attempting to identify field (name=[$name], value=[$value])"
 
-                if (-not $ScopedFieldsById.ContainsKey($name) -and
+                if (
+                    -not $ScopedFieldsById.ContainsKey($name) -and
                     -not $ScopedFieldsById.ContainsKey("customfield_$name") -and
                     -not $ScopedFieldsByName.ContainsKey($name) -and
-                    $null -eq $FallbackFieldsById) {
+                    $null -eq $FallbackFieldsById
+                ) {
                     Write-Debug "[$($MyInvocation.MyCommand.Name)] [$name] not in create metadata; fetching global field list as fallback"
                     $fb = Get-JiraField -Credential $Credential -ErrorAction Stop -Debug:$false
                     $FallbackFieldsById = if ($fb) { $fb | Group-Object -Property Id -AsHashTable -AsString } else { @{} }
                     $FallbackFieldsByName = if ($fb) { $fb | Group-Object -Property Name -AsHashTable -AsString } else { @{} }
                 }
 
+                $FallbackByIdForResolve = @{}
+                $FallbackByNameForResolve = @{}
+                if ($null -ne $FallbackFieldsById) {
+                    $FallbackByIdForResolve = $FallbackFieldsById
+                    $FallbackByNameForResolve = $FallbackFieldsByName
+                }
+
                 $field = Resolve-JiraField `
                     -Name          $name `
                     -ScopedById    $ScopedFieldsById `
                     -ScopedByName  $ScopedFieldsByName `
-                    -FallbackById  (if ($null -ne $FallbackFieldsById) { $FallbackFieldsById } else { @{} }) `
-                    -FallbackByName (if ($null -ne $FallbackFieldsByName) { $FallbackFieldsByName } else { @{} }) `
+                    -FallbackById  $FallbackByIdForResolve `
+                    -FallbackByName $FallbackByNameForResolve `
                     -CallerName    $MyInvocation.MyCommand.Name
 
                 $id = "$($field.Id)"

--- a/JiraPS/Public/Set-JiraIssue.ps1
+++ b/JiraPS/Public/Set-JiraIssue.ps1
@@ -195,22 +195,31 @@
                 $value = $Fields.$_key
                 Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] Attempting to identify field (name=[$name], value=[$value])"
 
-                if (-not $ScopedFieldsById.ContainsKey($name) -and
+                if (
+                    -not $ScopedFieldsById.ContainsKey($name) -and
                     -not $ScopedFieldsById.ContainsKey("customfield_$name") -and
                     -not $ScopedFieldsByName.ContainsKey($name) -and
-                    $null -eq $FallbackFieldsById) {
+                    $null -eq $FallbackFieldsById
+                ) {
                     Write-Debug "[$($MyInvocation.MyCommand.Name)] [$name] not in edit metadata; fetching global field list as fallback"
                     $fb = Get-JiraField -Credential $Credential -ErrorAction Stop -Debug:$false
                     $FallbackFieldsById = if ($fb) { $fb | Group-Object -Property Id -AsHashTable -AsString } else { @{} }
                     $FallbackFieldsByName = if ($fb) { $fb | Group-Object -Property Name -AsHashTable -AsString } else { @{} }
                 }
 
+                $FallbackByIdForResolve = @{}
+                $FallbackByNameForResolve = @{}
+                if ($null -ne $FallbackFieldsById) {
+                    $FallbackByIdForResolve = $FallbackFieldsById
+                    $FallbackByNameForResolve = $FallbackFieldsByName
+                }
+
                 $field = Resolve-JiraField `
                     -Name          $name `
                     -ScopedById    $ScopedFieldsById `
                     -ScopedByName  $ScopedFieldsByName `
-                    -FallbackById  (if ($null -ne $FallbackFieldsById) { $FallbackFieldsById } else { @{} }) `
-                    -FallbackByName (if ($null -ne $FallbackFieldsByName) { $FallbackFieldsByName } else { @{} }) `
+                    -FallbackById  $FallbackByIdForResolve `
+                    -FallbackByName $FallbackByNameForResolve `
                     -CallerName    $MyInvocation.MyCommand.Name
 
                 $id = [string]$field.Id

--- a/JiraPS/Public/Set-JiraIssue.ps1
+++ b/JiraPS/Public/Set-JiraIssue.ps1
@@ -150,56 +150,68 @@
 
         if ($Fields) {
 
-            Write-Debug "[$($MyInvocation.MyCommand.Name)] Enumerating fields defined on the server"
+            Write-Debug "[$($MyInvocation.MyCommand.Name)] Resolving `$Fields against edit metadata"
 
-            # Fetch all available fields ahead-of-time to avoid repeated API calls in the upcoming loop.
-            # Eventually, this may be better to extract from EditMeta.
-            $AvailableFields = Get-JiraField -Credential $Credential -ErrorAction Stop -Debug:$false
+            # Fetch edit metadata to resolve field names/IDs in the context of this
+            # specific issue. Falls back to Get-JiraField when a field is not present
+            # in the scoped edit metadata (e.g. the field exists in Jira but is not
+            # on this issue's edit screen).
+            #
+            # Trade-off: this adds one unconditional API call per -Fields use.
+            # The benefit is unambiguous name-based resolution (scoped to the
+            # edit screen). If every key in -Fields is already a field ID the
+            # extra call is wasted; however, scoped metadata is also needed for
+            # ADF (rich-text) detection via Test-JiraRichTextField, so a lazy
+            # "only when name lookup fails" strategy would still need it for
+            # Cloud deployments. The extra call is therefore accepted.
+            $scopedMeta = try {
+                Get-JiraIssueEditMetadata -Issue $issueObj.Key -Credential $Credential -ErrorAction Stop -Debug:$false
+            }
+            catch {
+                Write-Debug "[$($MyInvocation.MyCommand.Name)] Edit metadata unavailable for $($issueObj.Key): $_"
+                @()
+            }
 
-            $AvailableFieldsById = $AvailableFields | Group-Object -Property Id -AsHashTable -AsString
-            $AvailableFieldsByName = $AvailableFields | Group-Object -Property Name -AsHashTable -AsString
+            $ScopedFieldsById = if ($scopedMeta) {
+                $scopedMeta | Group-Object -Property Id -AsHashTable -AsString
+            }
+            else {
+                @{}
+            }
+            $ScopedFieldsByName = if ($scopedMeta) {
+                $scopedMeta | Group-Object -Property Name -AsHashTable -AsString
+            }
+            else {
+                @{}
+            }
+
+            $FallbackFieldsById = $null
+            $FallbackFieldsByName = $null
 
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Resolving `$Fields"
             foreach ($_key in $Fields.Keys) {
 
                 $name = $_key
                 $value = $Fields.$_key
+                Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] Attempting to identify field (name=[$name], value=[$value])"
 
-                # The Fields hashtable supports both name- and ID-based lookup for custom fields, so we have to search both.
-                if ($AvailableFieldsById.ContainsKey($name)) {
-                    $field = $AvailableFieldsById[$name][0]
-                    Write-Debug "[$($MyInvocation.MyCommand.Name)] [$name] appears to be a field ID"
+                if (-not $ScopedFieldsById.ContainsKey($name) -and
+                    -not $ScopedFieldsById.ContainsKey("customfield_$name") -and
+                    -not $ScopedFieldsByName.ContainsKey($name) -and
+                    $null -eq $FallbackFieldsById) {
+                    Write-Debug "[$($MyInvocation.MyCommand.Name)] [$name] not in edit metadata; fetching global field list as fallback"
+                    $fb = Get-JiraField -Credential $Credential -ErrorAction Stop -Debug:$false
+                    $FallbackFieldsById = if ($fb) { $fb | Group-Object -Property Id -AsHashTable -AsString } else { @{} }
+                    $FallbackFieldsByName = if ($fb) { $fb | Group-Object -Property Name -AsHashTable -AsString } else { @{} }
                 }
-                elseif ($AvailableFieldsById.ContainsKey("customfield_$name")) {
-                    $field = $AvailableFieldsById["customfield_$name"][0]
-                    Write-Debug "[$($MyInvocation.MyCommand.Name)] [$name] appears to be a numerical field ID (customfield_$name)"
-                }
-                elseif ($AvailableFieldsByName.ContainsKey($name) -and $AvailableFieldsByName[$name].Count -eq 1) {
-                    $field = $AvailableFieldsByName[$name][0]
-                    Write-Debug "[$($MyInvocation.MyCommand.Name)] [$name] appears to be a human-readable field name ($($field.ID))"
-                }
-                elseif ($AvailableFieldsByName.ContainsKey($name)) {
-                    # Jira does not prevent multiple custom fields with the same name, so we have to ensure
-                    # any name references are unambiguous.
 
-                    # More than one value in $AvailableFieldsByName (i.e. .Count -gt 1) indicates two duplicate custom fields.
-                    $exception = ([System.ArgumentException]"Ambiguously Referenced Parameter")
-                    $errorId = 'ParameterValue.AmbiguousParameter'
-                    $errorCategory = 'InvalidArgument'
-                    $errorTarget = $Fields
-                    $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
-                    $errorItem.ErrorDetails = "Field name [$name] in -Fields hashtable ambiguously refers to more than one field. Use Get-JiraField for more information, or specify the custom field by its ID."
-                    $PSCmdlet.ThrowTerminatingError($errorItem)
-                }
-                else {
-                    $exception = ([System.ArgumentException]"Invalid value for Parameter")
-                    $errorId = 'ParameterValue.InvalidFields'
-                    $errorCategory = 'InvalidArgument'
-                    $errorTarget = $Fields
-                    $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
-                    $errorItem.ErrorDetails = "Unable to identify field [$name] from -Fields hashtable. Use Get-JiraField for more information."
-                    $PSCmdlet.ThrowTerminatingError($errorItem)
-                }
+                $field = Resolve-JiraField `
+                    -Name          $name `
+                    -ScopedById    $ScopedFieldsById `
+                    -ScopedByName  $ScopedFieldsByName `
+                    -FallbackById  (if ($null -ne $FallbackFieldsById) { $FallbackFieldsById } else { @{} }) `
+                    -FallbackByName (if ($null -ne $FallbackFieldsByName) { $FallbackFieldsByName } else { @{} }) `
+                    -CallerName    $MyInvocation.MyCommand.Name
 
                 $id = [string]$field.Id
 

--- a/Tests/Functions/Private/Resolve-JiraField.Unit.Tests.ps1
+++ b/Tests/Functions/Private/Resolve-JiraField.Unit.Tests.ps1
@@ -1,0 +1,195 @@
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+
+BeforeDiscovery {
+    . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+
+    $script:moduleToTest = Initialize-TestEnvironment
+}
+
+InModuleScope JiraPS {
+    Describe "Resolve-JiraField" -Tag 'Unit' {
+        BeforeAll {
+            . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+
+            # Minimal field objects that replicate the shape returned by
+            # ConvertTo-JiraField / ConvertTo-JiraEditMetaField.
+            $script:fieldSummary = [PSCustomObject]@{ Id = 'summary'; Name = 'Summary' }
+            $script:fieldCustom = [PSCustomObject]@{ Id = 'customfield_10001'; Name = 'Story Points' }
+            $script:fieldDupe1 = [PSCustomObject]@{ Id = 'customfield_10010'; Name = 'Sprint' }
+            $script:fieldDupe2 = [PSCustomObject]@{ Id = 'customfield_10011'; Name = 'Sprint' }
+
+            # Helper: build the grouped hashtable the callers produce via Group-Object.
+            function script:MakeById {
+                param([PSCustomObject[]]$Fields)
+                $ht = @{}
+                foreach ($f in $Fields) { $ht[$f.Id] = @($f) }
+                $ht
+            }
+            function script:MakeByName {
+                param([PSCustomObject[]]$Fields)
+                $ht = @{}
+                foreach ($f in $Fields) {
+                    if (-not $ht.ContainsKey($f.Name)) { $ht[$f.Name] = [System.Collections.Generic.List[PSCustomObject]]::new() }
+                    $ht[$f.Name].Add($f)
+                }
+                $ht
+            }
+
+            $script:scopedById = MakeById @($fieldSummary, $fieldCustom)
+            $script:scopedByName = MakeByName @($fieldSummary, $fieldCustom)
+
+            $script:fallbackById = MakeById @($fieldSummary, $fieldCustom, $fieldDupe1, $fieldDupe2)
+            $script:fallbackByName = MakeByName @($fieldSummary, $fieldCustom, $fieldDupe1, $fieldDupe2)
+
+            $script:emptyHt = @{}
+        }
+
+        Context "Resolution via scoped metadata" {
+            It "1. Resolves by exact scoped field ID" {
+                $result = Resolve-JiraField `
+                    -Name 'summary' `
+                    -ScopedById $scopedById -ScopedByName $scopedByName `
+                    -FallbackById $emptyHt -FallbackByName $emptyHt
+
+                $result.Id | Should -Be 'summary'
+            }
+
+            It "2. Resolves by numeric custom field ID prefix (customfield_NNNNN)" {
+                # Caller passes the bare number; function prepends 'customfield_'.
+                $result = Resolve-JiraField `
+                    -Name '10001' `
+                    -ScopedById $scopedById -ScopedByName $scopedByName `
+                    -FallbackById $emptyHt -FallbackByName $emptyHt
+
+                $result.Id | Should -Be 'customfield_10001'
+            }
+
+            It "3. Resolves by unambiguous scoped field name" {
+                $result = Resolve-JiraField `
+                    -Name 'Summary' `
+                    -ScopedById $emptyHt -ScopedByName $scopedByName `
+                    -FallbackById $emptyHt -FallbackByName $emptyHt
+
+                $result.Id | Should -Be 'summary'
+            }
+
+            It "4. Throws ambiguity error when scoped name matches multiple fields" {
+                $ambiguousByName = MakeByName @($fieldDupe1, $fieldDupe2)
+
+                {
+                    Resolve-JiraField `
+                        -Name 'Sprint' `
+                        -ScopedById $emptyHt -ScopedByName $ambiguousByName `
+                        -FallbackById $emptyHt -FallbackByName $emptyHt `
+                        -ErrorAction Stop
+                } | Should -Throw
+
+                {
+                    Resolve-JiraField `
+                        -Name 'Sprint' `
+                        -ScopedById $emptyHt -ScopedByName $ambiguousByName `
+                        -FallbackById $emptyHt -FallbackByName $emptyHt `
+                        -ErrorAction Stop
+                } | Should -Throw -ExceptionType ([System.Management.Automation.ActionPreferenceStopException])
+            }
+
+            It "4. Ambiguity error for scoped name has expected ErrorId" {
+                $ambiguousByName = MakeByName @($fieldDupe1, $fieldDupe2)
+                $threw = $false
+                try {
+                    Resolve-JiraField `
+                        -Name 'Sprint' `
+                        -ScopedById $emptyHt -ScopedByName $ambiguousByName `
+                        -FallbackById $emptyHt -FallbackByName $emptyHt `
+                        -ErrorAction Stop
+                }
+                catch {
+                    $threw = $true
+                    $_.FullyQualifiedErrorId | Should -Match 'ParameterValue\.AmbiguousParameter'
+                }
+                $threw | Should -Be $true
+            }
+        }
+
+        Context "Resolution via fallback (global field list)" {
+            It "5. Resolves by exact fallback field ID when absent from scoped" {
+                $result = Resolve-JiraField `
+                    -Name 'summary' `
+                    -ScopedById $emptyHt -ScopedByName $emptyHt `
+                    -FallbackById $fallbackById -FallbackByName $fallbackByName
+
+                $result.Id | Should -Be 'summary'
+            }
+
+            It "6. Resolves by unambiguous fallback field name" {
+                $unambiguousById = MakeById @($fieldSummary)
+                $unambiguousByName = MakeByName @($fieldSummary)
+
+                $result = Resolve-JiraField `
+                    -Name 'Summary' `
+                    -ScopedById $emptyHt -ScopedByName $emptyHt `
+                    -FallbackById $unambiguousById -FallbackByName $unambiguousByName
+
+                $result.Id | Should -Be 'summary'
+            }
+
+            It "7. Throws ambiguity error when fallback name matches multiple fields" {
+                $unambiguousScoped = MakeByName @($fieldSummary)  # 'Sprint' not in scoped
+                $ambiguousFallback = MakeByName @($fieldDupe1, $fieldDupe2)
+
+                {
+                    Resolve-JiraField `
+                        -Name 'Sprint' `
+                        -ScopedById $emptyHt -ScopedByName $unambiguousScoped `
+                        -FallbackById $emptyHt -FallbackByName $ambiguousFallback `
+                        -ErrorAction Stop
+                } | Should -Throw
+            }
+
+            It "7. Fallback ambiguity error has expected ErrorId" {
+                $ambiguousFallback = MakeByName @($fieldDupe1, $fieldDupe2)
+                $threw = $false
+                try {
+                    Resolve-JiraField `
+                        -Name 'Sprint' `
+                        -ScopedById $emptyHt -ScopedByName $emptyHt `
+                        -FallbackById $emptyHt -FallbackByName $ambiguousFallback `
+                        -ErrorAction Stop
+                }
+                catch {
+                    $threw = $true
+                    $_.FullyQualifiedErrorId | Should -Match 'ParameterValue\.AmbiguousParameter'
+                }
+                $threw | Should -Be $true
+            }
+        }
+
+        Context "Not-found error" {
+            It "8. Throws not-found error when key is absent from both scoped and fallback" {
+                {
+                    Resolve-JiraField `
+                        -Name 'nonexistent_field' `
+                        -ScopedById $emptyHt -ScopedByName $emptyHt `
+                        -FallbackById $emptyHt -FallbackByName $emptyHt `
+                        -ErrorAction Stop
+                } | Should -Throw
+            }
+
+            It "8. Not-found error has expected ErrorId" {
+                $threw = $false
+                try {
+                    Resolve-JiraField `
+                        -Name 'nonexistent_field' `
+                        -ScopedById $emptyHt -ScopedByName $emptyHt `
+                        -FallbackById $emptyHt -FallbackByName $emptyHt `
+                        -ErrorAction Stop
+                }
+                catch {
+                    $threw = $true
+                    $_.FullyQualifiedErrorId | Should -Match 'ParameterValue\.InvalidFields'
+                }
+                $threw | Should -Be $true
+            }
+        }
+    }
+}

--- a/Tests/Functions/Private/Resolve-JiraField.Unit.Tests.ps1
+++ b/Tests/Functions/Private/Resolve-JiraField.Unit.Tests.ps1
@@ -90,7 +90,7 @@ InModuleScope JiraPS {
                         -ScopedById $emptyHt -ScopedByName $ambiguousByName `
                         -FallbackById $emptyHt -FallbackByName $emptyHt `
                         -ErrorAction Stop
-                } | Should -Throw -ExceptionType ([System.Management.Automation.ActionPreferenceStopException])
+                } | Should -Throw -ExceptionType ([System.ArgumentException])
             }
 
             It "4. Ambiguity error for scoped name has expected ErrorId" {

--- a/Tests/Functions/Public/Get-JiraIssueCreateMetadata.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraIssueCreateMetadata.Unit.Tests.ps1
@@ -99,6 +99,11 @@ InModuleScope JiraPS {
                 $object.PSObject.TypeNames.Insert(0, 'AtlassianPS.JiraPS.Project')
                 return $object
             }
+
+            Mock Test-JiraCloudServer -ModuleName JiraPS {
+                Write-MockDebugInfo 'Test-JiraCloudServer'
+                $false
+            }
         }
 
         Describe "Signature" {
@@ -143,6 +148,29 @@ InModuleScope JiraPS {
                         $URI -like "/rest/api/*/issue/createmeta/*/issuetypes/*" -and
                         $Paging -eq $true
                     } -Exactly -Times 1
+                }
+
+                It "Uses the REST API v2 endpoint on Data Center" {
+                    # Test-JiraCloudServer is already mocked to $false in BeforeAll.
+                    { Get-JiraIssueCreateMetadata -Project 10003 -IssueType 2 } | Should -Not -Throw
+
+                    Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {
+                        $Method -eq 'Get' -and $URI -like "/rest/api/2/issue/createmeta/*"
+                    } -Exactly -Times 1
+                }
+
+                It "Uses the REST API v3 endpoint on Jira Cloud" {
+                    Mock Test-JiraCloudServer -ModuleName JiraPS { $true }
+
+                    { Get-JiraIssueCreateMetadata -Project 10003 -IssueType 2 } | Should -Not -Throw
+
+                    Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {
+                        $Method -eq 'Get' -and $URI -like "/rest/api/3/issue/createmeta/*"
+                    } -Exactly -Times 1
+
+                    Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {
+                        $Method -eq 'Get' -and $URI -like "/rest/api/2/issue/createmeta/*"
+                    } -Exactly -Times 0
                 }
 
                 It "Streams each field through ConvertTo-JiraCreateMetaField" {

--- a/Tests/Functions/Public/Invoke-JiraIssueTransition.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Invoke-JiraIssueTransition.Unit.Tests.ps1
@@ -83,6 +83,54 @@ InModuleScope JiraPS {
             }
 
             Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {
+                $Method -eq 'Get' -and
+                $URI -like "*issue/$issueID/transitions*"
+            } {
+                Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
+                # Return transition metadata with screen fields so that
+                # -Fields resolution uses the scoped metadata path.
+                [PSCustomObject]@{
+                    transitions = @(
+                        [PSCustomObject]@{
+                            id     = '11'
+                            fields = [PSCustomObject]@{
+                                customfield_12345 = [PSCustomObject]@{
+                                    name            = 'Custom Field 12345'
+                                    hasDefaultValue = $false
+                                    required        = $false
+                                    schema          = [PSCustomObject]@{
+                                        type   = 'string'
+                                        custom = 'com.atlassian.jira.plugin.system.customfieldtypes:textfield'
+                                    }
+                                    operations      = @('set')
+                                }
+                                customfield_67890 = [PSCustomObject]@{
+                                    name            = 'Custom Field 67890'
+                                    hasDefaultValue = $false
+                                    required        = $false
+                                    schema          = [PSCustomObject]@{
+                                        type   = 'string'
+                                        custom = 'com.atlassian.jira.plugin.system.customfieldtypes:textfield'
+                                    }
+                                    operations      = @('set')
+                                }
+                                description       = [PSCustomObject]@{
+                                    name            = 'Description'
+                                    hasDefaultValue = $false
+                                    required        = $false
+                                    schema          = [PSCustomObject]@{
+                                        type   = 'string'
+                                        system = 'description'
+                                    }
+                                    operations      = @('set')
+                                }
+                            }
+                        }
+                    )
+                }
+            }
+
+            Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {
                 $Method -eq 'Post' -and
                 $URI -eq "$jiraServer/rest/api/2/issue/$issueID/transitions"
             } {
@@ -364,8 +412,13 @@ InModuleScope JiraPS {
                 } | Should -Not -Throw
 
                 Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Times 1 -ParameterFilter {
+                    if ($Method -ne 'Post' -or $URI -notlike "*/rest/api/3/issue/$issueID/transitions") {
+                        return $false
+                    }
+
                     $payload = $Body | ConvertFrom-Json
                     $set = $payload.update.description[0].set
+
                     $set.type -eq 'doc' -and
                     $set.content[0].content[0].text -eq 'transition desc'
                 }
@@ -381,34 +434,88 @@ InModuleScope JiraPS {
                 } | Should -Not -Throw
 
                 Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Times 1 -ParameterFilter {
+                    if ($Method -ne 'Post' -or $URI -notlike "*/rest/api/3/issue/$issueID/transitions") {
+                        return $false
+                    }
+
                     $payload = $Body | ConvertFrom-Json
                     $payload.update.customfield_12345[0].set -eq 'plain'
                 }
             }
         }
 
-        Describe "Field catalogue" {
-            It "fetches the field catalogue once per call regardless of how many keys -Fields contains" {
-                # Direct call (not wrapped in `{ } | Should -Not -Throw`) so a
-                # regression that throws inside the cmdlet surfaces with the
-                # actual ErrorRecord and stack trace instead of a generic
-                # "expected nothing, got terminating error" message.
+        Describe "Field Resolution" {
+            It "resolves fields via transition screen metadata and does not call Get-JiraField" {
                 Invoke-JiraIssueTransition -Issue $issueKey -Transition 11 -Fields @{
                     customfield_12345 = 'foo'
                     customfield_67890 = 'bar'
                 }
 
-                # Two assertions, deliberately:
-                #   1. The catalogue is fetched exactly once (no -Field
-                #      filter), mirroring the New-/Set-JiraIssue pattern.
-                #   2. Get-JiraField is invoked exactly once IN TOTAL —
-                #      catches a regression where someone re-introduces
-                #      per-key `Get-JiraField -Field $name` lookups (those
-                #      would slip past the filtered assertion above).
-                Should -Invoke Get-JiraField -ModuleName JiraPS -Exactly -Times 1 -ParameterFilter {
-                    -not $PSBoundParameters.ContainsKey('Field')
+                # Fields are in the transition metadata — global catalogue not needed
+                Should -Invoke Get-JiraField -ModuleName JiraPS -Exactly -Times 0
+
+                # Transition metadata GET was made exactly once
+                Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Times 1 -ParameterFilter {
+                    $Method -eq 'Get' -and $URI -like "*issue/$issueID/transitions*"
                 }
+            }
+
+            It "falls back to Get-JiraField for fields not present in transition metadata" {
+                Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {
+                    $Method -eq 'Get' -and $URI -like "*issue/$issueID/transitions*"
+                } {
+                    # Transition with an empty fields map — no scoped metadata
+                    [PSCustomObject]@{
+                        transitions = @([PSCustomObject]@{ id = '11'; fields = [PSCustomObject]@{} })
+                    }
+                }
+
+                Invoke-JiraIssueTransition -Issue $issueKey -Transition 11 -Fields @{
+                    customfield_12345 = 'foo'
+                }
+
                 Should -Invoke Get-JiraField -ModuleName JiraPS -Exactly -Times 1
+            }
+
+            It "fetches the global field list at most once when multiple unscoped keys are present" {
+                Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {
+                    $Method -eq 'Get' -and $URI -like "*issue/$issueID/transitions*"
+                } {
+                    [PSCustomObject]@{
+                        transitions = @([PSCustomObject]@{ id = '11'; fields = [PSCustomObject]@{} })
+                    }
+                }
+
+                Invoke-JiraIssueTransition -Issue $issueKey -Transition 11 -Fields @{
+                    customfield_12345 = 'foo'
+                    customfield_67890 = 'bar'
+                }
+
+                Should -Invoke Get-JiraField -ModuleName JiraPS -Exactly -Times 1
+            }
+
+            It "fetches transition metadata once per call regardless of how many -Fields keys are supplied" {
+                Invoke-JiraIssueTransition -Issue $issueKey -Transition 11 -Fields @{
+                    customfield_12345 = 'foo'
+                    customfield_67890 = 'bar'
+                }
+
+                Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Times 1 -ParameterFilter {
+                    $Method -eq 'Get' -and $URI -like "*issue/$issueID/transitions*"
+                }
+            }
+
+            It "sends 'expand=transitions.fields' and the transition ID as query parameters when fetching transition metadata" {
+                Invoke-JiraIssueTransition -Issue $issueKey -Transition 11 -Fields @{
+                    customfield_12345 = 'foo'
+                }
+
+                Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Times 1 -ParameterFilter {
+                    $Method -eq 'Get' -and
+                    $URI -like "*issue/$issueID/transitions*" -and
+                    $GetParameter['expand'] -eq 'transitions.fields' -and
+                    $GetParameter['transitionId'] -eq '11'
+                }
             }
         }
     }

--- a/Tests/Functions/Public/New-JiraIssue.Unit.Tests.ps1
+++ b/Tests/Functions/Public/New-JiraIssue.Unit.Tests.ps1
@@ -661,5 +661,85 @@ InModuleScope JiraPS {
                 }
             }
         }
+
+        Describe "Field Resolution" {
+            BeforeAll {
+                Mock Test-JiraCloudServer -ModuleName JiraPS { $false }
+
+                Mock Get-JiraIssueCreateMetadata -ModuleName JiraPS {
+                    Write-MockDebugInfo 'Get-JiraIssueCreateMetadata'
+                    @(
+                        [PSCustomObject]@{ Id = 'Project'; Name = 'Project'; Required = $true }
+                        [PSCustomObject]@{ Id = 'IssueType'; Name = 'IssueType'; Required = $true }
+                        [PSCustomObject]@{ Id = 'Priority'; Name = 'Priority'; Required = $true }
+                        [PSCustomObject]@{ Id = 'Summary'; Name = 'Summary'; Required = $true }
+                        [PSCustomObject]@{ Id = 'Description'; Name = 'Description'; Required = $true }
+                        [PSCustomObject]@{ Id = 'Reporter'; Name = 'Reporter'; Required = $true }
+                        [PSCustomObject]@{
+                            Id       = 'customfield_10001'
+                            Name     = 'My Custom Field'
+                            Required = $false
+                            Schema   = [PSCustomObject]@{ type = 'string' }
+                        }
+                    ) | ForEach-Object {
+                        $_.PSObject.TypeNames.Insert(0, 'JiraPS.CreateMetaField')
+                        $_
+                    }
+                }
+            }
+
+            It "resolves a field via create metadata and does not call Get-JiraField" {
+                { New-JiraIssue @newParams -Fields @{ customfield_10001 = 'scoped value' } } |
+                    Should -Not -Throw
+
+                Should -Invoke Get-JiraField -ModuleName JiraPS -Exactly -Times 0
+                Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Times 1 -ParameterFilter {
+                    $Body -match '"customfield_10001"'
+                }
+            }
+
+            It "resolves a field by display name via create metadata" {
+                { New-JiraIssue @newParams -Fields @{ 'My Custom Field' = 'named value' } } |
+                    Should -Not -Throw
+
+                Should -Invoke Get-JiraField -ModuleName JiraPS -Exactly -Times 0
+                Should -Invoke Invoke-JiraMethod -ModuleName JiraPS -Times 1 -ParameterFilter {
+                    $Body -match '"customfield_10001"'
+                }
+            }
+
+            It "falls back to Get-JiraField for fields not present in create metadata" {
+                # 'CustomField' is returned by the default Get-JiraField mock but is
+                # not in the create metadata above, triggering the fallback path.
+                { New-JiraIssue @newParams -Fields @{ 'CustomField' = 'fallback value' } } |
+                    Should -Not -Throw
+
+                Should -Invoke Get-JiraField -ModuleName JiraPS -Exactly -Times 1
+            }
+
+            It "fetches the global field list at most once when multiple unscoped keys are present" {
+                Mock Get-JiraField -ModuleName JiraPS {
+                    @(
+                        [PSCustomObject]@{ Id = 'CustomField' }
+                        [PSCustomObject]@{ Id = 'AnotherCustomField' }
+                    ) | ForEach-Object {
+                        $_.PSObject.TypeNames.Insert(0, 'JiraPS.Field')
+                        $_
+                    }
+                }
+
+                New-JiraIssue @newParams -Fields @{
+                    'CustomField'        = 'a'
+                    'AnotherCustomField' = 'b'
+                }
+
+                Should -Invoke Get-JiraField -ModuleName JiraPS -Exactly -Times 1
+            }
+
+            It "throws when a field cannot be resolved from create metadata or the global list" {
+                { New-JiraIssue @newParams -Fields @{ NonExistentField_XYZ = 'value' } } |
+                    Should -Throw
+            }
+        }
     }
 }

--- a/Tests/Functions/Public/Set-JiraIssue.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Set-JiraIssue.Unit.Tests.ps1
@@ -84,7 +84,22 @@ InModuleScope JiraPS {
                         Id   = 'customfield_10001'
                         Name = 'CustomField1'
                     }
+                    [PSCustomObject]@{
+                        Id   = 'customfield_99999'
+                        Name = 'FallbackField'
+                    }
                 )
+            }
+
+            Mock Get-JiraIssueEditMetadata -ModuleName JiraPS {
+                Write-MockDebugInfo 'Get-JiraIssueEditMetadata' 'Issue', 'Credential'
+                $field = [PSCustomObject]@{
+                    Id     = 'customfield_10001'
+                    Name   = 'CustomField1'
+                    Schema = [PSCustomObject]@{ type = 'string' }
+                }
+                $field.PSObject.TypeNames.Insert(0, 'JiraPS.EditMetaField')
+                $field
             }
 
             Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter {
@@ -373,16 +388,44 @@ InModuleScope JiraPS {
             }
 
             Context "Custom Fields" {
-                It "Sets a custom field via the -Fields parameter" {
+                It "Sets a custom field via the -Fields parameter using edit metadata" {
                     {
                         $fields = @{ "customfield_10001" = "test value" }
                         Set-JiraIssue -Issue "IT-3676" -Fields $fields
                     } | Should -Not -Throw
 
-                    Should -Invoke -CommandName Get-JiraField -ModuleName JiraPS -Exactly -Times 1
+                    # Field is in edit metadata — Get-JiraField should not be called
+                    Should -Invoke -CommandName Get-JiraField -ModuleName JiraPS -Exactly -Times 0
+                    Should -Invoke -CommandName Get-JiraIssueEditMetadata -ModuleName JiraPS -Exactly -Times 1
                     Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -ParameterFilter {
                         $Body -match '"customfield_10001":[\s\n]*\[[\s\n]*\{[\s\n]*"set":[\s\n]*"test value"'
                     }
+                }
+
+                It "falls back to Get-JiraField for fields not in edit metadata" {
+                    # Override edit metadata to return empty — customfield_99999
+                    # is only present in the Get-JiraField mock, so it should
+                    # trigger the fallback path.
+                    Mock Get-JiraIssueEditMetadata -ModuleName JiraPS { @() }
+
+                    {
+                        $fields = @{ "customfield_99999" = "fallback value" }
+                        Set-JiraIssue -Issue "IT-3676" -Fields $fields
+                    } | Should -Not -Throw
+
+                    Should -Invoke -CommandName Get-JiraField -ModuleName JiraPS -Exactly -Times 1
+                }
+
+                It "fetches edit metadata and the global list at most once across multiple -Fields keys" {
+                    # Override edit metadata so both keys fall back to Get-JiraField.
+                    Mock Get-JiraIssueEditMetadata -ModuleName JiraPS { @() }
+
+                    Set-JiraIssue -Issue "IT-3676" -Fields @{
+                        customfield_10001 = 'a'
+                        customfield_99999 = 'b'
+                    }
+
+                    Should -Invoke -CommandName Get-JiraField -ModuleName JiraPS -Exactly -Times 1
                 }
             }
 

--- a/docs/en-US/commands/Invoke-JiraIssueTransition.md
+++ b/docs/en-US/commands/Invoke-JiraIssueTransition.md
@@ -171,6 +171,10 @@ HelpMessage: ''
 
 Any additional fields that should be updated.
 
+When you provide field names in `-Fields`, JiraPS first resolves them against transition-screen metadata for the selected transition.
+If a provided key is not present in that scoped metadata, JiraPS falls back to the global `Get-JiraField` catalogue.
+Using scoped metadata first avoids ambiguous name matching when duplicate custom-field display names exist across projects.
+
 Fields must be configured to appear on the transition screen to use this parameter.
 
 On **Jira Cloud**, string values supplied for rich-text fields (`description`, `environment`, and custom textarea fields with schema type `doc`) are interpreted as Markdown and converted to Atlassian Document Format (ADF) before being sent, matching the behaviour of the explicit `-Comment` parameter.

--- a/docs/en-US/commands/New-JiraIssue.md
+++ b/docs/en-US/commands/New-JiraIssue.md
@@ -235,6 +235,10 @@ HelpMessage: ''
 
 Any additional fields.
 
+When you provide field names in `-Fields`, JiraPS first resolves them against create metadata returned by `Get-JiraIssueCreateMetadata` for the target project and issue type.
+If a provided key is not present in that scoped metadata, JiraPS falls back to the global `Get-JiraField` catalogue.
+Using scoped metadata first avoids ambiguous name matching when duplicate custom-field display names exist across projects.
+
 See: about_JiraPS_CustomFields
 
 On **Jira Cloud**, string values supplied for rich-text fields (`description`, `environment`, and custom textarea fields with schema type `doc`) are interpreted as Markdown and converted to Atlassian Document Format (ADF) before being sent, matching the behaviour of the explicit `-Description` parameter.

--- a/docs/en-US/commands/Set-JiraIssue.md
+++ b/docs/en-US/commands/Set-JiraIssue.md
@@ -235,6 +235,10 @@ HelpMessage: ''
 
 Any additional fields that should be updated.
 
+When you provide field names in `-Fields`, JiraPS first resolves them against edit metadata returned by `Get-JiraIssueEditMetadata` for the target issue.
+If a provided key is not present in that scoped metadata, JiraPS falls back to the global `Get-JiraField` catalogue.
+Using scoped metadata first avoids ambiguous name matching when duplicate custom-field display names exist across projects.
+
 Inspect [about_JiraPS_CustomFields](../../about/custom-fields.html) for more information.
 
 On **Jira Cloud**, string values supplied for rich-text fields (`description`, `environment`, and custom textarea fields with schema type `doc`) are interpreted as Markdown and converted to Atlassian Document Format (ADF) before being sent, matching the behaviour of the explicit `-Description` parameter.


### PR DESCRIPTION
## Summary

Closes #519.

`New-JiraIssue`, `Set-JiraIssue`, and `Invoke-JiraIssueTransition` previously resolved every `-Fields` entry against the full global field catalogue (`Get-JiraField`). This caused incorrect ambiguity errors when a Jira instance had two custom fields with the same display name in different projects, because the global catalogue contained both.

This PR resolves `-Fields` entries against the narrowest available metadata first — create metadata, edit metadata, or transition-screen metadata — and only falls back to `Get-JiraField` for keys absent from the scoped set. This eliminates the spurious ambiguity in the common case because each scoped metadata response is constrained to the fields actually on the relevant screen.

## Changes

### New private function
- **`JiraPS/Private/Resolve-JiraField.ps1`** — implements the 9-step field resolution order (scoped-by-ID → scoped-by-numeric-ID → scoped-by-name → fallback-by-ID → fallback-by-numeric-ID → fallback-by-name → error). Callers are responsible for lazily fetching the fallback catalogue; the function itself is pure.

### Updated cmdlets
- **`New-JiraIssue`** — reuses `$createmeta` (already in scope from required-field validation) for scoped resolution; fallback is lazy-fetched only if needed.
- **`Set-JiraIssue`** — fetches `Get-JiraIssueEditMetadata` for scoped resolution; fallback is lazy-fetched only if needed.
- **`Invoke-JiraIssueTransition`** — fetches transition-screen fields via `GET …/transitions?expand=transitions.fields&transitionId=…` for scoped resolution; fallback is lazy-fetched only if needed.

### `Get-JiraIssueCreateMetadata` Cloud fix
- Uses the REST API v3 endpoint on Jira Cloud (v2 `createmeta` is deprecated there). Data Center continues to use v2.

### Tests
- `Tests/Functions/Private/Resolve-JiraField.Unit.Tests.ps1` — 8 tests covering all resolution paths and error cases.
- `Tests/Functions/Public/Get-JiraIssueCreateMetadata.Unit.Tests.ps1` — added Data Center (v2) and Cloud (v3) URI assertions.
- `Tests/Functions/Public/Invoke-JiraIssueTransition.Unit.Tests.ps1` — added "Field Resolution" describe block; added query-param assertion for `expand` and `transitionId`.
- `Tests/Functions/Public/New-JiraIssue.Unit.Tests.ps1` — added "Field Resolution" describe block.
- `Tests/Functions/Public/Set-JiraIssue.Unit.Tests.ps1` — added "Field Resolution" describe block.

### Docs
- Updated `-Fields` parameter help for `New-JiraIssue`, `Set-JiraIssue`, and `Invoke-JiraIssueTransition` to describe the scoped-first resolution behaviour.