### PR TITLE
Extract shared field-resolution helper

### DIFF
--- a/JiraPS/Private/ConvertTo-JiraFieldAssignment.ps1
+++ b/JiraPS/Private/ConvertTo-JiraFieldAssignment.ps1
@@ -1,0 +1,91 @@
+﻿function ConvertTo-JiraFieldAssignment {
+    <#
+    .SYNOPSIS
+        Converts a -Fields hashtable into resolved Jira field assignments.
+    .DESCRIPTION
+        Reuses scoped metadata first, then lazily fetches the global field
+        catalogue only if at least one key is absent from the scoped metadata.
+        Returns normalized assignment objects so callers can keep their own
+        payload-writing logic.
+    #>
+    [CmdletBinding()]
+    [OutputType([PSObject[]])]
+    param(
+        [Parameter(Mandatory)]
+        [object]$Fields,
+
+        [AllowNull()]
+        [object[]]$ScopedMeta = @(),
+
+        [Parameter(Mandatory)]
+        [bool]$IsCloud,
+
+        [string]$ScopedContext = 'scoped metadata',
+
+        [string]$CallerName = $MyInvocation.MyCommand.Name,
+
+        [scriptblock]$FallbackFieldFetcher
+    )
+
+    $scopedFieldsById = if ($ScopedMeta) {
+        $ScopedMeta | Group-Object -Property Id -AsHashTable -AsString
+    }
+    else {
+        @{}
+    }
+    $scopedFieldsByName = if ($ScopedMeta) {
+        $ScopedMeta | Group-Object -Property Name -AsHashTable -AsString
+    }
+    else {
+        @{}
+    }
+
+    $fallbackFieldsById = $null
+    $fallbackFieldsByName = $null
+
+    Write-Debug "[$CallerName] Resolving `$Fields"
+
+    foreach ($_key in $Fields.Keys) {
+        $name = $_key
+        $value = $Fields.$_key
+        Write-DebugMessage "[$CallerName] Attempting to identify field (name=[$name], value=[$value])"
+
+        if (
+            -not $scopedFieldsById.ContainsKey($name) -and
+            -not $scopedFieldsById.ContainsKey("customfield_$name") -and
+            -not $scopedFieldsByName.ContainsKey($name) -and
+            $null -eq $fallbackFieldsById
+        ) {
+            Write-Debug "[$CallerName] [$name] not in $ScopedContext; fetching global field list as fallback"
+            $fb = if ($FallbackFieldFetcher) { & $FallbackFieldFetcher } else { @() }
+            $fallbackFieldsById = if ($fb) { $fb | Group-Object -Property Id -AsHashTable -AsString } else { @{} }
+            $fallbackFieldsByName = if ($fb) { $fb | Group-Object -Property Name -AsHashTable -AsString } else { @{} }
+        }
+
+        $fallbackByIdForResolve = @{}
+        $fallbackByNameForResolve = @{}
+        if ($null -ne $fallbackFieldsById) {
+            $fallbackByIdForResolve = $fallbackFieldsById
+            $fallbackByNameForResolve = $fallbackFieldsByName
+        }
+
+        $field = Resolve-JiraField `
+            -Name $name `
+            -ScopedById $scopedFieldsById `
+            -ScopedByName $scopedFieldsByName `
+            -FallbackById $fallbackByIdForResolve `
+            -FallbackByName $fallbackByNameForResolve `
+            -CallerName $CallerName
+
+        if ($IsCloud -and ($value -is [string]) -and (Test-JiraRichTextField -Field $field)) {
+            $value = Resolve-JiraTextFieldPayload -Text $value -IsCloud $true
+        }
+
+        [PSCustomObject]@{
+            InputName = $name
+            Field     = $field
+            Id        = [string]$field.Id
+            Value     = $value
+        }
+    }
+}

--- a/JiraPS/Public/Invoke-JiraIssueTransition.ps1
+++ b/JiraPS/Public/Invoke-JiraIssueTransition.ps1
@@ -163,73 +163,15 @@
                 @()
             }
 
