### PR TITLE
docs: add CI triage runbook and PS5 checklist gates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,6 +28,8 @@
 - [ ] My code follows the code style of this project.
 - [ ] I have added Pester Tests that describe what my changes should do.
 - [ ] I have updated the documentation accordingly.
+- [ ] If I developed on macOS/Linux, I confirmed the Windows PowerShell 5.1 CI lane passed.
+- [ ] If I changed transport/response helper paths, I covered edge cases (request context, session, cache, paging, exception status fallback).
 
 ### Cloud / Data Center Compatibility
 

--- a/.github/ai-context/ci-triage-runbook.md
+++ b/.github/ai-context/ci-triage-runbook.md
@@ -1,0 +1,43 @@
+# CI Triage Runbook
+
+Use this runbook when `.github/workflows/ci.yml` fails on a pull request.
+
+## Quick Triage Sequence
+
+1. Open the failing run and identify the first failed job.
+2. Determine whether the failure is `Lint`, `Test` (especially Windows PowerShell 5.1), or `Smoke`.
+3. Fix the root cause before rerunning, instead of rerunning first.
+4. Confirm all required checks are green, including `CI Result`, before merge.
+
+## Lint Failures
+
+1. Read the exact PSScriptAnalyzer rule name and file path from the failed log.
+2. Prefer code fixes over suppressions, and only use suppressions that match repository patterns.
+3. For private helper functions that intentionally mutate state, use narrow helper-level suppressions instead of broad file-level suppressions.
+4. Re-run local lint with `Invoke-Build -Task Lint` before pushing.
+
+## Windows PowerShell 5.1 Failures
+
+1. Treat PS5 failures as compatibility defects, not flaky noise.
+2. Remember that macOS and Linux cannot run Windows PowerShell 5.1 locally.
+3. Focus on known PS5-sensitive areas such as inline C# (`Add-Type`), casting behavior, and legacy parser limitations.
+4. Keep C# snippets compatible with PS5 compilation constraints.
+5. Push the fix and use the CI PS5 lane as the source of truth for final verification.
+
+## Edge-Case Matrix for High-Risk Refactors
+
+For changes in request/transport/response helpers, verify tests cover:
+
+1. request context resolution and invalid URI branches,
+2. session variable capture and restoration paths,
+3. cache read and cache write branches (including non-GET behavior),
+4. paging and non-paging response shapes,
+5. HTTP status fallback paths when status is only present on `Exception.Response`.
+
+## Useful Commands
+
+```bash
+gh pr checks <pr-number>
+gh run view <run-id> --log-failed
+gh workflow run "Integration Tests" --ref <branch> -f track=cloud
+```

--- a/.github/ai-context/powershell-rules.md
+++ b/.github/ai-context/powershell-rules.md
@@ -161,6 +161,9 @@ Invoke-Build -Task TestIntegration -Tag 'Smoke'         # Smoke subset only
 Invoke-Build -Task TestIntegration -ThrottleLimit 8     # More parallelism
 ```
 
+- macOS and Linux contributors cannot run the Windows PowerShell 5.1 lane locally.
+- Treat the Windows PowerShell 5.1 CI test job as a required merge gate for every code change.
+
 ### Available Build Tasks
 
 | Task | What it does |
@@ -179,6 +182,10 @@ Invoke-Build -Task TestIntegration -ThrottleLimit 8     # More parallelism
 - **Forgetting `./Tools/setup.ps1`** — Missing dependencies (Pester, InvokeBuild, etc.)
 - **Running `TestIntegration` without `.env`** — Will fail fast on missing credentials
 
+### CI Failure Triage Runbook
+
+Use [CI Triage Runbook](ci-triage-runbook.md) when lint or Windows PowerShell 5.1 jobs fail.
+
 ## Review Checklist
 
 When changing PowerShell files:
@@ -188,3 +195,6 @@ When changing PowerShell files:
 3. If text fields are read/written: is ADF conversion conditional on deployment type?
 4. Are tests written/updated?
 5. Do tests pass? (`Invoke-Build -Task Build && Invoke-Build -Task Test`)
+6. If transport/response internals changed: are edge paths covered (request context, session capture, cache branches, paging, and status fallback from exceptions)?
+7. If you developed on macOS/Linux: did the Windows PowerShell 5.1 CI lane pass before merge?
+8. If CI failed: did you follow the [CI Triage Runbook](ci-triage-runbook.md)?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,6 +294,7 @@ Private functions in `JiraPS/Private/` may use minimal comment-based help (`.SYN
 > You MUST build before running unit tests.
 >
 > Integration tests run directly against `JiraPS/JiraPS.psd1` (no build step) and require live Jira Cloud credentials.
+> macOS and Linux contributors cannot execute the Windows PowerShell 5.1 lane locally, so treat that CI lane as a required pre-merge gate.
 
 ```powershell
 ./Tools/setup.ps1
@@ -347,6 +348,7 @@ Invoke-Pester Tests/Functions/Public/Get-JiraIssue.Unit.Tests.ps1
 - `Style.Tests.ps1` (encoding, whitespace, line endings) runs with the full test suite
 
 **Before committing**: Run full `Invoke-Build -Task Build, Test`.
+**Before merging**: Ensure the Windows PowerShell 5.1 `Test` job in `ci.yml` is green.
 
 **VSCode Integration:**
 
@@ -493,6 +495,7 @@ Follow the [`powershell-rules.md` Review Checklist](.github/ai-context/powershel
   - `server_integration_tests` — `Server`-tagged suite against a Dockerized Jira Data Center (`moveworkforward/atlas-run-standalone:jira-11`). **Never wired up to PRs**: the cold-boot cost (~25 min) is too expensive for per-PR feedback; PR-level Server coverage comes from the Server-tagged unit suites in `ci.yml`. Use `gh workflow run "Integration Tests" --ref <branch> -f track=server` to trigger on demand when working on a Server-track change.
 - `release.yml` — runs on `v*` tags, downloads the `Release` artifact produced by `ci.yml` for the tagged commit, publishes to PSGallery, and creates a GitHub Release.
 - Workflow source: [`.github/workflows/`](.github/workflows/); shared setup: [`.github/actions/setup-powershell/`](.github/actions/setup-powershell/) (caller must run `actions/checkout` first).
+- CI triage runbook: [`.github/ai-context/ci-triage-runbook.md`](.github/ai-context/ci-triage-runbook.md).
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary
- add a dedicated CI triage runbook for lint and Windows PowerShell 5.1 failures
- document macOS/Linux PS5 limitation and require PS5 CI lane before merge
- extend review/checklist guidance in powershell-rules, AGENTS, and PR template

## Context
These changes capture lessons learned from recent lint + PS5 CI failures and make the expected triage/validation path explicit.