### PR TITLE
Refactor Invoke-JiraMethod internals into private helpers

### DIFF
--- a/JiraPS/Private/Get-JiraCachedResponse.ps1
+++ b/JiraPS/Private/Get-JiraCachedResponse.ps1
@@ -1,0 +1,34 @@
+﻿function Get-JiraCachedResponse {
+    [CmdletBinding()]
+    param(
+        [String]
+        $CacheKey,
+
+        [Microsoft.PowerShell.Commands.WebRequestMethod]
+        $Method = "GET",
+
+        [Switch]
+        $BypassCache,
+
+        [String]
+        $CommandName = "Invoke-JiraMethod"
+    )
+
+    if (-not $CacheKey -or $Method -ne 'GET' -or $BypassCache) {
+        return $null
+    }
+
+    if (-not $script:JiraCache) {
+        $script:JiraCache = @{}
+    }
+
+    $cacheServer = Get-JiraConfigServer -ErrorAction SilentlyContinue
+    $fullCacheKey = "${CacheKey}:${cacheServer}"
+    $cached = $script:JiraCache[$fullCacheKey]
+    if ($cached -and (Get-Date) -lt $cached.Expiry) {
+        Write-Verbose "[$CommandName] Cache hit for $CacheKey"
+        return $cached
+    }
+
+    $null
+}

--- a/JiraPS/Private/Invoke-JiraWebRequestSafely.ps1
+++ b/JiraPS/Private/Invoke-JiraWebRequestSafely.ps1
@@ -1,0 +1,49 @@
+﻿function Invoke-JiraWebRequestSafely {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNull()]
+        [Hashtable]
+        $SplatParameters
+    )
+
+    # Normal ProgressPreference really slows down invoke-webrequest as it tries to update the screen for bytes received.
+    # By setting ProgressPreference to silentlyContinue it doesn't try to update the screen and speeds up the downloads.
+    # See https://stackoverflow.com/a/43477248/2641196
+    $oldProgressPreference = $progressPreference
+    $progressPreference = 'silentlyContinue'
+
+    $webResponse = $null
+    $exception = $null
+    $sessionVariableName = $null
+    $sessionVariableValue = $null
+
+    if ($SplatParameters.ContainsKey('SessionVariable')) {
+        $sessionVariableName = [string]$SplatParameters['SessionVariable']
+    }
+
+    try {
+        $webResponse = Invoke-WebRequest @SplatParameters
+    }
+    catch {
+        $exception = $_
+        $webResponse = $exception.Exception.Response
+    }
+    finally {
+        if ($sessionVariableName) {
+            $capturedSessionVariable = Get-Variable -Name $sessionVariableName -Scope Local -ErrorAction SilentlyContinue
+            if ($capturedSessionVariable) {
+                $sessionVariableValue = $capturedSessionVariable.Value
+            }
+        }
+
+        $progressPreference = $oldProgressPreference
+    }
+
+    [PSCustomObject]@{
+        WebResponse          = $webResponse
+        Exception            = $exception
+        SessionVariableName  = $sessionVariableName
+        SessionVariableValue = $sessionVariableValue
+    }
+}

--- a/JiraPS/Private/New-JiraWebRequestSplat.ps1
+++ b/JiraPS/Private/New-JiraWebRequestSplat.ps1
@@ -1,0 +1,99 @@
+﻿function New-JiraWebRequestSplat {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [Uri]
+        $Uri,
+
+        [Parameter(Mandatory)]
+        [Microsoft.PowerShell.Commands.WebRequestMethod]
+        $Method,
+
+        [Parameter(Mandatory)]
+        [Hashtable]
+        $Headers,
+
+        [String]
+        $Body,
+
+        [Switch]
+        $RawBody,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty,
+
+        [ValidateRange(0, [int]::MaxValue)]
+        [Int]
+        $TimeoutSec = 100,
+
+        [String]
+        $InFile,
+
+        [String]
+        $OutFile,
+
+        [Switch]
+        $StoreSession,
+
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $DefaultContentType = "application/json; charset=utf-8"
+    )
+
+    $splatParameters = @{
+        Uri             = $Uri
+        Method          = $Method
+        Headers         = $Headers
+        UseBasicParsing = $true
+        Credential      = $Credential
+        ErrorAction     = "Stop"
+        Verbose         = $false
+    }
+
+    if ($TimeoutSec -gt 0) {
+        $splatParameters["TimeoutSec"] = $TimeoutSec
+    }
+
+    if ($Headers.ContainsKey("Content-Type")) {
+        $splatParameters["ContentType"] = $Headers["Content-Type"]
+        $splatParameters["Headers"].Remove("Content-Type")
+        $Headers.Remove("Content-Type")
+    }
+    elseif ($Body) {
+        $splatParameters["ContentType"] = $DefaultContentType
+    }
+
+    if ($Body) {
+        if ($RawBody) {
+            $splatParameters["Body"] = $Body
+        }
+        else {
+            # Encode Body to preserve special chars
+            # http://stackoverflow.com/questions/15290185/invoke-webrequest-issue-with-special-characters-in-json
+            $splatParameters["Body"] = [System.Text.Encoding]::UTF8.GetBytes($Body)
+        }
+    }
+
+    if ((-not $Credential) -or ($Credential -eq [System.Management.Automation.PSCredential]::Empty)) {
+        $splatParameters.Remove("Credential")
+        if ($session = Get-JiraSession -ErrorAction SilentlyContinue) {
+            $splatParameters["WebSession"] = $session.WebSession
+        }
+    }
+
+    if ($StoreSession) {
+        $splatParameters["SessionVariable"] = "newSessionVar"
+        $splatParameters.Remove("WebSession")
+    }
+
+    if ($InFile) {
+        $splatParameters["InFile"] = $InFile
+    }
+    if ($OutFile) {
+        $splatParameters["OutFile"] = $OutFile
+    }
+
+    $splatParameters
+}