-            $ScopedFieldsById = if ($scopedMeta) {
-                $scopedMeta | Group-Object -Property Id -AsHashTable -AsString
-            }
-            else {
-                @{}
-            }
-            $ScopedFieldsByName = if ($scopedMeta) {
-                $scopedMeta | Group-Object -Property Name -AsHashTable -AsString
-            }
-            else {
-                @{}
-            }
-
-            $FallbackFieldsById = $null
-            $FallbackFieldsByName = $null
-
-            Write-Debug "[$($MyInvocation.MyCommand.Name)] Resolving `$Fields"
-            foreach ($_key in $Fields.Keys) {
-
-                $name = $_key
-                $value = $Fields.$_key
-                Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] Attempting to identify field (name=[$name], value=[$value])"
-
-                if (
-                    -not $ScopedFieldsById.ContainsKey($name) -and
-                    -not $ScopedFieldsById.ContainsKey("customfield_$name") -and
-                    -not $ScopedFieldsByName.ContainsKey($name) -and
-                    $null -eq $FallbackFieldsById
-                ) {
-                    Write-Debug "[$($MyInvocation.MyCommand.Name)] [$name] not in transition metadata; fetching global field list as fallback"
-                    $fb = Get-JiraField -Credential $Credential -ErrorAction Stop -Debug:$false
-                    $FallbackFieldsById = if ($fb) { $fb | Group-Object -Property Id -AsHashTable -AsString } else { @{} }
-                    $FallbackFieldsByName = if ($fb) { $fb | Group-Object -Property Name -AsHashTable -AsString } else { @{} }
-                }
-
-                $FallbackByIdForResolve = @{}
-                $FallbackByNameForResolve = @{}
-                if ($null -ne $FallbackFieldsById) {
-                    $FallbackByIdForResolve = $FallbackFieldsById
-                    $FallbackByNameForResolve = $FallbackFieldsByName
-                }
-
-                $field = Resolve-JiraField `
-                    -Name          $name `
-                    -ScopedById    $ScopedFieldsById `
-                    -ScopedByName  $ScopedFieldsByName `
-                    -FallbackById  $FallbackByIdForResolve `
-                    -FallbackByName $FallbackByNameForResolve `
-                    -CallerName    $MyInvocation.MyCommand.Name
-
-                # Force the id to a string — Get-JiraField historically
-                # surfaced numeric ids as hashtables in some metadata
-                # shapes, which crashed ConvertTo-Json downstream.
-                $id = "$($field.Id)"
-
-                # `-Fields` values hit a raw assignment; wrap rich-text strings here
-                # for parity with the named-parameter paths.
-                if (
-                    $isCloud -and
-                    ($value -is [string]) -and
-                    (Test-JiraRichTextField -Field $field)
-                ) {
-                    $value = Resolve-JiraTextFieldPayload -Text $value -IsCloud $true
-                }
-
-                $requestBody.update.$id = @( @{
-                        'set' = $value
+            foreach ($assignment in ConvertTo-JiraFieldAssignment `
+                    -Fields $Fields `
+                    -ScopedMeta $scopedMeta `
+                    -IsCloud $isCloud `
+                    -ScopedContext 'transition metadata' `
+                    -CallerName $MyInvocation.MyCommand.Name `
+                    -FallbackFieldFetcher { Get-JiraField -Credential $Credential -ErrorAction Stop -Debug:$false }) {
+                $requestBody.update.$($assignment.Id) = @( @{
+                        'set' = $assignment.Value
                     })
             }
         }

--- a/JiraPS/Public/New-JiraIssue.ps1
+++ b/JiraPS/Public/New-JiraIssue.ps1
@@ -177,66 +177,14 @@
             # project/issue-type create screen and avoids a global Get-JiraField
             # round-trip for the common case. Get-JiraField is only fetched as a
             # fallback for fields not present in the scoped metadata.
-            $ScopedFieldsById = if ($createmeta) {
-                $createmeta | Group-Object -Property Id -AsHashTable -AsString
-            }
-            else {
-                @{}
-            }
-            $ScopedFieldsByName = if ($createmeta) {
-                $createmeta | Group-Object -Property Name -AsHashTable -AsString
-            }
-            else {
-                @{}
-            }
-
-            $FallbackFieldsById = $null
-            $FallbackFieldsByName = $null
-
-            Write-Debug "[$($MyInvocation.MyCommand.Name)] Resolving `$Fields"
-
-            foreach ($_key in $Fields.Keys) {
-
-                $name = $_key
-                $value = $Fields.$_key
-                Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] Attempting to identify field (name=[$name], value=[$value])"
-
-                if (
-                    -not $ScopedFieldsById.ContainsKey($name) -and
-                    -not $ScopedFieldsById.ContainsKey("customfield_$name") -and
-                    -not $ScopedFieldsByName.ContainsKey($name) -and
-                    $null -eq $FallbackFieldsById
-                ) {
-                    Write-Debug "[$($MyInvocation.MyCommand.Name)] [$name] not in create metadata; fetching global field list as fallback"
-                    $fb = Get-JiraField -Credential $Credential -ErrorAction Stop -Debug:$false
-                    $FallbackFieldsById = if ($fb) { $fb | Group-Object -Property Id -AsHashTable -AsString } else { @{} }
-                    $FallbackFieldsByName = if ($fb) { $fb | Group-Object -Property Name -AsHashTable -AsString } else { @{} }
-                }
-
-                $FallbackByIdForResolve = @{}
-                $FallbackByNameForResolve = @{}
-                if ($null -ne $FallbackFieldsById) {
-                    $FallbackByIdForResolve = $FallbackFieldsById
-                    $FallbackByNameForResolve = $FallbackFieldsByName
-                }
-
-                $field = Resolve-JiraField `
-                    -Name          $name `
-                    -ScopedById    $ScopedFieldsById `
-                    -ScopedByName  $ScopedFieldsByName `
-                    -FallbackById  $FallbackByIdForResolve `
-                    -FallbackByName $FallbackByNameForResolve `
-                    -CallerName    $MyInvocation.MyCommand.Name
-
-                $id = "$($field.Id)"
-
-                # `-Fields` values hit a raw assignment; wrap rich-text strings here
-                # for parity with the named-parameter paths.
-                if ($isCloud -and ($value -is [string]) -and (Test-JiraRichTextField -Field $field)) {
-                    $value = Resolve-JiraTextFieldPayload -Text $value -IsCloud $true
-                }
-
-                $requestBody["$id"] = $value
+            foreach ($assignment in ConvertTo-JiraFieldAssignment `
+                    -Fields $Fields `
+                    -ScopedMeta $createmeta `
+                    -IsCloud $isCloud `
+                    -ScopedContext 'create metadata' `
+                    -CallerName $MyInvocation.MyCommand.Name `
+                    -FallbackFieldFetcher { Get-JiraField -Credential $Credential -ErrorAction Stop -Debug:$false }) {
+                $requestBody[$assignment.Id] = $assignment.Value
             }
         }
 

--- a/JiraPS/Public/Set-JiraIssue.ps1
+++ b/JiraPS/Public/Set-JiraIssue.ps1
@@ -172,65 +172,14 @@
                 @()
             }
 
-            $ScopedFieldsById = if ($scopedMeta) {
-                $scopedMeta | Group-Object -Property Id -AsHashTable -AsString
-            }
-            else {
-                @{}
-            }
-            $ScopedFieldsByName = if ($scopedMeta) {
-                $scopedMeta | Group-Object -Property Name -AsHashTable -AsString
-            }
-            else {
-                @{}
-            }
-
-            $FallbackFieldsById = $null
-            $FallbackFieldsByName = $null
-
-            Write-Debug "[$($MyInvocation.MyCommand.Name)] Resolving `$Fields"
-            foreach ($_key in $Fields.Keys) {
-
-                $name = $_key
-                $value = $Fields.$_key
-                Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] Attempting to identify field (name=[$name], value=[$value])"
-
-                if (
-                    -not $ScopedFieldsById.ContainsKey($name) -and
-                    -not $ScopedFieldsById.ContainsKey("customfield_$name") -and
-                    -not $ScopedFieldsByName.ContainsKey($name) -and
-                    $null -eq $FallbackFieldsById
-                ) {
-                    Write-Debug "[$($MyInvocation.MyCommand.Name)] [$name] not in edit metadata; fetching global field list as fallback"
-                    $fb = Get-JiraField -Credential $Credential -ErrorAction Stop -Debug:$false
-                    $FallbackFieldsById = if ($fb) { $fb | Group-Object -Property Id -AsHashTable -AsString } else { @{} }
-                    $FallbackFieldsByName = if ($fb) { $fb | Group-Object -Property Name -AsHashTable -AsString } else { @{} }
-                }
-
-                $FallbackByIdForResolve = @{}
-                $FallbackByNameForResolve = @{}
-                if ($null -ne $FallbackFieldsById) {
-                    $FallbackByIdForResolve = $FallbackFieldsById
-                    $FallbackByNameForResolve = $FallbackFieldsByName
-                }
-
-                $field = Resolve-JiraField `
-                    -Name          $name `
-                    -ScopedById    $ScopedFieldsById `
-                    -ScopedByName  $ScopedFieldsByName `
-                    -FallbackById  $FallbackByIdForResolve `
-                    -FallbackByName $FallbackByNameForResolve `
-                    -CallerName    $MyInvocation.MyCommand.Name
-
-                $id = [string]$field.Id
-
-                # `-Fields` values hit a raw assignment; wrap rich-text strings here
-                # for parity with the named-parameter paths.
-                if ($isCloud -and ($value -is [string]) -and (Test-JiraRichTextField -Field $field)) {
-                    $value = Resolve-JiraTextFieldPayload -Text $value -IsCloud $true
-                }
-
-                $issueProps.update[$id] = @(@{ 'set' = $value })
+            foreach ($assignment in ConvertTo-JiraFieldAssignment `
+                    -Fields $Fields `
+                    -ScopedMeta $scopedMeta `
+                    -IsCloud $isCloud `
+                    -ScopedContext 'edit metadata' `
+                    -CallerName $MyInvocation.MyCommand.Name `
+                    -FallbackFieldFetcher { Get-JiraField -Credential $Credential -ErrorAction Stop -Debug:$false }) {
+                $issueProps.update[$assignment.Id] = @(@{ 'set' = $assignment.Value })
             }
         }
 