--- a/JiraPS/Private/New-JiraWebRequestSplat.ps1
+++ b/JiraPS/Private/New-JiraWebRequestSplat.ps1
@@ -1,5 +1,10 @@
 ﻿function New-JiraWebRequestSplat {
     [CmdletBinding()]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSUseShouldProcessForStateChangingFunctions',
+        '',
+        Justification = 'Private helper used internally by Invoke-JiraMethod; it does not perform an external side-effectful action itself.'
+    )]
     param(
         [Parameter(Mandatory)]
         [Uri]

--- a/JiraPS/Private/Resolve-JiraRequestContext.ps1
+++ b/JiraPS/Private/Resolve-JiraRequestContext.ps1
@@ -1,0 +1,85 @@
+﻿function Resolve-JiraRequestContext {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [Uri]
+        $Uri,
+
+        [Hashtable]
+        $GetParameter = @{},
+
+        [Parameter(Mandatory)]
+        [ValidateRange(1, [int]::MaxValue)]
+        [int]
+        $DefaultPageSize,
+
+        [System.Management.Automation.PSCmdlet]
+        $Cmdlet
+    )
+
+    $providedUriValue = $Uri.OriginalString
+    if (-not $Uri.IsAbsoluteUri) {
+        if (-not $providedUriValue.StartsWith('/')) {
+            $errorParameter = @{
+                Cmdlet       = $Cmdlet
+                Exception    = [System.ArgumentException]::new("Invalid URI path '$providedUriValue'. Relative URIs must start with '/'.")
+                ErrorId      = 'ParameterValue.UriPathMustStartWithSlash'
+                Category     = [System.Management.Automation.ErrorCategory]::InvalidArgument
+                TargetObject = $providedUriValue
+            }
+            ThrowError @errorParameter
+        }
+
+        $server = Get-JiraConfigServer -ErrorAction SilentlyContinue
+        if ([String]::IsNullOrWhiteSpace($server)) {
+            $errorParameter = @{
+                Cmdlet       = $Cmdlet
+                Exception    = [System.ArgumentException]::new("Cannot resolve relative URI '$providedUriValue' because no Jira server is configured. Use Set-JiraConfigServer first.")
+                ErrorId      = 'ParameterValue.JiraServerNotConfigured'
+                Category     = [System.Management.Automation.ErrorCategory]::InvalidArgument
+                TargetObject = $providedUriValue
+            }
+            ThrowError @errorParameter
+        }
+
+        [Uri]$Uri = "{0}{1}" -f $server.TrimEnd('/'), $providedUriValue
+    }
+
+    if (-not $Uri.IsAbsoluteUri) {
+        $errorParameter = @{
+            Cmdlet       = $Cmdlet
+            Exception    = [System.ArgumentException]::new("Invoke-JiraMethod: -Uri must be an absolute URI. Got '$providedUriValue'.")
+            ErrorId      = 'ParameterValue.UriMustBeAbsolute'
+            Category     = [System.Management.Automation.ErrorCategory]::InvalidArgument
+            TargetObject = $providedUriValue
+        }
+        ThrowError @errorParameter
+    }
+
+    $uriQuery = ConvertTo-ParameterHash -Uri $Uri
+    $internalGetParameter = Join-Hashtable $uriQuery, $GetParameter
+
+    [Uri]$resolvedUri = $Uri.GetLeftPart("Path")
+
+    if (-not $internalGetParameter.ContainsKey("maxResults")) {
+        $internalGetParameter["maxResults"] = $DefaultPageSize
+    }
+
+    if ($Cmdlet -and $Cmdlet.PagingParameters) {
+        if ($Cmdlet.PagingParameters.Skip) {
+            $internalGetParameter["startAt"] = $Cmdlet.PagingParameters.Skip
+        }
+
+        if ($Cmdlet.PagingParameters.First -lt $internalGetParameter["maxResults"]) {
+            $internalGetParameter["maxResults"] = $Cmdlet.PagingParameters.First
+        }
+    }
+
+    [Uri]$paginatedUri = "{0}{1}" -f $resolvedUri, (ConvertTo-GetParameter $internalGetParameter)
+
+    [PSCustomObject]@{
+        Uri          = $resolvedUri
+        PaginatedUri = $paginatedUri
+        GetParameter = $internalGetParameter
+    }
+}

--- a/JiraPS/Private/Resolve-JiraWebResponse.ps1
+++ b/JiraPS/Private/Resolve-JiraWebResponse.ps1
@@ -1,0 +1,83 @@
+﻿function Resolve-JiraWebResponse {
+    [CmdletBinding()]
+    param(
+        $WebResponse,
+
+        $Exception,
+
+        [Switch]
+        $StoreSession,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty,
+
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $SessionTransformationMethod = "ConvertTo-JiraSession",
+
+        $Session,
+
+        [String]
+        $CacheKey,
+
+        [Microsoft.PowerShell.Commands.WebRequestMethod]
+        $Method = "GET",
+
+        [TimeSpan]
+        $CacheExpiry = [TimeSpan]::FromHours(1),
+
+        [Switch]
+        $Paging,
+
+        [Hashtable]
+        $BoundParameters = @{},
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCmdlet]
+        $Cmdlet,
+
+        [String]
+        $CommandName = "Invoke-JiraMethod"
+    )
+
+    if (-not $WebResponse) {
+        Write-Verbose "[$CommandName] No Web result object was returned from. This is unusual!"
+        return
+    }
+
+    # In PowerShellCore (v6+) the StatusCode of an exception is somewhere else
+    if (-not ($statusCode = $WebResponse.StatusCode)) {
+        $statusCode = $WebResponse.Exception.Response.StatusCode
+    }
+    Write-Verbose "[$CommandName] Status code: $($statusCode)"
+
+    if ($statusCode.value__ -ge 400) {
+        Resolve-ErrorWebResponse -Exception $Exception -StatusCode $statusCode -Cmdlet $Cmdlet
+        return
+    }
+
+    if ($StoreSession) {
+        return & $SessionTransformationMethod -Session $Session -Username $Credential.UserName
+    }
+
+    if (-not $WebResponse.Content) {
+        # No content, although statusCode < 400
+        # This could be wanted behavior of the API
+        Write-Verbose "[$CommandName] No content was returned from."
+        return
+    }
+
+    $response = ConvertFrom-Json ([Text.Encoding]::UTF8.GetString($WebResponse.RawContentStream.ToArray()))
+
+    Set-JiraCachedResponse -CacheKey $CacheKey -Method $Method -Response $response -CacheExpiry $CacheExpiry -CommandName $CommandName
+
+    if ($Paging) {
+        Invoke-PaginatedRequest -Response $response @BoundParameters
+    }
+    else {
+        $response
+    }
+}