--- a/Tests/Functions/Private/ConvertTo-JiraFieldAssignment.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraFieldAssignment.Unit.Tests.ps1
@@ -1,0 +1,119 @@
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+
+BeforeDiscovery {
+    . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+
+    $script:moduleToTest = Initialize-TestEnvironment
+}
+
+InModuleScope JiraPS {
+    Describe "ConvertTo-JiraFieldAssignment" -Tag 'Unit' {
+        BeforeAll {
+            . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+
+            $script:scopedField = [PSCustomObject]@{
+                Id     = 'customfield_10001'
+                Name   = 'Scoped Field'
+                Schema = [PSCustomObject]@{ type = 'string' }
+            }
+            $script:fallbackField = [PSCustomObject]@{
+                Id     = 'customfield_20001'
+                Name   = 'Fallback Field'
+                Schema = [PSCustomObject]@{ type = 'string' }
+            }
+            $script:anotherFallbackField = [PSCustomObject]@{
+                Id     = 'customfield_20002'
+                Name   = 'Another Fallback Field'
+                Schema = [PSCustomObject]@{ type = 'string' }
+            }
+            $script:richTextField = [PSCustomObject]@{
+                Id     = 'description'
+                Name   = 'Description'
+                Schema = [PSCustomObject]@{ type = 'string'; system = 'description' }
+            }
+            $script:dupeField1 = [PSCustomObject]@{
+                Id     = 'customfield_30001'
+                Name   = 'Duplicate'
+                Schema = [PSCustomObject]@{ type = 'string' }
+            }
+            $script:dupeField2 = [PSCustomObject]@{
+                Id     = 'customfield_30002'
+                Name   = 'Duplicate'
+                Schema = [PSCustomObject]@{ type = 'string' }
+            }
+        }
+
+        BeforeEach {
+            Mock Get-JiraField -ModuleName JiraPS {
+                @($fallbackField, $anotherFallbackField, $richTextField)
+            }
+
+            Mock Test-JiraRichTextField -ModuleName JiraPS { $false }
+            Mock Resolve-JiraTextFieldPayload -ModuleName JiraPS { "ADF:$Text" }
+        }
+
+        It "resolves scoped fields without fetching the global field list" {
+            $result = ConvertTo-JiraFieldAssignment -Fields @{ 'Scoped Field' = 'scoped value' } -ScopedMeta @($scopedField) -IsCloud $false -FallbackFieldFetcher { Get-JiraField }
+
+            $result | Should -HaveCount 1
+            $result[0].Id | Should -Be 'customfield_10001'
+            $result[0].Value | Should -Be 'scoped value'
+            Should -Invoke Get-JiraField -ModuleName JiraPS -Exactly -Times 0
+        }
+
+        It "fetches the global field list at most once for multiple unscoped fields" {
+            $result = ConvertTo-JiraFieldAssignment -Fields @{
+                'Fallback Field'         = 'a'
+                'Another Fallback Field' = 'b'
+            } -ScopedMeta @() -IsCloud $false -FallbackFieldFetcher { Get-JiraField }
+
+            $result | Should -HaveCount 2
+            @($result.Id) | Should -Contain 'customfield_20001'
+            @($result.Id) | Should -Contain 'customfield_20002'
+            Should -Invoke Get-JiraField -ModuleName JiraPS -Exactly -Times 1
+        }
+
+        It "wraps Cloud rich-text string values via Resolve-JiraTextFieldPayload" {
+            Mock Get-JiraField -ModuleName JiraPS { @($richTextField) }
+            Mock Test-JiraRichTextField -ModuleName JiraPS -ParameterFilter { $Field.Id -eq 'description' } { $true }
+
+            $result = ConvertTo-JiraFieldAssignment -Fields @{ description = 'Hello world' } -ScopedMeta @() -IsCloud $true -FallbackFieldFetcher { Get-JiraField }
+
+            $result | Should -HaveCount 1
+            $result[0].Value | Should -Be 'ADF:Hello world'
+            Should -Invoke Resolve-JiraTextFieldPayload -ModuleName JiraPS -Exactly -Times 1
+        }
+
+        It "leaves non-string values unchanged on Cloud" {
+            Mock Get-JiraField -ModuleName JiraPS { @($richTextField) }
+            Mock Test-JiraRichTextField -ModuleName JiraPS -ParameterFilter { $Field.Id -eq 'description' } { $true }
+
+            $result = ConvertTo-JiraFieldAssignment -Fields @{ description = @{ text = 'already structured' } } -ScopedMeta @() -IsCloud $true -FallbackFieldFetcher { Get-JiraField }
+
+            $result[0].Value.text | Should -Be 'already structured'
+            Should -Invoke Resolve-JiraTextFieldPayload -ModuleName JiraPS -Exactly -Times 0
+        }
+
+        It "preserves ambiguity failures from Resolve-JiraField" {
+            Mock Get-JiraField -ModuleName JiraPS { @($dupeField1, $dupeField2) }
+
+            {
+                ConvertTo-JiraFieldAssignment -Fields @{ Duplicate = 'value' } -ScopedMeta @() -IsCloud $false -FallbackFieldFetcher { Get-JiraField } -ErrorAction Stop
+            } | Should -Throw -ExceptionType ([System.ArgumentException])
+        }
+
+        It "preserves not-found failures from Resolve-JiraField" {
+            {
+                ConvertTo-JiraFieldAssignment -Fields @{ MissingField = 'value' } -ScopedMeta @() -IsCloud $false -FallbackFieldFetcher { @() } -ErrorAction Stop
+            } | Should -Throw -ExceptionType ([System.ArgumentException])
+        }
+
+        It "does not fetch fallback fields when the fetcher is omitted and all keys resolve from scoped metadata" {
+            $result = ConvertTo-JiraFieldAssignment -Fields @{ 'Scoped Field' = 'scoped value' } -ScopedMeta @($scopedField) -IsCloud $false
+
+            $result | Should -HaveCount 1
+            $result[0].Id | Should -Be 'customfield_10001'
+            Should -Invoke Get-JiraField -ModuleName JiraPS -Exactly -Times 0
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extract shared `-Fields` orchestration into a private `Resolve-JiraFields` helper
- update `New-JiraIssue`, `Set-JiraIssue`, and `Invoke-JiraIssueTransition` to use the helper while preserving their existing metadata and payload behavior
- add focused helper tests for scoped resolution, lazy fallback fetching, Cloud rich-text conversion, and omitted fallback handling

## Testing
- `Invoke-Build -Task Build, Test`
- `Invoke-Build -Task TestIntegration -Tag Smoke`