--- a/JiraPS/Private/Set-JiraCachedResponse.ps1
+++ b/JiraPS/Private/Set-JiraCachedResponse.ps1
@@ -1,5 +1,10 @@
 ﻿function Set-JiraCachedResponse {
     [CmdletBinding()]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSUseShouldProcessForStateChangingFunctions',
+        '',
+        Justification = 'Private helper used internally by Invoke-JiraMethod to update an in-memory cache; no interactive ShouldProcess flow is expected.'
+    )]
     param(
         [String]
         $CacheKey,

--- a/JiraPS/Private/Set-JiraCachedResponse.ps1
+++ b/JiraPS/Private/Set-JiraCachedResponse.ps1
@@ -1,0 +1,35 @@
+﻿function Set-JiraCachedResponse {
+    [CmdletBinding()]
+    param(
+        [String]
+        $CacheKey,
+
+        [Microsoft.PowerShell.Commands.WebRequestMethod]
+        $Method = "GET",
+
+        [Parameter(Mandatory)]
+        $Response,
+
+        [TimeSpan]
+        $CacheExpiry = [TimeSpan]::FromHours(1),
+
+        [String]
+        $CommandName = "Invoke-JiraMethod"
+    )
+
+    if (-not $CacheKey -or $Method -ne 'GET') {
+        return
+    }
+
+    if (-not $script:JiraCache) {
+        $script:JiraCache = @{}
+    }
+
+    $cacheServer = Get-JiraConfigServer -ErrorAction SilentlyContinue
+    $fullCacheKey = "${CacheKey}:${cacheServer}"
+    $script:JiraCache[$fullCacheKey] = @{
+        Data   = $Response
+        Expiry = (Get-Date).Add($CacheExpiry)
+    }
+    Write-Verbose "[$CommandName] Cached response for $CacheKey (expires in $CacheExpiry)"
+}

--- a/JiraPS/Public/Invoke-JiraMethod.ps1
+++ b/JiraPS/Public/Invoke-JiraMethod.ps1
@@ -84,67 +84,16 @@
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] PSBoundParameters: $($PSBoundParameters | Out-String)"
 
         #region Manage URI
-        $providedUriValue = $Uri.OriginalString
-        if (-not $Uri.IsAbsoluteUri) {
-            if (-not $providedUriValue.StartsWith('/')) {
-                $errorParameter = @{
-                    Cmdlet       = $PSCmdlet
-                    Exception    = [System.ArgumentException]::new("Invalid URI path '$providedUriValue'. Relative URIs must start with '/'.")
-                    ErrorId      = 'ParameterValue.UriPathMustStartWithSlash'
-                    Category     = [System.Management.Automation.ErrorCategory]::InvalidArgument
-                    TargetObject = $providedUriValue
-                }
-                ThrowError @errorParameter
-            }
-
-            $server = Get-JiraConfigServer -ErrorAction SilentlyContinue
-            if ([String]::IsNullOrWhiteSpace($server)) {
-                $errorParameter = @{
-                    Cmdlet       = $PSCmdlet
-                    Exception    = [System.ArgumentException]::new("Cannot resolve relative URI '$providedUriValue' because no Jira server is configured. Use Set-JiraConfigServer first.")
-                    ErrorId      = 'ParameterValue.JiraServerNotConfigured'
-                    Category     = [System.Management.Automation.ErrorCategory]::InvalidArgument
-                    TargetObject = $providedUriValue
-                }
-                ThrowError @errorParameter
-            }
-
-            [Uri]$Uri = "{0}{1}" -f $server.TrimEnd('/'), $providedUriValue
-        }
-
-        if (-not $Uri.IsAbsoluteUri) {
-            $errorParameter = @{
-                Cmdlet       = $PSCmdlet
-                Exception    = [System.ArgumentException]::new("Invoke-JiraMethod: -Uri must be an absolute URI. Got '$providedUriValue'.")
-                ErrorId      = 'ParameterValue.UriMustBeAbsolute'
-                Category     = [System.Management.Automation.ErrorCategory]::InvalidArgument
-                TargetObject = $providedUriValue
-            }
-            ThrowError @errorParameter
-        }
-
-        # Amend query from URI with GetParameter
-        $uriQuery = ConvertTo-ParameterHash -Uri $Uri
-        $internalGetParameter = Join-Hashtable $uriQuery, $GetParameter
-
-        # And remove it from URI
-        [Uri]$Uri = $Uri.GetLeftPart("Path")
-        $PaginatedUri = $Uri
+        $requestContext = Resolve-JiraRequestContext -Uri $Uri -GetParameter $GetParameter -DefaultPageSize $script:DefaultPageSize -Cmdlet $PSCmdlet
+        [Uri]$Uri = $requestContext.Uri
+        [Uri]$PaginatedUri = $requestContext.PaginatedUri
         #endregion Manage URI
 
         #region Cache Check
-        if ($CacheKey -and $Method -eq 'GET' -and -not $BypassCache) {
-            if (-not $script:JiraCache) {
-                $script:JiraCache = @{}
-            }
-            $cacheServer = Get-JiraConfigServer -ErrorAction SilentlyContinue
-            $fullCacheKey = "${CacheKey}:${cacheServer}"
-            $cached = $script:JiraCache[$fullCacheKey]
-            if ($cached -and (Get-Date) -lt $cached.Expiry) {
-                Write-Verbose "[$($MyInvocation.MyCommand.Name)] Cache hit for $CacheKey"
-                Set-TlsLevel -Revert
-                return $cached.Data
-            }
+        $cached = Get-JiraCachedResponse -CacheKey $CacheKey -Method $Method -BypassCache:$BypassCache -CommandName $MyInvocation.MyCommand.Name
+        if ($cached) {
+            Set-TlsLevel -Revert
+            return $cached.Data
         }
         #endregion Cache Check
 
@@ -160,99 +109,22 @@
         $_headers = Join-Hashtable -Hashtable $script:DefaultHeaders, $PSDefaultParameterValues["Invoke-WebRequest:Headers"], $Headers
         #endregion Headers
 
-        # Use default PageSize
-        if (-not $internalGetParameter.ContainsKey("maxResults")) {
-            $internalGetParameter["maxResults"] = $script:DefaultPageSize
-        }
-
-        # Append GET parameters to URi
-        if ($PSCmdlet.PagingParameters) {
-            if ($PSCmdlet.PagingParameters.Skip) {
-                $internalGetParameter["startAt"] = $PSCmdlet.PagingParameters.Skip
-            }
-            if ($PSCmdlet.PagingParameters.First -lt $internalGetParameter["maxResults"]) {
-                $internalGetParameter["maxResults"] = $PSCmdlet.PagingParameters.First
-            }
-        }
-
-        [Uri]$PaginatedUri = "{0}{1}" -f $PaginatedUri, (ConvertTo-GetParameter $internalGetParameter)
-
         #region Constructe IWR Parameter
-        $splatParameters = @{
-            Uri             = $PaginatedUri
-            Method          = $Method
-            Headers         = $_headers
-            UseBasicParsing = $true
-            Credential      = $Credential
-            ErrorAction     = "Stop"
-            Verbose         = $false
-        }
-
-        if ($TimeoutSec -gt 0) {
-            $splatParameters["TimeoutSec"] = $TimeoutSec
-        }
-
-        if ($_headers.ContainsKey("Content-Type")) {
-            $splatParameters["ContentType"] = $_headers["Content-Type"]
-            $splatParameters["Headers"].Remove("Content-Type")
-            $_headers.Remove("Content-Type")
-        }
-        elseif ($Body) {
-            $splatParameters["ContentType"] = $script:DefaultContentType
-        }
-
-        if ($Body) {
-            if ($RawBody) {
-                $splatParameters["Body"] = $Body
-            }
-            else {
-                # Encode Body to preserve special chars
-                # http://stackoverflow.com/questions/15290185/invoke-webrequest-issue-with-special-characters-in-json
-                $splatParameters["Body"] = [System.Text.Encoding]::UTF8.GetBytes($Body)
-            }
-        }
-
-        if ((-not $Credential) -or ($Credential -eq [System.Management.Automation.PSCredential]::Empty)) {
-            $splatParameters.Remove("Credential")
-            if ($session = Get-JiraSession -ErrorAction SilentlyContinue) {
-                $splatParameters["WebSession"] = $session.WebSession
-            }
-        }
-
-        if ($StoreSession) {
-            $splatParameters["SessionVariable"] = "newSessionVar"
-            $splatParameters.Remove("WebSession")
-        }
-
-        if ($InFile) {
-            $splatParameters["InFile"] = $InFile
-        }
-        if ($OutFile) {
-            $splatParameters["OutFile"] = $OutFile
-        }
+        $splatParameters = New-JiraWebRequestSplat -Uri $PaginatedUri -Method $Method -Headers $_headers -Body $Body -RawBody:$RawBody -Credential $Credential -TimeoutSec $TimeoutSec -InFile $InFile -OutFile $OutFile -StoreSession:$StoreSession -DefaultContentType $script:DefaultContentType
         #endregion Constructe IWR Parameter
 
         #region Execute the actual query
-        # Normal ProgressPreference really slows down invoke-webrequest as it tries to update the screen for bytes received.
-        # By setting ProgressPreference to silentlyContinue it doesn't try to update the screen and speeds up the downloads.
-        # See https://stackoverflow.com/a/43477248/2641196
-        $oldProgressPreference = $progressPreference
-        $progressPreference = 'silentlyContinue'
-
-        try {
-            Write-Verbose "[$($MyInvocation.MyCommand.Name)] $($splatParameters.Method) $($splatParameters.Uri)"
-            Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoke-WebRequest with `$splatParameters: $($splatParameters | Out-String)"
-            # Invoke the API
-            $webResponse = Invoke-WebRequest @splatParameters
+        Write-Verbose "[$($MyInvocation.MyCommand.Name)] $($splatParameters.Method) $($splatParameters.Uri)"
+        Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoke-WebRequest with `$splatParameters: $($splatParameters | Out-String)"
+        $webRequestResult = Invoke-JiraWebRequestSafely -SplatParameters $splatParameters
+        $webResponse = $webRequestResult.WebResponse
+        $exception = $webRequestResult.Exception
+        if ($webRequestResult.SessionVariableName -and $null -ne $webRequestResult.SessionVariableValue) {
+            Set-Variable -Name $webRequestResult.SessionVariableName -Value $webRequestResult.SessionVariableValue -Scope Local
         }
-        catch {
+        if ($exception) {
             Write-Verbose "[$($MyInvocation.MyCommand.Name)] Failed to get an answer from the server"
-
-            $exception = $_
-            $webResponse = $exception.Exception.Response
         }
-
-        $progressPreference = $oldProgressPreference
 
         Write-Debug "[$($MyInvocation.MyCommand.Name)] Executed WebRequest. Access `$webResponse to see details"
         $shouldRetry = Test-ServerResponse -InputObject $webResponse -Cmdlet $Cmdlet -RetryCount $_RetryCount
@@ -270,61 +142,7 @@
     }
 
     process {
-        if ($webResponse) {
-            # In PowerShellCore (v6+) the StatusCode of an exception is somewhere else
-            if (-not ($statusCode = $webResponse.StatusCode)) {
-                $statusCode = $webResponse.Exception.Response.StatusCode
-            }
-            Write-Verbose "[$($MyInvocation.MyCommand.Name)] Status code: $($statusCode)"
-
-            #region Code 400+
-            if ($statusCode.value__ -ge 400) {
-                Resolve-ErrorWebResponse -Exception $exception -StatusCode $statusCode -Cmdlet $Cmdlet
-            }
-            #endregion Code 400+
-
-            #region Code 399-
-            else {
-                if ($StoreSession) {
-                    return & $script:SessionTransformationMethod -Session $newSessionVar -Username $Credential.UserName
-                }
-
-                if ($webResponse.Content) {
-                    $response = ConvertFrom-Json ([Text.Encoding]::UTF8.GetString($webResponse.RawContentStream.ToArray()))
-
-                    #region Cache Store
-                    if ($CacheKey -and $Method -eq 'GET') {
-                        if (-not $script:JiraCache) {
-                            $script:JiraCache = @{}
-                        }
-                        $cacheServer = Get-JiraConfigServer -ErrorAction SilentlyContinue
-                        $fullCacheKey = "${CacheKey}:${cacheServer}"
-                        $script:JiraCache[$fullCacheKey] = @{
-                            Data   = $response
-                            Expiry = (Get-Date).Add($CacheExpiry)
-                        }
-                        Write-Verbose "[$($MyInvocation.MyCommand.Name)] Cached response for $CacheKey (expires in $CacheExpiry)"
-                    }
-                    #endregion Cache Store
-
-                    if ($Paging) {
-                        Invoke-PaginatedRequest -Response $response @PSBoundParameters
-                    }
-                    else {
-                        $response
-                    }
-                }
-                else {
-                    # No content, although statusCode < 400
-                    # This could be wanted behavior of the API
-                    Write-Verbose "[$($MyInvocation.MyCommand.Name)] No content was returned from."
-                }
-            }
-            #endregion Code 399-
-        }
-        else {
-            Write-Verbose "[$($MyInvocation.MyCommand.Name)] No Web result object was returned from. This is unusual!"
-        }
+        Resolve-JiraWebResponse -WebResponse $webResponse -Exception $exception -StoreSession:$StoreSession -Credential $Credential -SessionTransformationMethod $script:SessionTransformationMethod -Session $newSessionVar -CacheKey $CacheKey -Method $Method -CacheExpiry $CacheExpiry -Paging:$Paging -BoundParameters $PSBoundParameters -Cmdlet $Cmdlet -CommandName $MyInvocation.MyCommand.Name
     }
 
     end {

--- a/Tests/Functions/Private/Get-JiraCachedResponse.Unit.Tests.ps1
+++ b/Tests/Functions/Private/Get-JiraCachedResponse.Unit.Tests.ps1
@@ -1,0 +1,54 @@
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+
+BeforeDiscovery {
+    . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+
+    $script:moduleToTest = Initialize-TestEnvironment
+}
+
+InModuleScope JiraPS {
+    Describe "Get-JiraCachedResponse" -Tag 'Unit' {
+        BeforeAll {
+            . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+        }
+
+        BeforeEach {
+            $script:JiraCache = @{}
+            Mock Get-JiraConfigServer -ModuleName 'JiraPS' { 'https://jira.example.com' }
+        }
+
+        It "returns null when cache should be bypassed" {
+            $script:JiraCache['Fields:https://jira.example.com'] = @{
+                Data   = @{ id = 1 }
+                Expiry = (Get-Date).AddMinutes(5)
+            }
+
+            $result = Get-JiraCachedResponse -CacheKey 'Fields' -BypassCache
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It "returns null for non-GET methods" {
+            $script:JiraCache['Fields:https://jira.example.com'] = @{
+                Data   = @{ id = 1 }
+                Expiry = (Get-Date).AddMinutes(5)
+            }
+
+            $result = Get-JiraCachedResponse -CacheKey 'Fields' -Method 'POST'
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It "returns cached entry when present and not expired" {
+            $entry = @{
+                Data   = @{ id = 1 }
+                Expiry = (Get-Date).AddMinutes(5)
+            }
+            $script:JiraCache['Fields:https://jira.example.com'] = $entry
+
+            $result = Get-JiraCachedResponse -CacheKey 'Fields'
+
+            $result | Should -Be $entry
+        }
+    }
+}

--- a/Tests/Functions/Private/Invoke-JiraWebRequestSafely.Unit.Tests.ps1
+++ b/Tests/Functions/Private/Invoke-JiraWebRequestSafely.Unit.Tests.ps1
@@ -1,0 +1,145 @@
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+
+BeforeDiscovery {
+    . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+
+    $script:moduleToTest = Initialize-TestEnvironment
+}
+
+InModuleScope JiraPS {
+    Describe "Invoke-JiraWebRequestSafely" -Tag 'Unit' {
+        BeforeAll {
+            . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+
+            if (-not ('JiraPS.Tests.FakeWebRequestException' -as [type])) {
+                Add-Type -TypeDefinition @"
+namespace JiraPS.Tests {
+    public class FakeWebRequestException : System.Exception {
+        public object Response { get; }
+        public FakeWebRequestException(string message, object response) : base(message) {
+            Response = response;
+        }
+    }
+}
+"@
+            }
+        }
+
+        It "returns web response with no exception on success" {
+            $expectedResponse = [PSCustomObject]@{
+                StatusCode = [System.Net.HttpStatusCode]::OK
+            }
+            Mock Invoke-WebRequest -ModuleName 'JiraPS' { $expectedResponse }
+
+            $result = Invoke-JiraWebRequestSafely -SplatParameters @{
+                Uri     = 'https://jira.example.com/rest/api/2/myself'
+                Method  = 'GET'
+                Headers = @{}
+            }
+
+            $result.WebResponse | Should -Be $expectedResponse
+            $result.Exception | Should -BeNullOrEmpty
+        }
+
+        It "returns exception and falls back to the exception response object" {
+            $fallbackResponse = [PSCustomObject]@{
+                StatusCode = [System.Net.HttpStatusCode]::ServiceUnavailable
+            }
+            Mock Invoke-WebRequest -ModuleName 'JiraPS' {
+                throw [JiraPS.Tests.FakeWebRequestException]::new('boom', $fallbackResponse)
+            }
+
+            $result = Invoke-JiraWebRequestSafely -SplatParameters @{
+                Uri     = 'https://jira.example.com/rest/api/2/myself'
+                Method  = 'GET'
+                Headers = @{}
+            }
+
+            $result.Exception | Should -Not -BeNullOrEmpty
+            $result.WebResponse | Should -Be $fallbackResponse
+        }
+
+        It "captures session variable name and value when SessionVariable is used" {
+            $capturedSession = [Microsoft.PowerShell.Commands.WebRequestSession]::new()
+            Mock Get-Variable -ModuleName 'JiraPS' -ParameterFilter {
+                $Name -eq 'newSessionVar' -and $Scope -eq 'Local'
+            } {
+                [PSCustomObject]@{
+                    Value = $capturedSession
+                }
+            }
+            Mock Invoke-WebRequest -ModuleName 'JiraPS' {
+                [PSCustomObject]@{
+                    StatusCode = [System.Net.HttpStatusCode]::OK
+                }
+            }
+
+            $result = Invoke-JiraWebRequestSafely -SplatParameters @{
+                Uri             = 'https://jira.example.com/rest/api/2/myself'
+                Method          = 'GET'
+                Headers         = @{}
+                SessionVariable = 'newSessionVar'
+            }
+
+            $result.SessionVariableName | Should -Be 'newSessionVar'
+            $result.SessionVariableValue | Should -Be $capturedSession
+        }
+
+        It "returns null session value when SessionVariable is requested but not available in scope" {
+            Mock Get-Variable -ModuleName 'JiraPS' -ParameterFilter {
+                $Name -eq 'missingSessionVar' -and $Scope -eq 'Local'
+            } { $null }
+            Mock Invoke-WebRequest -ModuleName 'JiraPS' {
+                [PSCustomObject]@{
+                    StatusCode = [System.Net.HttpStatusCode]::OK
+                }
+            }
+
+            $result = Invoke-JiraWebRequestSafely -SplatParameters @{
+                Uri             = 'https://jira.example.com/rest/api/2/myself'
+                Method          = 'GET'
+                Headers         = @{}
+                SessionVariable = 'missingSessionVar'
+            }
+
+            $result.SessionVariableName | Should -Be 'missingSessionVar'
+            $result.SessionVariableValue | Should -BeNullOrEmpty
+        }
+
+        It "restores ProgressPreference after successful requests" {
+            Mock Invoke-WebRequest -ModuleName 'JiraPS' { [PSCustomObject]@{ StatusCode = [System.Net.HttpStatusCode]::OK } }
+            $previousProgressPreference = $ProgressPreference
+            $ProgressPreference = 'Continue'
+            try {
+                $null = Invoke-JiraWebRequestSafely -SplatParameters @{
+                    Uri     = 'https://jira.example.com/rest/api/2/myself'
+                    Method  = 'GET'
+                    Headers = @{}
+                }
+                $ProgressPreference | Should -Be 'Continue'
+            }
+            finally {
+                $ProgressPreference = $previousProgressPreference
+            }
+        }
+
+        It "restores ProgressPreference when request throws" {
+            Mock Invoke-WebRequest -ModuleName 'JiraPS' {
+                throw [JiraPS.Tests.FakeWebRequestException]::new('boom', $null)
+            }
+            $previousProgressPreference = $ProgressPreference
+            $ProgressPreference = 'Continue'
+            try {
+                $null = Invoke-JiraWebRequestSafely -SplatParameters @{
+                    Uri     = 'https://jira.example.com/rest/api/2/myself'
+                    Method  = 'GET'
+                    Headers = @{}
+                }
+                $ProgressPreference | Should -Be 'Continue'
+            }
+            finally {
+                $ProgressPreference = $previousProgressPreference
+            }
+        }
+    }
+}

--- a/Tests/Functions/Private/Invoke-JiraWebRequestSafely.Unit.Tests.ps1
+++ b/Tests/Functions/Private/Invoke-JiraWebRequestSafely.Unit.Tests.ps1
@@ -15,7 +15,7 @@ InModuleScope JiraPS {
                 Add-Type -TypeDefinition @"
 namespace JiraPS.Tests {
     public class FakeWebRequestException : System.Exception {
-        public object Response { get; }
+        public object Response { get; private set; }
         public FakeWebRequestException(string message, object response) : base(message) {
             Response = response;
         }

--- a/Tests/Functions/Private/New-JiraWebRequestSplat.Unit.Tests.ps1
+++ b/Tests/Functions/Private/New-JiraWebRequestSplat.Unit.Tests.ps1
@@ -1,0 +1,52 @@
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+
+BeforeDiscovery {
+    . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+
+    $script:moduleToTest = Initialize-TestEnvironment
+}
+
+InModuleScope JiraPS {
+    Describe "New-JiraWebRequestSplat" -Tag 'Unit' {
+        BeforeAll {
+            . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+        }
+
+        It "defaults ContentType only when a body is supplied" {
+            Mock Get-JiraSession -ModuleName 'JiraPS' { $null }
+
+            $withBody = New-JiraWebRequestSplat -Uri 'https://jira.example.com/rest/api/2/issue' -Method Post -Headers @{} -Body '{}' -DefaultContentType 'application/json; charset=utf-8'
+            $withoutBody = New-JiraWebRequestSplat -Uri 'https://jira.example.com/rest/api/2/issue' -Method Post -Headers @{} -InFile './attachment.bin' -DefaultContentType 'application/json; charset=utf-8'
+
+            $withBody.ContentType | Should -Be 'application/json; charset=utf-8'
+            $withoutBody.ContainsKey('ContentType') | Should -BeFalse
+        }
+
+        It "honors explicit Content-Type header and removes it from Headers" {
+            Mock Get-JiraSession -ModuleName 'JiraPS' { $null }
+
+            $headers = @{
+                'Content-Type' = 'text/plain'
+                'X-Trace'      = 'abc123'
+            }
+            $result = New-JiraWebRequestSplat -Uri 'https://jira.example.com/rest/api/2/issue' -Method Post -Headers $headers -Body '{}'
+
+            $result.ContentType | Should -Be 'text/plain'
+            $result.Headers['X-Trace'] | Should -Be 'abc123'
+            $result.Headers.ContainsKey('Content-Type') | Should -BeFalse
+        }
+
+        It "uses SessionVariable and drops WebSession when -StoreSession is set" {
+            Mock Get-JiraSession -ModuleName 'JiraPS' {
+                [PSCustomObject]@{
+                    WebSession = [Microsoft.PowerShell.Commands.WebRequestSession]::new()
+                }
+            }
+
+            $result = New-JiraWebRequestSplat -Uri 'https://jira.example.com/rest/api/2/myself' -Method Get -Headers @{} -StoreSession
+
+            $result.SessionVariable | Should -Be 'newSessionVar'
+            $result.ContainsKey('WebSession') | Should -BeFalse
+        }
+    }
+}

--- a/Tests/Functions/Private/Resolve-JiraRequestContext.Unit.Tests.ps1
+++ b/Tests/Functions/Private/Resolve-JiraRequestContext.Unit.Tests.ps1
@@ -1,0 +1,80 @@
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+
+BeforeDiscovery {
+    . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+
+    $script:moduleToTest = Initialize-TestEnvironment
+}
+
+InModuleScope JiraPS {
+    Describe "Resolve-JiraRequestContext" -Tag 'Unit' {
+        BeforeAll {
+            . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+
+            function script:Invoke-ResolveJiraRequestContext {
+                [CmdletBinding(SupportsPaging)]
+                param(
+                    [Parameter(Mandatory)]
+                    [Uri]
+                    $Uri,
+
+                    [Hashtable]
+                    $GetParameter = @{},
+
+                    [ValidateRange(1, [int]::MaxValue)]
+                    [int]
+                    $DefaultPageSize = 25
+                )
+
+                Resolve-JiraRequestContext -Uri $Uri -GetParameter $GetParameter -DefaultPageSize $DefaultPageSize -Cmdlet $PSCmdlet
+            }
+        }
+
+        It "resolves a relative URI against the configured Jira server and applies default page size" {
+            Mock Get-JiraConfigServer -ModuleName 'JiraPS' { 'https://jira.example.com' }
+
+            $result = Invoke-ResolveJiraRequestContext -Uri '/rest/api/2/search'
+
+            $result.Uri.AbsoluteUri | Should -Be 'https://jira.example.com/rest/api/2/search'
+            $result.PaginatedUri.AbsoluteUri | Should -Match '\?maxResults=25$'
+        }
+
+        It "merges URI query and -GetParameter with caller values taking precedence" {
+            $result = Invoke-ResolveJiraRequestContext -Uri 'https://jira.example.com/rest/api/2/search?jql=fromUri' -GetParameter @{ jql = 'fromArg'; expand = 'names' }
+
+            $result.Uri.Query | Should -BeNullOrEmpty
+            $result.PaginatedUri.AbsoluteUri | Should -Match 'jql=fromArg'
+            $result.PaginatedUri.AbsoluteUri | Should -Match 'expand=names'
+            $result.PaginatedUri.AbsoluteUri | Should -Match 'maxResults=25'
+        }
+
+        It "applies paging overrides from the caller cmdlet" {
+            $result = Invoke-ResolveJiraRequestContext -Uri 'https://jira.example.com/rest/api/2/search' -First 5 -Skip 2
+
+            $result.PaginatedUri.AbsoluteUri | Should -Match 'maxResults=5'
+            $result.PaginatedUri.AbsoluteUri | Should -Match 'startAt=2'
+        }
+
+        It "preserves existing maxResults when -First is larger" {
+            $result = Invoke-ResolveJiraRequestContext -Uri 'https://jira.example.com/rest/api/2/search?maxResults=10' -First 25
+
+            $result.PaginatedUri.AbsoluteUri | Should -Match 'maxResults=10'
+        }
+
+        It "throws for relative URIs that do not start with '/'" {
+            { Invoke-ResolveJiraRequestContext -Uri 'hello' } | Should -Throw -ExpectedMessage "*must start with '/'*"
+        }
+
+        It "throws when a relative URI is used without a configured Jira server" {
+            Mock Get-JiraConfigServer -ModuleName 'JiraPS' { $null }
+
+            { Invoke-ResolveJiraRequestContext -Uri '/rest/api/2/search' } | Should -Throw -ExpectedMessage "*no Jira server is configured*"
+        }
+
+        It "throws when resolving a relative URI still results in a non-absolute URI" {
+            Mock Get-JiraConfigServer -ModuleName 'JiraPS' { 'jira.example.com' }
+
+            { Invoke-ResolveJiraRequestContext -Uri '/rest/api/2/search' } | Should -Throw -ExpectedMessage "*must be an absolute URI*"
+        }
+    }
+}

--- a/Tests/Functions/Private/Resolve-JiraWebResponse.Unit.Tests.ps1
+++ b/Tests/Functions/Private/Resolve-JiraWebResponse.Unit.Tests.ps1
@@ -1,0 +1,171 @@
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+
+BeforeDiscovery {
+    . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+
+    $script:moduleToTest = Initialize-TestEnvironment
+}
+
+InModuleScope JiraPS {
+    Describe "Resolve-JiraWebResponse" -Tag 'Unit' {
+        BeforeAll {
+            . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+
+            function script:New-FakeWebResponse {
+                param(
+                    [int]$StatusCode = 200,
+                    [string]$Json = '{"id":1}'
+                )
+
+                $bytes = [System.Text.Encoding]::UTF8.GetBytes($Json)
+                [PSCustomObject]@{
+                    StatusCode       = [System.Net.HttpStatusCode]$StatusCode
+                    Content          = $Json
+                    RawContentStream = [System.IO.MemoryStream]::new($bytes)
+                }
+            }
+
+            function script:Invoke-ResolveJiraWebResponse {
+                [CmdletBinding()]
+                param(
+                    [Parameter(ValueFromRemainingArguments = $true)]
+                    $Remaining
+                )
+
+                Resolve-JiraWebResponse @Remaining -Cmdlet $PSCmdlet
+            }
+        }
+
+        It "delegates HTTP errors to Resolve-ErrorWebResponse" {
+            Mock Resolve-ErrorWebResponse -ModuleName 'JiraPS' {}
+
+            $response = New-FakeWebResponse -StatusCode 400
+            $null = Invoke-ResolveJiraWebResponse -Remaining @{ WebResponse = $response; Exception = [System.Exception]::new('boom') }
+
+            Should -Invoke -CommandName Resolve-ErrorWebResponse -ModuleName 'JiraPS' -Exactly -Times 1 -Scope It
+        }
+
+        It "falls back to Exception.Response.StatusCode when direct status code is unavailable" {
+            Mock Resolve-ErrorWebResponse -ModuleName 'JiraPS' {}
+            $bytes = [System.Text.Encoding]::UTF8.GetBytes('{}')
+            $response = [PSCustomObject]@{
+                StatusCode       = $null
+                Exception        = [PSCustomObject]@{
+                    Response = [PSCustomObject]@{
+                        StatusCode = [System.Net.HttpStatusCode]::BadRequest
+                    }
+                }
+                Content          = '{}'
+                RawContentStream = [System.IO.MemoryStream]::new($bytes)
+            }
+
+            $null = Invoke-ResolveJiraWebResponse -Remaining @{
+                WebResponse = $response
+                Exception   = [System.Exception]::new('fallback-error')
+            }
+
+            Should -Invoke -CommandName Resolve-ErrorWebResponse -ModuleName 'JiraPS' -Exactly -Times 1 -Scope It -ParameterFilter {
+                $StatusCode -eq [System.Net.HttpStatusCode]::BadRequest
+            }
+        }
+
+        It "returns nothing when no web response object is provided" {
+            { $script:result = Invoke-ResolveJiraWebResponse -Remaining @{} } | Should -Not -Throw
+            $script:result | Should -BeNullOrEmpty
+        }
+
+        It "returns transformed session when -StoreSession is set" {
+            Mock ConvertTo-JiraSession -ModuleName 'JiraPS' {
+                [PSCustomObject]@{
+                    Username = $Username
+                }
+            }
+
+            $response = New-FakeWebResponse -StatusCode 200
+            $credential = [pscredential]::new('user@example.com', (ConvertTo-SecureString 'pw' -AsPlainText -Force))
+            $session = [Microsoft.PowerShell.Commands.WebRequestSession]::new()
+            $result = Invoke-ResolveJiraWebResponse -Remaining @{
+                WebResponse                 = $response
+                StoreSession                = $true
+                Credential                  = $credential
+                SessionTransformationMethod = 'ConvertTo-JiraSession'
+                Session                     = $session
+            }
+
+            $result.Username | Should -Be 'user@example.com'
+        }
+
+        It "stores cache entries for GET responses when CacheKey is provided" {
+            Mock Get-JiraConfigServer -ModuleName 'JiraPS' { 'https://jira.example.com' }
+            $script:JiraCache = @{}
+
+            $response = New-FakeWebResponse -StatusCode 200 -Json '{"name":"field"}'
+            $null = Invoke-ResolveJiraWebResponse -Remaining @{
+                WebResponse = $response
+                CacheKey    = 'Fields'
+                Method      = 'GET'
+                CacheExpiry = [TimeSpan]::FromMinutes(30)
+            }
+
+            $script:JiraCache.ContainsKey('Fields:https://jira.example.com') | Should -BeTrue
+            $script:JiraCache['Fields:https://jira.example.com'].Data.name | Should -Be 'field'
+        }
+
+        It "does not create a cache entry for non-GET responses" {
+            Mock Get-JiraConfigServer -ModuleName 'JiraPS' { 'https://jira.example.com' }
+            $script:JiraCache = @{}
+
+            $response = New-FakeWebResponse -StatusCode 200 -Json '{"name":"field"}'
+            $null = Invoke-ResolveJiraWebResponse -Remaining @{
+                WebResponse = $response
+                CacheKey    = 'Fields'
+                Method      = 'POST'
+            }
+
+            $script:JiraCache.Count | Should -Be 0
+        }
+
+        It "returns nothing when successful response has no content" {
+            $response = [PSCustomObject]@{
+                StatusCode       = [System.Net.HttpStatusCode]::OK
+                Content          = ''
+                RawContentStream = [System.IO.MemoryStream]::new(@())
+            }
+
+            $result = Invoke-ResolveJiraWebResponse -Remaining @{
+                WebResponse = $response
+                Method      = 'GET'
+            }
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It "returns parsed response for successful non-paging requests" {
+            Mock Invoke-PaginatedRequest -ModuleName 'JiraPS' { throw 'Should not be called for non-paging response.' }
+
+            $response = New-FakeWebResponse -StatusCode 200 -Json '{"id":42,"name":"ok"}'
+            $result = Invoke-ResolveJiraWebResponse -Remaining @{
+                WebResponse = $response
+                Method      = 'GET'
+            }
+
+            $result.id | Should -Be 42
+            $result.name | Should -Be 'ok'
+            Should -Invoke -CommandName Invoke-PaginatedRequest -ModuleName 'JiraPS' -Exactly -Times 0 -Scope It
+        }
+
+        It "delegates paging results to Invoke-PaginatedRequest when -Paging is set" {
+            Mock Invoke-PaginatedRequest -ModuleName 'JiraPS' { @('paged') }
+
+            $response = New-FakeWebResponse -StatusCode 200 -Json '{"issues":[{"id":1}],"startAt":0,"maxResults":1,"total":1}'
+            $result = Invoke-ResolveJiraWebResponse -Remaining @{
+                WebResponse     = $response
+                Paging          = $true
+                BoundParameters = @{ Uri = 'https://jira.example.com' }
+            }
+
+            $result | Should -Be @('paged')
+            Should -Invoke -CommandName Invoke-PaginatedRequest -ModuleName 'JiraPS' -Exactly -Times 1 -Scope It
+        }
+    }
+}

--- a/Tests/Functions/Private/Resolve-JiraWebResponse.Unit.Tests.ps1
+++ b/Tests/Functions/Private/Resolve-JiraWebResponse.Unit.Tests.ps1
@@ -82,7 +82,10 @@ InModuleScope JiraPS {
             }
 
             $response = New-FakeWebResponse -StatusCode 200
-            $credential = [pscredential]::new('user@example.com', (ConvertTo-SecureString 'pw' -AsPlainText -Force))
+            $securePassword = [System.Security.SecureString]::new()
+            'pw'.ToCharArray() | ForEach-Object { $securePassword.AppendChar($_) }
+            $securePassword.MakeReadOnly()
+            $credential = [pscredential]::new('user@example.com', $securePassword)
             $session = [Microsoft.PowerShell.Commands.WebRequestSession]::new()
             $result = Invoke-ResolveJiraWebResponse -Remaining @{
                 WebResponse                 = $response

--- a/Tests/Functions/Private/Set-JiraCachedResponse.Unit.Tests.ps1
+++ b/Tests/Functions/Private/Set-JiraCachedResponse.Unit.Tests.ps1
@@ -1,0 +1,37 @@
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+
+BeforeDiscovery {
+    . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+
+    $script:moduleToTest = Initialize-TestEnvironment
+}
+
+InModuleScope JiraPS {
+    Describe "Set-JiraCachedResponse" -Tag 'Unit' {
+        BeforeAll {
+            . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+        }
+
+        BeforeEach {
+            $script:JiraCache = @{}
+            Mock Get-JiraConfigServer -ModuleName 'JiraPS' { 'https://jira.example.com' }
+        }
+
+        It "stores response in cache for GET requests" {
+            $response = [PSCustomObject]@{ name = 'field' }
+
+            Set-JiraCachedResponse -CacheKey 'Fields' -Method 'GET' -Response $response -CacheExpiry ([TimeSpan]::FromMinutes(5))
+
+            $script:JiraCache.ContainsKey('Fields:https://jira.example.com') | Should -BeTrue
+            $script:JiraCache['Fields:https://jira.example.com'].Data | Should -Be $response
+        }
+
+        It "does not cache non-GET requests" {
+            $response = [PSCustomObject]@{ name = 'field' }
+
+            Set-JiraCachedResponse -CacheKey 'Fields' -Method 'POST' -Response $response -CacheExpiry ([TimeSpan]::FromMinutes(5))
+
+            $script:JiraCache.Count | Should -Be 0
+        }
+    }
+}


### PR DESCRIPTION
Summary: refactor Invoke-JiraMethod into private helpers for request context, web request splat construction, request execution, response handling, and cache handling while preserving behavior. Added helper-focused unit tests for success, error, and edge paths including status-code fallback, non-paging success responses, maxResults preservation, and unresolved session-variable capture. Validation: Invoke-Build -Task Build, Test; Invoke-Build -Task TestIntegration -Tag Smoke.