### PR TITLE
Type-system PR3: split Add-JiraIssueLink request/response models

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,6 +182,16 @@ Release/                 # Build output (gitignored)
 
 When you add a new `*TransformationAttribute`, decide which rule applies before copying an existing implementation.
 
+**Transformer design guardrails (issue-611 lessons learned)**
+
+- Do **not** match generic `System.Management.Automation.PSCustomObject` by `TypeNames` in `LegacyTypeNames`; use explicit property-shape detection in `ShouldMapLegacyObject` instead.
+- Keep a strict split of responsibilities:
+  - **Transformers** handle coercion and shape validation.
+  - **Cmdlet bodies** handle business invariants.
+- For paired nested payload fields (for example `inwardIssue`/`outwardIssue`), validate both sides symmetrically and produce actionable transformation error messages.
+- When tightening parameter types, re-check `-PassThru` flows: prefer shared resolver helpers over ad-hoc branch logic and avoid passing raw REST payloads into newly typed parameters.
+- Keep unit-test mocks self-contained; mocks should not call other public cmdlets unless the test explicitly validates that integration path.
+
 ### Coding Standards
 
 #### PowerShell Style

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## 3.0 - 2026-05-10
+
 This release focuses on Cloud and Data Center compatibility, safer typing, and better automation ergonomics.
 
 ### Highlights for users

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ For the migration playbook and concrete before/after script examples, see [`abou
 
 - `Get-JiraIssueLinkType -LinkType` now binds to `[AtlassianPS.JiraPS.IssueLinkType]` via `IssueLinkTypeTransformation`, and `Remove-JiraIssueLink` now uses typed parameter sets (`-IssueLink [AtlassianPS.JiraPS.IssueLink[]]` and `-Issue [AtlassianPS.JiraPS.Issue[]]`) instead of custom `ValidateScript` type checks.
   Invalid values now fail with argument-transformation errors at bind time, and `Get-JiraIssueLinkType` still supports numeric ID lookups and name-based matches.
+- `Add-JiraIssueLink -IssueLink` now binds to `[AtlassianPS.JiraPS.IssueLink[]]` via `IssueLinkTransformation`.
+  The transformation accepts existing issue-link objects and compatible loose payload shapes, while business validation for required link fields remains in the cmdlet.
 - `Get-JiraUser -InputObject` now binds as `[AtlassianPS.JiraPS.User[]]` via `UserTransformation`, and `Set-JiraUser -PassThru` now reuses a typed user object before refreshing from Jira.
   This removes stale `<Object>` help metadata for user input and keeps pass-through behavior compatible with the stricter input type.
 - Removed the custom `ConvertFrom-Json` override because PowerShell 5.1 native JSON handling is sufficient for JiraPS payload sizes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,9 @@ For the migration playbook and concrete before/after script examples, see [`abou
 
 - `Get-JiraIssueLinkType -LinkType` now binds to `[AtlassianPS.JiraPS.IssueLinkType]` via `IssueLinkTypeTransformation`, and `Remove-JiraIssueLink` now uses typed parameter sets (`-IssueLink [AtlassianPS.JiraPS.IssueLink[]]` and `-Issue [AtlassianPS.JiraPS.Issue[]]`) instead of custom `ValidateScript` type checks.
   Invalid values now fail with argument-transformation errors at bind time, and `Get-JiraIssueLinkType` still supports numeric ID lookups and name-based matches.
-- `Add-JiraIssueLink -IssueLink` now binds to `[AtlassianPS.JiraPS.IssueLink[]]` via `IssueLinkTransformation`.
-  The transformation accepts existing issue-link objects and compatible loose payload shapes, while business validation for required link fields remains in the cmdlet.
+- **BREAKING**: `Add-JiraIssueLink -IssueLink` now binds to `[AtlassianPS.JiraPS.IssueLinkCreateRequest[]]` via `IssueLinkCreateRequestTransformation` instead of reusing the response/domain `IssueLink` model.
+  Create payloads now use dedicated request DTOs (`IssueLinkCreateRequest`, `IssueLinkTypeRef`, `LinkedIssueRef`), while `IssueLink` remains the response type for read operations.
+  The transformation accepts compatible loose payload objects and rejects malformed nested `type`/issue refs with clear argument-transformation errors before cmdlet execution.
 - `Get-JiraUser -InputObject` now binds as `[AtlassianPS.JiraPS.User[]]` via `UserTransformation`, and `Set-JiraUser -PassThru` now reuses a typed user object before refreshing from Jira.
   This removes stale `<Object>` help metadata for user input and keeps pass-through behavior compatible with the stricter input type.
 - Removed the custom `ConvertFrom-Json` override because PowerShell 5.1 native JSON handling is sufficient for JiraPS payload sizes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ For the migration playbook and concrete before/after script examples, see [`abou
 
 ### Changed
 
+- `Get-JiraIssueLinkType -LinkType` now binds to `[AtlassianPS.JiraPS.IssueLinkType]` via `IssueLinkTypeTransformation`, and `Remove-JiraIssueLink` now uses typed parameter sets (`-IssueLink [AtlassianPS.JiraPS.IssueLink[]]` and `-Issue [AtlassianPS.JiraPS.Issue[]]`) instead of custom `ValidateScript` type checks.
+  Invalid values now fail with argument-transformation errors at bind time, and `Get-JiraIssueLinkType` still supports numeric ID lookups and name-based matches.
+- `Get-JiraUser -InputObject` now binds as `[AtlassianPS.JiraPS.User[]]` via `UserTransformation`, and `Set-JiraUser -PassThru` now reuses a typed user object before refreshing from Jira.
+  This removes stale `<Object>` help metadata for user input and keeps pass-through behavior compatible with the stricter input type.
 - Removed the custom `ConvertFrom-Json` override because PowerShell 5.1 native JSON handling is sufficient for JiraPS payload sizes.
 - Removed the legacy PowerShell 3-era `Accept` header workaround from module initialization.
 - Promoted the remaining JiraPS leaf return types to real .NET classes under the `AtlassianPS.JiraPS.*` namespace.

--- a/JiraPS/Public/Add-JiraIssueLink.ps1
+++ b/JiraPS/Public/Add-JiraIssueLink.ps1
@@ -10,7 +10,9 @@
         $Issue,
 
         [Parameter( Mandatory )]
-        [Object[]]
+        [ValidateNotNull()]
+        [AtlassianPS.JiraPS.IssueLinkTransformation()]
+        [AtlassianPS.JiraPS.IssueLink[]]
         $IssueLink,
 
         [String]
@@ -35,14 +37,12 @@
         # Find the proper object for the Issue
         $issueObj = Resolve-JiraIssueObject -InputObject $Issue -Credential $Credential -ErrorAction Stop
 
-        foreach ($_issueLink in $IssueLink) {
-            $typedIssueLink = ConvertTo-JiraIssueLink -InputObject $_issueLink
-
+        foreach ($typedIssueLink in $IssueLink) {
             if (-not $typedIssueLink.Type -or (-not $typedIssueLink.InwardIssue -and -not $typedIssueLink.OutwardIssue)) {
                 $exception = ([System.ArgumentException]"Invalid Parameter")
                 $errorId = 'ParameterProperties.Incomplete'
                 $errorCategory = 'InvalidArgument'
-                $errorTarget = $_issueLink
+                $errorTarget = $typedIssueLink
                 $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
                 $errorItem.ErrorDetails = "The IssueLink provided does not contain the information needed."
                 $PSCmdlet.ThrowTerminatingError($errorItem)

--- a/JiraPS/Public/Add-JiraIssueLink.ps1
+++ b/JiraPS/Public/Add-JiraIssueLink.ps1
@@ -11,8 +11,8 @@
 
         [Parameter( Mandatory )]
         [ValidateNotNull()]
-        [AtlassianPS.JiraPS.IssueLinkTransformation()]
-        [AtlassianPS.JiraPS.IssueLink[]]
+        [AtlassianPS.JiraPS.IssueLinkCreateRequestTransformation()]
+        [AtlassianPS.JiraPS.IssueLinkCreateRequest[]]
         $IssueLink,
 
         [String]
@@ -48,22 +48,70 @@
                     -Cmdlet $PSCmdlet
             }
 
+            if (-not $typedIssueLink.Type.Name -and -not $typedIssueLink.Type.Id) {
+                ThrowError `
+                    -ExceptionType "System.ArgumentException" `
+                    -Message "The IssueLink type must include either a Name or an Id." `
+                    -ErrorId 'ParameterProperties.Incomplete' `
+                    -Category InvalidArgument `
+                    -TargetObject $typedIssueLink `
+                    -Cmdlet $PSCmdlet
+            }
+
+            if ($typedIssueLink.InwardIssue -and (-not $typedIssueLink.InwardIssue.Key -and -not $typedIssueLink.InwardIssue.Id)) {
+                ThrowError `
+                    -ExceptionType "System.ArgumentException" `
+                    -Message "The inwardIssue reference must include either a Key or an Id." `
+                    -ErrorId 'ParameterProperties.Incomplete' `
+                    -Category InvalidArgument `
+                    -TargetObject $typedIssueLink `
+                    -Cmdlet $PSCmdlet
+            }
+
+            if ($typedIssueLink.OutwardIssue -and (-not $typedIssueLink.OutwardIssue.Key -and -not $typedIssueLink.OutwardIssue.Id)) {
+                ThrowError `
+                    -ExceptionType "System.ArgumentException" `
+                    -Message "The outwardIssue reference must include either a Key or an Id." `
+                    -ErrorId 'ParameterProperties.Incomplete' `
+                    -Category InvalidArgument `
+                    -TargetObject $typedIssueLink `
+                    -Cmdlet $PSCmdlet
+            }
+
             if ($typedIssueLink.InwardIssue) {
-                $inwardIssue = @{ key = $typedIssueLink.InwardIssue.Key }
+                if ($typedIssueLink.InwardIssue.Key) {
+                    $inwardIssue = @{ key = $typedIssueLink.InwardIssue.Key }
+                }
+                else {
+                    $inwardIssue = @{ id = $typedIssueLink.InwardIssue.Id }
+                }
             }
             else {
                 $inwardIssue = @{ key = $issueObj.key }
             }
 
             if ($typedIssueLink.OutwardIssue) {
-                $outwardIssue = @{ key = $typedIssueLink.OutwardIssue.Key }
+                if ($typedIssueLink.OutwardIssue.Key) {
+                    $outwardIssue = @{ key = $typedIssueLink.OutwardIssue.Key }
+                }
+                else {
+                    $outwardIssue = @{ id = $typedIssueLink.OutwardIssue.Id }
+                }
             }
             else {
                 $outwardIssue = @{ key = $issueObj.key }
             }
 
+            $typePayload = @{}
+            if ($typedIssueLink.Type.Name) {
+                $typePayload.name = $typedIssueLink.Type.Name
+            }
+            if ($typedIssueLink.Type.Id) {
+                $typePayload.id = $typedIssueLink.Type.Id
+            }
+
             $body = @{
-                type         = @{ name = $typedIssueLink.Type.Name }
+                type         = $typePayload
                 inwardIssue  = $inwardIssue
                 outwardIssue = $outwardIssue
             }

--- a/JiraPS/Public/Add-JiraIssueLink.ps1
+++ b/JiraPS/Public/Add-JiraIssueLink.ps1
@@ -10,31 +10,6 @@
         $Issue,
 
         [Parameter( Mandatory )]
-        [ValidateScript({
-                $propertyNames = $_.PSObject.Properties.Name
-                if (
-                    ($propertyNames -contains "type") -and
-                    (
-                        ($propertyNames -contains "outwardIssue") -or
-                        ($propertyNames -contains "inwardIssue")
-                    )
-                ) {
-                    return $true
-                }
-                else {
-                    $exception = ([System.ArgumentException]"Invalid Parameter")
-                    $errorId = 'ParameterProperties.Incomplete'
-                    $errorCategory = 'InvalidArgument'
-                    $errorTarget = $_
-                    $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
-                    $errorItem.ErrorDetails = "The IssueLink provided does not contain the information needed."
-                    $PSCmdlet.ThrowTerminatingError($errorItem)
-                    <#
-                      #ToDo:CustomClass
-                      Now that we have custom classes, this polymorphic ValidateScript could be split into a parameter set with [AtlassianPS.JiraPS.<Type>] strong typing
-                    #>
-                }
-            })]
         [Object[]]
         $IssueLink,
 
@@ -61,22 +36,34 @@
         $issueObj = Resolve-JiraIssueObject -InputObject $Issue -Credential $Credential -ErrorAction Stop
 
         foreach ($_issueLink in $IssueLink) {
-            if ($_issueLink.inwardIssue) {
-                $inwardIssue = @{ key = $_issueLink.inwardIssue.key }
+            $typedIssueLink = ConvertTo-JiraIssueLink -InputObject $_issueLink
+
+            if (-not $typedIssueLink.Type -or (-not $typedIssueLink.InwardIssue -and -not $typedIssueLink.OutwardIssue)) {
+                $exception = ([System.ArgumentException]"Invalid Parameter")
+                $errorId = 'ParameterProperties.Incomplete'
+                $errorCategory = 'InvalidArgument'
+                $errorTarget = $_issueLink
+                $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
+                $errorItem.ErrorDetails = "The IssueLink provided does not contain the information needed."
+                $PSCmdlet.ThrowTerminatingError($errorItem)
+            }
+
+            if ($typedIssueLink.InwardIssue) {
+                $inwardIssue = @{ key = $typedIssueLink.InwardIssue.Key }
             }
             else {
                 $inwardIssue = @{ key = $issueObj.key }
             }
 
-            if ($_issueLink.outwardIssue) {
-                $outwardIssue = @{ key = $_issueLink.outwardIssue.key }
+            if ($typedIssueLink.OutwardIssue) {
+                $outwardIssue = @{ key = $typedIssueLink.OutwardIssue.Key }
             }
             else {
                 $outwardIssue = @{ key = $issueObj.key }
             }
 
             $body = @{
-                type         = @{ name = $_issueLink.type.name }
+                type         = @{ name = $typedIssueLink.Type.Name }
                 inwardIssue  = $inwardIssue
                 outwardIssue = $outwardIssue
             }

--- a/JiraPS/Public/Add-JiraIssueLink.ps1
+++ b/JiraPS/Public/Add-JiraIssueLink.ps1
@@ -39,13 +39,13 @@
 
         foreach ($typedIssueLink in $IssueLink) {
             if (-not $typedIssueLink.Type -or (-not $typedIssueLink.InwardIssue -and -not $typedIssueLink.OutwardIssue)) {
-                $exception = ([System.ArgumentException]"Invalid Parameter")
-                $errorId = 'ParameterProperties.Incomplete'
-                $errorCategory = 'InvalidArgument'
-                $errorTarget = $typedIssueLink
-                $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
-                $errorItem.ErrorDetails = "The IssueLink provided does not contain the information needed."
-                $PSCmdlet.ThrowTerminatingError($errorItem)
+                ThrowError `
+                    -ExceptionType "System.ArgumentException" `
+                    -Message "The IssueLink provided does not contain the information needed." `
+                    -ErrorId 'ParameterProperties.Incomplete' `
+                    -Category InvalidArgument `
+                    -TargetObject $typedIssueLink `
+                    -Cmdlet $PSCmdlet
             }
 
             if ($typedIssueLink.InwardIssue) {

--- a/JiraPS/Public/Get-JiraIssueLinkType.ps1
+++ b/JiraPS/Public/Get-JiraIssueLinkType.ps1
@@ -4,27 +4,8 @@
     param(
         [Parameter( Position = 0, Mandatory, ParameterSetName = '_Search' )]
         [ValidateNotNullOrEmpty()]
-        [ValidateScript(
-            {
-                if (("JiraPS.IssueLinkType" -notin $_.PSObject.TypeNames) -and (($_ -isnot [String])) -and (($_ -isnot [Int]))) {
-                    $exception = ([System.ArgumentException]"Invalid Type for Parameter") #fix code highlighting]
-                    $errorId = 'ParameterType.NotJiraIssueLinkType'
-                    $errorCategory = 'InvalidArgument'
-                    $errorTarget = $_
-                    $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
-                    $errorItem.ErrorDetails = "Wrong object type provided for IssueLinkType. Expected [JiraPS.IssueLinkType], [String] or [Int], but was $($_.GetType().Name)"
-                    $PSCmdlet.ThrowTerminatingError($errorItem)
-                    <#
-                      #ToDo:CustomClass
-                      Now that we have custom classes, this polymorphic ValidateScript could be split into a parameter set with [AtlassianPS.JiraPS.<Type>] strong typing
-                    #>
-                }
-                else {
-                    return $true
-                }
-            }
-        )]
-        [Object]
+        [AtlassianPS.JiraPS.IssueLinkTypeTransformation()]
+        [AtlassianPS.JiraPS.IssueLinkType]
         $LinkType,
 
         [Parameter()]
@@ -43,10 +24,9 @@
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] ParameterSetName: $($PsCmdlet.ParameterSetName)"
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] PSBoundParameters: $($PSBoundParameters | Out-String)"
 
-        if ($LinkType -is [Int]) {
-            # If the link type provided is an int, we can assume it's an ID number.
+        if ($LinkType -and $LinkType.Id) {
             $parameter = @{
-                URI        = $resourceURi -f "/$LinkType"
+                URI        = $resourceURi -f "/$($LinkType.Id)"
                 Method     = "GET"
                 Credential = $Credential
             }
@@ -56,7 +36,6 @@
             Write-Output (ConvertTo-JiraIssueLinkType -InputObject $result)
         }
         else {
-            # If it's a String, it's probably a name, though, and there isn't an API call to look up a link type by name.
             $parameter = @{
                 URI        = $resourceURi -f ""
                 Method     = "GET"
@@ -67,7 +46,7 @@
             $allLinkTypes = ConvertTo-JiraIssueLinkType -InputObject $result.issueLinkTypes
 
             if ($LinkType) {
-                Write-Output ($allLinkTypes | Where-Object { $_.Name -like $LinkType })
+                Write-Output ($allLinkTypes | Where-Object { $_.Name -like $LinkType.Name })
             }
             else {
                 Write-Output $allLinkTypes

--- a/JiraPS/Public/Get-JiraUser.ps1
+++ b/JiraPS/Public/Get-JiraUser.ps1
@@ -14,7 +14,10 @@
         $AccountId,
 
         [Parameter( Position = 0, Mandatory, ParameterSetName = 'ByInputObject' )]
-        [Object[]] $InputObject,
+        [ValidateNotNull()]
+        [AtlassianPS.JiraPS.UserTransformation()]
+        [AtlassianPS.JiraPS.User[]]
+        $InputObject,
 
         [Parameter( ParameterSetName = 'ByInputObject' )]
         [Parameter( ParameterSetName = 'ByUserName' )]
@@ -77,11 +80,12 @@
         switch ($PsCmdlet.ParameterSetName) {
             'ByInputObject' {
                 if ($isCloud) {
-                    $lookupValue = $InputObject.AccountId
-                    if (-not $lookupValue) { $lookupValue = $InputObject.Name }
+                    $lookupValue = foreach ($inputUser in $InputObject) {
+                        if ($inputUser.AccountId) { $inputUser.AccountId } else { $inputUser.Name }
+                    }
                 }
                 else {
-                    $lookupValue = $InputObject.Name
+                    $lookupValue = foreach ($inputUser in $InputObject) { $inputUser.Name }
                 }
                 $ParameterSetName = 'ByLookupValue'
                 $Exact = $true

--- a/JiraPS/Public/Remove-JiraIssueLink.ps1
+++ b/JiraPS/Public/Remove-JiraIssueLink.ps1
@@ -1,33 +1,18 @@
 ﻿function Remove-JiraIssueLink {
     # .ExternalHelp ..\JiraPS-help.xml
-    [CmdletBinding( SupportsShouldProcess, ConfirmImpact = 'Medium' )]
+    [CmdletBinding( SupportsShouldProcess, ConfirmImpact = 'Medium', DefaultParameterSetName = 'ByIssueLink' )]
     param(
-        [Parameter( Mandatory, ValueFromPipeline )]
-        [ValidateNotNullOrEmpty()]
-        [ValidateScript(
-            {
-                $_input = $_
-                switch ($true) {
-                    { $_input -is [AtlassianPS.JiraPS.Issue] } { return $true }
-                    { $_input -is [AtlassianPS.JiraPS.IssueLink] } { return $true }
-                    default {
-                        $exception = ([System.ArgumentException]"Invalid Type for Parameter") #fix code highlighting]
-                        $errorId = 'ParameterType.NotJiraIssue'
-                        $errorCategory = 'InvalidArgument'
-                        $errorTarget = $_input
-                        $errorItem = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $errorTarget
-                        $errorItem.ErrorDetails = "Wrong object type provided for Issue. Expected [AtlassianPS.JiraPS.Issue] or [AtlassianPS.JiraPS.IssueLink], but was $($_input.GetType().Name)"
-                        $PSCmdlet.ThrowTerminatingError($errorItem)
-                        <#
-                          #ToDo:CustomClass
-                          Now that we have custom classes, this polymorphic ValidateScript could be split into a parameter set with [AtlassianPS.JiraPS.<Type>] strong typing
-                        #>
-                    }
-                }
-            }
-        )]
-        [Object[]]
+        [Parameter( Mandatory, ValueFromPipeline, ParameterSetName = 'ByIssueLink' )]
+        [ValidateNotNull()]
+        [AtlassianPS.JiraPS.IssueLinkTransformation()]
+        [AtlassianPS.JiraPS.IssueLink[]]
         $IssueLink,
+
+        [Parameter( Mandatory, ValueFromPipeline, ParameterSetName = 'ByIssue' )]
+        [ValidateNotNull()]
+        [AtlassianPS.JiraPS.IssueTransformation()]
+        [AtlassianPS.JiraPS.Issue[]]
+        $Issue,
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -45,17 +30,27 @@
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] ParameterSetName: $($PsCmdlet.ParameterSetName)"
         Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] PSBoundParameters: $($PSBoundParameters | Out-String)"
 
-        # As we are not able to use proper type casting in the parameters, this is a workaround
-        # to extract the data from a AtlassianPS.JiraPS.Issue object
-        <#
-          #ToDo:CustomClass
-          Now that we have custom classes, this Resolve-* shim could be replaced by a parameter set that takes [AtlassianPS.JiraPS.<Type>] directly
-        #>
-        if ($IssueLink.issueLinks) {
-            $IssueLink = $IssueLink.issueLinks
+        $linksToRemove = switch ($PSCmdlet.ParameterSetName) {
+            'ByIssue' {
+                foreach ($currentIssue in $Issue) {
+                    $resolvedIssue = $currentIssue
+                    if (-not $resolvedIssue.IssueLinks) {
+                        $resolvedIssue = Resolve-JiraIssueObject -InputObject $currentIssue -Credential $Credential -ErrorAction Stop
+                    }
+
+                    foreach ($link in @($resolvedIssue.IssueLinks)) {
+                        if ($link) {
+                            $link
+                        }
+                    }
+                }
+            }
+            default {
+                $IssueLink
+            }
         }
 
-        foreach ($link in $IssueLink) {
+        foreach ($link in $linksToRemove) {
             Write-Verbose "[$($MyInvocation.MyCommand.Name)] Processing [$link]"
             Write-Debug "[$($MyInvocation.MyCommand.Name)] Processing `$link [$link]"
 

--- a/JiraPS/Public/Set-JiraUser.ps1
+++ b/JiraPS/Public/Set-JiraUser.ps1
@@ -115,8 +115,15 @@
             $result = Invoke-JiraMethod @parameter
 
             if ($PassThru) {
-                $typedUser = ConvertTo-JiraUser -InputObject $result
-                Write-Output (Get-JiraUser -InputObject $typedUser)
+                if ($isCloud -and $userObj.AccountId) {
+                    Write-Output (Get-JiraUser -AccountId $userObj.AccountId -Exact -Credential $Credential)
+                }
+                elseif ($userObj.Name) {
+                    Write-Output (Get-JiraUser -UserName $userObj.Name -Exact -Credential $Credential)
+                }
+                else {
+                    Write-Output (ConvertTo-JiraUser -InputObject $result)
+                }
             }
         }
     }

--- a/JiraPS/Public/Set-JiraUser.ps1
+++ b/JiraPS/Public/Set-JiraUser.ps1
@@ -115,11 +115,12 @@
             $result = Invoke-JiraMethod @parameter
 
             if ($PassThru) {
-                if ($isCloud -and $userObj.AccountId) {
-                    Write-Output (Get-JiraUser -AccountId $userObj.AccountId -Exact -Credential $Credential)
-                }
-                elseif ($userObj.Name) {
-                    Write-Output (Get-JiraUser -UserName $userObj.Name -Exact -Credential $Credential)
+                if ($userObj.AccountId -or $userObj.Name) {
+                    $refreshUser = [AtlassianPS.JiraPS.User]@{
+                        AccountId = $userObj.AccountId
+                        Name      = $userObj.Name
+                    }
+                    Write-Output (Resolve-JiraUser -InputObject $refreshUser -Exact -Credential $Credential -ErrorAction Stop)
                 }
                 else {
                     Write-Output (ConvertTo-JiraUser -InputObject $result)

--- a/JiraPS/Public/Set-JiraUser.ps1
+++ b/JiraPS/Public/Set-JiraUser.ps1
@@ -115,7 +115,8 @@
             $result = Invoke-JiraMethod @parameter
 
             if ($PassThru) {
-                Write-Output (Get-JiraUser -InputObject $result)
+                $typedUser = ConvertTo-JiraUser -InputObject $result
+                Write-Output (Get-JiraUser -InputObject $typedUser)
             }
         }
     }

--- a/JiraPS/Types/AtlassianPS.JiraPS.Common.cs
+++ b/JiraPS/Types/AtlassianPS.JiraPS.Common.cs
@@ -257,8 +257,23 @@ namespace AtlassianPS.JiraPS
         protected virtual string[] LegacyTypeNames { get { return null; } }
 
         // Map properties from a legacy PSCustomObject to a new domain object.
-        // Only called when the PSObject's TypeNames contain one of LegacyTypeNames.
+        // Called when ShouldMapLegacyObject(...) returns true.
         protected virtual object MapLegacyObject(System.Management.Automation.PSObject pso) { return null; }
+
+        // Override for transformers that support property-shape detection in
+        // addition to (or instead of) PSTypeName matching.
+        protected virtual bool ShouldMapLegacyObject(System.Management.Automation.PSObject pso)
+        {
+            var legacyNames = LegacyTypeNames;
+            if (legacyNames == null || pso == null || pso.TypeNames == null) { return false; }
+
+            foreach (var tag in legacyNames)
+            {
+                if (pso.TypeNames.Contains(tag)) { return true; }
+            }
+
+            return false;
+        }
 
         public sealed override object Transform(System.Management.Automation.EngineIntrinsics engineIntrinsics, object inputData)
         {
@@ -293,16 +308,9 @@ namespace AtlassianPS.JiraPS
                 return FromString(text);
             }
 
-            var legacyNames = LegacyTypeNames;
-            if (legacyNames != null && pso != null && pso.TypeNames != null)
+            if (ShouldMapLegacyObject(pso))
             {
-                foreach (var tag in legacyNames)
-                {
-                    if (pso.TypeNames.Contains(tag))
-                    {
-                        return MapLegacyObject(pso);
-                    }
-                }
+                return MapLegacyObject(pso);
             }
 
             if (JiraTransform.IsJiraDomainObject(inputData)) { return inputData; }

--- a/JiraPS/Types/AtlassianPS.JiraPS.LeafTypes.cs
+++ b/JiraPS/Types/AtlassianPS.JiraPS.LeafTypes.cs
@@ -223,6 +223,41 @@ namespace AtlassianPS.JiraPS
         }
     }
 
+    public class IssueLinkTypeRef
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+
+        public IssueLinkTypeRef() { }
+
+        public override string ToString()
+        {
+            return Name ?? Id ?? string.Empty;
+        }
+    }
+
+    public class LinkedIssueRef
+    {
+        public string Id { get; set; }
+        public string Key { get; set; }
+
+        public LinkedIssueRef() { }
+
+        public override string ToString()
+        {
+            return Key ?? Id ?? string.Empty;
+        }
+    }
+
+    public class IssueLinkCreateRequest
+    {
+        public IssueLinkTypeRef Type { get; set; }
+        public LinkedIssueRef InwardIssue { get; set; }
+        public LinkedIssueRef OutwardIssue { get; set; }
+
+        public IssueLinkCreateRequest() { }
+    }
+
     public class IssueLink
     {
         public long? Id { get; set; }

--- a/JiraPS/Types/AtlassianPS.JiraPS.Transformations.cs
+++ b/JiraPS/Types/AtlassianPS.JiraPS.Transformations.cs
@@ -94,8 +94,7 @@ namespace AtlassianPS.JiraPS
 
             return HasProperty(pso, "type")
                 || HasProperty(pso, "inwardIssue")
-                || HasProperty(pso, "outwardIssue")
-                || HasProperty(pso, "id");
+                || HasProperty(pso, "outwardIssue");
         }
 
         protected override object MapLegacyObject(System.Management.Automation.PSObject pso)

--- a/JiraPS/Types/AtlassianPS.JiraPS.Transformations.cs
+++ b/JiraPS/Types/AtlassianPS.JiraPS.Transformations.cs
@@ -85,8 +85,18 @@ namespace AtlassianPS.JiraPS
         protected override Type TargetType { get { return typeof(IssueLink); } }
         protected override object FromString(string value) { return new IssueLink(value); }
 
-        // Accept loose PSCustomObject payloads used by Add-JiraIssueLink examples.
-        protected override string[] LegacyTypeNames { get { return new[] { "AtlassianPS.JiraPS.IssueLink", "JiraPS.IssueLink", "System.Management.Automation.PSCustomObject" }; } }
+        protected override string[] LegacyTypeNames { get { return new[] { "AtlassianPS.JiraPS.IssueLink", "JiraPS.IssueLink" }; } }
+
+        protected override bool ShouldMapLegacyObject(System.Management.Automation.PSObject pso)
+        {
+            if (base.ShouldMapLegacyObject(pso)) { return true; }
+            if (pso == null || pso.Properties == null) { return false; }
+
+            return HasProperty(pso, "type")
+                || HasProperty(pso, "inwardIssue")
+                || HasProperty(pso, "outwardIssue")
+                || HasProperty(pso, "id");
+        }
 
         protected override object MapLegacyObject(System.Management.Automation.PSObject pso)
         {
@@ -109,17 +119,17 @@ namespace AtlassianPS.JiraPS
                         break;
                     case "Type":
                     case "type":
-                        issueLink.Type = MapIssueLinkType(prop.Value);
+                        issueLink.Type = MapIssueLinkType(prop.Value, prop.Name);
                         hasKnownShape = true;
                         break;
                     case "InwardIssue":
                     case "inwardIssue":
-                        issueLink.InwardIssue = MapIssue(prop.Value);
+                        issueLink.InwardIssue = MapIssue(prop.Value, prop.Name);
                         hasKnownShape = true;
                         break;
                     case "OutwardIssue":
                     case "outwardIssue":
-                        issueLink.OutwardIssue = MapIssue(prop.Value);
+                        issueLink.OutwardIssue = MapIssue(prop.Value, prop.Name);
                         hasKnownShape = true;
                         break;
                 }
@@ -134,9 +144,22 @@ namespace AtlassianPS.JiraPS
             return issueLink;
         }
 
-        private static IssueLinkType MapIssueLinkType(object value)
+        private static bool HasProperty(System.Management.Automation.PSObject pso, string name)
         {
-            if (value == null) { return null; }
+            foreach (var prop in pso.Properties)
+            {
+                if (string.Equals(prop.Name, name, StringComparison.OrdinalIgnoreCase)) { return true; }
+            }
+            return false;
+        }
+
+        private static IssueLinkType MapIssueLinkType(object value, string propertyName)
+        {
+            if (value == null)
+            {
+                throw new System.Management.Automation.ArgumentTransformationMetadataException(
+                    "IssueLink property '" + propertyName + "' must not be null.");
+            }
 
             var typed = value as IssueLinkType;
             if (typed != null) { return typed; }
@@ -146,11 +169,18 @@ namespace AtlassianPS.JiraPS
             {
                 return new IssueLinkType(text);
             }
+            if (text != null)
+            {
+                throw new System.Management.Automation.ArgumentTransformationMetadataException(
+                    "IssueLink property '" + propertyName + "' cannot be empty or whitespace.");
+            }
 
             var pso = value as System.Management.Automation.PSObject;
             if (pso != null)
             {
                 var mapped = new IssueLinkType();
+                var hasName = false;
+                var hasId = false;
                 foreach (var prop in pso.Properties)
                 {
                     switch (prop.Name)
@@ -159,10 +189,12 @@ namespace AtlassianPS.JiraPS
                         case "Id":
                         case "id":
                             mapped.Id = prop.Value != null ? prop.Value.ToString() : null;
+                            hasId = !string.IsNullOrWhiteSpace(mapped.Id);
                             break;
                         case "Name":
                         case "name":
                             mapped.Name = prop.Value as string;
+                            hasName = !string.IsNullOrWhiteSpace(mapped.Name);
                             break;
                         case "InwardText":
                         case "inwardText":
@@ -174,15 +206,26 @@ namespace AtlassianPS.JiraPS
                             break;
                     }
                 }
+
+                if (!hasName && !hasId)
+                {
+                    throw new System.Management.Automation.ArgumentTransformationMetadataException(
+                        "IssueLink property '" + propertyName + "' must include either a non-empty 'name' or 'id'.");
+                }
                 return mapped;
             }
 
-            return null;
+            throw new System.Management.Automation.ArgumentTransformationMetadataException(
+                "IssueLink property '" + propertyName + "' must be a string, AtlassianPS.JiraPS.IssueLinkType, or object with 'name'/'id'.");
         }
 
-        private static Issue MapIssue(object value)
+        private static Issue MapIssue(object value, string propertyName)
         {
-            if (value == null) { return null; }
+            if (value == null)
+            {
+                throw new System.Management.Automation.ArgumentTransformationMetadataException(
+                    "IssueLink property '" + propertyName + "' must not be null.");
+            }
 
             var typed = value as Issue;
             if (typed != null) { return typed; }
@@ -192,11 +235,18 @@ namespace AtlassianPS.JiraPS
             {
                 return new Issue(text);
             }
+            if (text != null)
+            {
+                throw new System.Management.Automation.ArgumentTransformationMetadataException(
+                    "IssueLink property '" + propertyName + "' cannot be empty or whitespace.");
+            }
 
             var pso = value as System.Management.Automation.PSObject;
             if (pso != null)
             {
                 var mapped = new Issue();
+                var hasKey = false;
+                var hasId = false;
                 foreach (var prop in pso.Properties)
                 {
                     switch (prop.Name)
@@ -205,17 +255,26 @@ namespace AtlassianPS.JiraPS
                         case "Id":
                         case "id":
                             mapped.Id = prop.Value != null ? prop.Value.ToString() : null;
+                            hasId = !string.IsNullOrWhiteSpace(mapped.Id);
                             break;
                         case "Key":
                         case "key":
                             mapped.Key = prop.Value as string;
+                            hasKey = !string.IsNullOrWhiteSpace(mapped.Key);
                             break;
                     }
+                }
+
+                if (!hasKey && !hasId)
+                {
+                    throw new System.Management.Automation.ArgumentTransformationMetadataException(
+                        "IssueLink property '" + propertyName + "' must include either a non-empty 'key' or 'id'.");
                 }
                 return mapped;
             }
 
-            return null;
+            throw new System.Management.Automation.ArgumentTransformationMetadataException(
+                "IssueLink property '" + propertyName + "' must be a string, AtlassianPS.JiraPS.Issue, or object with 'key'/'id'.");
         }
     }
 

--- a/JiraPS/Types/AtlassianPS.JiraPS.Transformations.cs
+++ b/JiraPS/Types/AtlassianPS.JiraPS.Transformations.cs
@@ -278,6 +278,282 @@ namespace AtlassianPS.JiraPS
     }
 
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+    public sealed class IssueLinkCreateRequestTransformationAttribute : JiraTransformationAttribute
+    {
+        protected override Type TargetType { get { return typeof(IssueLinkCreateRequest); } }
+
+        protected override object FromString(string value)
+        {
+            throw new System.Management.Automation.ArgumentTransformationMetadataException(
+                "Cannot convert a string to AtlassianPS.JiraPS.IssueLinkCreateRequest. Supply an AtlassianPS.JiraPS.IssueLinkCreateRequest object or an object with 'type', 'inwardIssue', or 'outwardIssue' properties.");
+        }
+
+        protected override string[] LegacyTypeNames { get { return new[] { "AtlassianPS.JiraPS.IssueLinkCreateRequest" }; } }
+
+        protected override bool ShouldMapLegacyObject(System.Management.Automation.PSObject pso)
+        {
+            if (base.ShouldMapLegacyObject(pso)) { return true; }
+            if (pso == null || pso.Properties == null) { return false; }
+
+            return HasProperty(pso, "type")
+                || HasProperty(pso, "inwardIssue")
+                || HasProperty(pso, "outwardIssue");
+        }
+
+        protected override object MapLegacyObject(System.Management.Automation.PSObject pso)
+        {
+            var request = new IssueLinkCreateRequest();
+            var hasKnownShape = false;
+
+            foreach (var prop in pso.Properties)
+            {
+                switch (prop.Name)
+                {
+                    case "Type":
+                    case "type":
+                        request.Type = MapIssueLinkTypeRef(prop.Value, prop.Name);
+                        hasKnownShape = true;
+                        break;
+                    case "InwardIssue":
+                    case "inwardIssue":
+                        request.InwardIssue = MapLinkedIssueRef(prop.Value, prop.Name);
+                        hasKnownShape = true;
+                        break;
+                    case "OutwardIssue":
+                    case "outwardIssue":
+                        request.OutwardIssue = MapLinkedIssueRef(prop.Value, prop.Name);
+                        hasKnownShape = true;
+                        break;
+                }
+            }
+
+            if (!hasKnownShape)
+            {
+                throw new System.Management.Automation.ArgumentTransformationMetadataException(
+                    "Cannot convert value to AtlassianPS.JiraPS.IssueLinkCreateRequest. Expected an issue-link create object shape with type, inwardIssue, or outwardIssue properties.");
+            }
+
+            return request;
+        }
+
+        private static bool HasProperty(System.Management.Automation.PSObject pso, string name)
+        {
+            foreach (var prop in pso.Properties)
+            {
+                if (string.Equals(prop.Name, name, StringComparison.OrdinalIgnoreCase)) { return true; }
+            }
+            return false;
+        }
+
+        private static IssueLinkTypeRef MapIssueLinkTypeRef(object value, string propertyName)
+        {
+            if (value == null)
+            {
+                throw new System.Management.Automation.ArgumentTransformationMetadataException(
+                    "IssueLinkCreateRequest property '" + propertyName + "' must not be null.");
+            }
+
+            var typed = value as IssueLinkTypeRef;
+            if (typed != null) { return typed; }
+
+            var legacyTyped = value as IssueLinkType;
+            if (legacyTyped != null)
+            {
+                return new IssueLinkTypeRef { Id = legacyTyped.Id, Name = legacyTyped.Name };
+            }
+
+            var text = value as string;
+            if (!string.IsNullOrWhiteSpace(text))
+            {
+                return new IssueLinkTypeRef { Name = text };
+            }
+            if (text != null)
+            {
+                throw new System.Management.Automation.ArgumentTransformationMetadataException(
+                    "IssueLinkCreateRequest property '" + propertyName + "' cannot be empty or whitespace.");
+            }
+
+            var pso = value as System.Management.Automation.PSObject;
+            if (pso != null)
+            {
+                var mapped = new IssueLinkTypeRef();
+                var hasName = false;
+                var hasId = false;
+                foreach (var prop in pso.Properties)
+                {
+                    switch (prop.Name)
+                    {
+                        case "ID":
+                        case "Id":
+                        case "id":
+                            mapped.Id = prop.Value != null ? prop.Value.ToString() : null;
+                            hasId = !string.IsNullOrWhiteSpace(mapped.Id);
+                            break;
+                        case "Name":
+                        case "name":
+                            mapped.Name = prop.Value as string;
+                            hasName = !string.IsNullOrWhiteSpace(mapped.Name);
+                            break;
+                    }
+                }
+
+                if (!hasName && !hasId)
+                {
+                    throw new System.Management.Automation.ArgumentTransformationMetadataException(
+                        "IssueLinkCreateRequest property '" + propertyName + "' must include either a non-empty 'name' or 'id'.");
+                }
+                return mapped;
+            }
+
+            var dict = value as System.Collections.IDictionary;
+            if (dict != null)
+            {
+                var mapped = new IssueLinkTypeRef();
+                var hasName = false;
+                var hasId = false;
+                foreach (System.Collections.DictionaryEntry entry in dict)
+                {
+                    var key = entry.Key != null ? entry.Key.ToString() : string.Empty;
+                    switch (key)
+                    {
+                        case "ID":
+                        case "Id":
+                        case "id":
+                            mapped.Id = entry.Value != null ? entry.Value.ToString() : null;
+                            hasId = !string.IsNullOrWhiteSpace(mapped.Id);
+                            break;
+                        case "Name":
+                        case "name":
+                            mapped.Name = entry.Value != null ? entry.Value.ToString() : null;
+                            hasName = !string.IsNullOrWhiteSpace(mapped.Name);
+                            break;
+                    }
+                }
+
+                if (!hasName && !hasId)
+                {
+                    throw new System.Management.Automation.ArgumentTransformationMetadataException(
+                        "IssueLinkCreateRequest property '" + propertyName + "' must include either a non-empty 'name' or 'id'.");
+                }
+                return mapped;
+            }
+
+            throw new System.Management.Automation.ArgumentTransformationMetadataException(
+                "IssueLinkCreateRequest property '" + propertyName + "' must be a string, AtlassianPS.JiraPS.IssueLinkTypeRef, or object with 'name'/'id'.");
+        }
+
+        private static LinkedIssueRef MapLinkedIssueRef(object value, string propertyName)
+        {
+            if (value == null)
+            {
+                throw new System.Management.Automation.ArgumentTransformationMetadataException(
+                    "IssueLinkCreateRequest property '" + propertyName + "' must not be null.");
+            }
+
+            var typed = value as LinkedIssueRef;
+            if (typed != null) { return typed; }
+
+            var legacyIssue = value as Issue;
+            if (legacyIssue != null)
+            {
+                return new LinkedIssueRef { Id = legacyIssue.Id, Key = legacyIssue.Key };
+            }
+
+            var legacyIssueRef = value as IssueLink;
+            if (legacyIssueRef != null)
+            {
+                if (legacyIssueRef.OutwardIssue != null)
+                {
+                    return new LinkedIssueRef { Id = legacyIssueRef.OutwardIssue.Id, Key = legacyIssueRef.OutwardIssue.Key };
+                }
+                if (legacyIssueRef.InwardIssue != null)
+                {
+                    return new LinkedIssueRef { Id = legacyIssueRef.InwardIssue.Id, Key = legacyIssueRef.InwardIssue.Key };
+                }
+            }
+
+            var text = value as string;
+            if (!string.IsNullOrWhiteSpace(text))
+            {
+                return new LinkedIssueRef { Key = text };
+            }
+            if (text != null)
+            {
+                throw new System.Management.Automation.ArgumentTransformationMetadataException(
+                    "IssueLinkCreateRequest property '" + propertyName + "' cannot be empty or whitespace.");
+            }
+
+            var pso = value as System.Management.Automation.PSObject;
+            if (pso != null)
+            {
+                var mapped = new LinkedIssueRef();
+                var hasKey = false;
+                var hasId = false;
+                foreach (var prop in pso.Properties)
+                {
+                    switch (prop.Name)
+                    {
+                        case "ID":
+                        case "Id":
+                        case "id":
+                            mapped.Id = prop.Value != null ? prop.Value.ToString() : null;
+                            hasId = !string.IsNullOrWhiteSpace(mapped.Id);
+                            break;
+                        case "Key":
+                        case "key":
+                            mapped.Key = prop.Value as string;
+                            hasKey = !string.IsNullOrWhiteSpace(mapped.Key);
+                            break;
+                    }
+                }
+
+                if (!hasKey && !hasId)
+                {
+                    throw new System.Management.Automation.ArgumentTransformationMetadataException(
+                        "IssueLinkCreateRequest property '" + propertyName + "' must include either a non-empty 'key' or 'id'.");
+                }
+                return mapped;
+            }
+
+            var dict = value as System.Collections.IDictionary;
+            if (dict != null)
+            {
+                var mapped = new LinkedIssueRef();
+                var hasKey = false;
+                var hasId = false;
+                foreach (System.Collections.DictionaryEntry entry in dict)
+                {
+                    var key = entry.Key != null ? entry.Key.ToString() : string.Empty;
+                    switch (key)
+                    {
+                        case "ID":
+                        case "Id":
+                        case "id":
+                            mapped.Id = entry.Value != null ? entry.Value.ToString() : null;
+                            hasId = !string.IsNullOrWhiteSpace(mapped.Id);
+                            break;
+                        case "Key":
+                        case "key":
+                            mapped.Key = entry.Value != null ? entry.Value.ToString() : null;
+                            hasKey = !string.IsNullOrWhiteSpace(mapped.Key);
+                            break;
+                    }
+                }
+
+                if (!hasKey && !hasId)
+                {
+                    throw new System.Management.Automation.ArgumentTransformationMetadataException(
+                        "IssueLinkCreateRequest property '" + propertyName + "' must include either a non-empty 'key' or 'id'.");
+                }
+                return mapped;
+            }
+
+            throw new System.Management.Automation.ArgumentTransformationMetadataException(
+                "IssueLinkCreateRequest property '" + propertyName + "' must be a string, AtlassianPS.JiraPS.LinkedIssueRef, or object with 'key'/'id'.");
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
     public sealed class AttachmentTransformationAttribute : JiraTransformationAttribute
     {
         protected override Type TargetType { get { return typeof(Attachment); } }

--- a/JiraPS/Types/AtlassianPS.JiraPS.Transformations.cs
+++ b/JiraPS/Types/AtlassianPS.JiraPS.Transformations.cs
@@ -53,6 +53,30 @@ namespace AtlassianPS.JiraPS
     {
         protected override Type TargetType { get { return typeof(IssueLinkType); } }
         protected override object FromString(string value) { return new IssueLinkType(value); }
+        protected override object FromNumericScalar(long value)
+        {
+            return new IssueLinkType { Id = value.ToString(System.Globalization.CultureInfo.InvariantCulture) };
+        }
+
+        protected override string[] LegacyTypeNames { get { return new[] { "AtlassianPS.JiraPS.IssueLinkType", "JiraPS.IssueLinkType" }; } }
+
+        protected override object MapLegacyObject(System.Management.Automation.PSObject pso)
+        {
+            var issueLinkType = new IssueLinkType();
+            foreach (var prop in pso.Properties)
+            {
+                switch (prop.Name)
+                {
+                    case "ID": case "Id": case "id": issueLinkType.Id = prop.Value as string ?? (prop.Value != null ? prop.Value.ToString() : null); break;
+                    case "Name": case "name": issueLinkType.Name = prop.Value as string; break;
+                    case "InwardText": case "inwardText": issueLinkType.InwardText = prop.Value as string; break;
+                    case "OutwardText": case "outwardText": issueLinkType.OutwardText = prop.Value as string; break;
+                    case "RestUrl": case "RestURL": case "self":
+                        issueLinkType.RestUrl = JiraTransform.ToUri(prop.Value); break;
+                }
+            }
+            return issueLinkType;
+        }
     }
 
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]

--- a/JiraPS/Types/AtlassianPS.JiraPS.Transformations.cs
+++ b/JiraPS/Types/AtlassianPS.JiraPS.Transformations.cs
@@ -84,6 +84,139 @@ namespace AtlassianPS.JiraPS
     {
         protected override Type TargetType { get { return typeof(IssueLink); } }
         protected override object FromString(string value) { return new IssueLink(value); }
+
+        // Accept loose PSCustomObject payloads used by Add-JiraIssueLink examples.
+        protected override string[] LegacyTypeNames { get { return new[] { "AtlassianPS.JiraPS.IssueLink", "JiraPS.IssueLink", "System.Management.Automation.PSCustomObject" }; } }
+
+        protected override object MapLegacyObject(System.Management.Automation.PSObject pso)
+        {
+            var issueLink = new IssueLink();
+            var hasKnownShape = false;
+
+            foreach (var prop in pso.Properties)
+            {
+                switch (prop.Name)
+                {
+                    case "ID":
+                    case "Id":
+                    case "id":
+                        if (prop.Value != null)
+                        {
+                            long parsedId;
+                            if (long.TryParse(prop.Value.ToString(), out parsedId)) { issueLink.Id = parsedId; }
+                        }
+                        hasKnownShape = true;
+                        break;
+                    case "Type":
+                    case "type":
+                        issueLink.Type = MapIssueLinkType(prop.Value);
+                        hasKnownShape = true;
+                        break;
+                    case "InwardIssue":
+                    case "inwardIssue":
+                        issueLink.InwardIssue = MapIssue(prop.Value);
+                        hasKnownShape = true;
+                        break;
+                    case "OutwardIssue":
+                    case "outwardIssue":
+                        issueLink.OutwardIssue = MapIssue(prop.Value);
+                        hasKnownShape = true;
+                        break;
+                }
+            }
+
+            if (!hasKnownShape)
+            {
+                throw new System.Management.Automation.ArgumentTransformationMetadataException(
+                    "Cannot convert value to AtlassianPS.JiraPS.IssueLink. Expected an issue-link object shape with id, type, inwardIssue, or outwardIssue properties.");
+            }
+
+            return issueLink;
+        }
+
+        private static IssueLinkType MapIssueLinkType(object value)
+        {
+            if (value == null) { return null; }
+
+            var typed = value as IssueLinkType;
+            if (typed != null) { return typed; }
+
+            var text = value as string;
+            if (!string.IsNullOrWhiteSpace(text))
+            {
+                return new IssueLinkType(text);
+            }
+
+            var pso = value as System.Management.Automation.PSObject;
+            if (pso != null)
+            {
+                var mapped = new IssueLinkType();
+                foreach (var prop in pso.Properties)
+                {
+                    switch (prop.Name)
+                    {
+                        case "ID":
+                        case "Id":
+                        case "id":
+                            mapped.Id = prop.Value != null ? prop.Value.ToString() : null;
+                            break;
+                        case "Name":
+                        case "name":
+                            mapped.Name = prop.Value as string;
+                            break;
+                        case "InwardText":
+                        case "inwardText":
+                            mapped.InwardText = prop.Value as string;
+                            break;
+                        case "OutwardText":
+                        case "outwardText":
+                            mapped.OutwardText = prop.Value as string;
+                            break;
+                    }
+                }
+                return mapped;
+            }
+
+            return null;
+        }
+
+        private static Issue MapIssue(object value)
+        {
+            if (value == null) { return null; }
+
+            var typed = value as Issue;
+            if (typed != null) { return typed; }
+
+            var text = value as string;
+            if (!string.IsNullOrWhiteSpace(text))
+            {
+                return new Issue(text);
+            }
+
+            var pso = value as System.Management.Automation.PSObject;
+            if (pso != null)
+            {
+                var mapped = new Issue();
+                foreach (var prop in pso.Properties)
+                {
+                    switch (prop.Name)
+                    {
+                        case "ID":
+                        case "Id":
+                        case "id":
+                            mapped.Id = prop.Value != null ? prop.Value.ToString() : null;
+                            break;
+                        case "Key":
+                        case "key":
+                            mapped.Key = prop.Value as string;
+                            break;
+                    }
+                }
+                return mapped;
+            }
+
+            return null;
+        }
     }
 
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]

--- a/Tests/Functions/Public/Add-JiraIssueLink.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Add-JiraIssueLink.Unit.Tests.ps1
@@ -66,16 +66,12 @@ InModuleScope JiraPS {
 
             Context "Parameter Types" {
                 It "has a parameter '<parameter>' of type '<type>'" -TestCases @(
-                    @{ parameter = "Issue"; type = "Object[]" }
+                    @{ parameter = "Issue"; type = "AtlassianPS.JiraPS.Issue" }
                     @{ parameter = "IssueLink"; type = "Object[]" }
                     @{ parameter = "Comment"; type = "String" }
                     @{ parameter = "Credential"; type = "System.Management.Automation.PSCredential" }
                 ) {
-                    $command | Should -HaveParameter $parameter
-
-                    #ToDo:CustomClass
-                    # can't use -Type as long we are using `PSObject.TypeNames.Insert(0, 'AtlassianPS.JiraPS.Filter')`
-                    (Get-Member -InputObject $command.Parameters.Item($parameter)).Attributes | Should -Contain $typeName
+                    $command | Should -HaveParameter $parameter -Type $type
                 }
             }
 

--- a/Tests/Functions/Public/Add-JiraIssueLink.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Add-JiraIssueLink.Unit.Tests.ps1
@@ -116,6 +116,26 @@ InModuleScope JiraPS {
                     { Add-JiraIssueLink -Issue $issueKey -IssueLink $string } | Should -Throw -ErrorId 'ParameterProperties.Incomplete,Add-JiraIssueLink'
                     { Add-JiraIssueLink -Issue $issueKey -IssueLink $incompleteObject } | Should -Throw -ErrorId 'ParameterProperties.Incomplete,Add-JiraIssueLink'
                 }
+
+                It "rejects malformed type objects in -IssueLink payload" {
+                    $invalidTypeObject = [PSCustomObject]@{
+                        outwardIssue = [PSCustomObject]@{ key = "TEST-10" }
+                        type         = [PSCustomObject]@{ foo = "bar" }
+                    }
+
+                    { Add-JiraIssueLink -Issue $issueKey -IssueLink $invalidTypeObject -ErrorAction Stop } |
+                        Should -Throw -ExpectedMessage "*IssueLink property 'type' must include either a non-empty 'name' or 'id'.*"
+                }
+
+                It "rejects malformed inward/outward issue objects in -IssueLink payload" {
+                    $invalidIssueObject = [PSCustomObject]@{
+                        outwardIssue = [PSCustomObject]@{ foo = "bar" }
+                        type         = [PSCustomObject]@{ name = "Composition" }
+                    }
+
+                    { Add-JiraIssueLink -Issue $issueKey -IssueLink $invalidIssueObject -ErrorAction Stop } |
+                        Should -Throw -ExpectedMessage "*IssueLink property 'outwardIssue' must include either a non-empty 'key' or 'id'.*"
+                }
             }
         }
     }

--- a/Tests/Functions/Public/Add-JiraIssueLink.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Add-JiraIssueLink.Unit.Tests.ps1
@@ -67,7 +67,7 @@ InModuleScope JiraPS {
             Context "Parameter Types" {
                 It "has a parameter '<parameter>' of type '<type>'" -TestCases @(
                     @{ parameter = "Issue"; type = "AtlassianPS.JiraPS.Issue" }
-                    @{ parameter = "IssueLink"; type = "Object[]" }
+                    @{ parameter = "IssueLink"; type = "AtlassianPS.JiraPS.IssueLink[]" }
                     @{ parameter = "Comment"; type = "String" }
                     @{ parameter = "Credential"; type = "System.Management.Automation.PSCredential" }
                 ) {

--- a/Tests/Functions/Public/Add-JiraIssueLink.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Add-JiraIssueLink.Unit.Tests.ps1
@@ -67,7 +67,7 @@ InModuleScope JiraPS {
             Context "Parameter Types" {
                 It "has a parameter '<parameter>' of type '<type>'" -TestCases @(
                     @{ parameter = "Issue"; type = "AtlassianPS.JiraPS.Issue" }
-                    @{ parameter = "IssueLink"; type = "AtlassianPS.JiraPS.IssueLink[]" }
+                    @{ parameter = "IssueLink"; type = "AtlassianPS.JiraPS.IssueLinkCreateRequest[]" }
                     @{ parameter = "Comment"; type = "String" }
                     @{ parameter = "Credential"; type = "System.Management.Automation.PSCredential" }
                 ) {
@@ -99,6 +99,40 @@ InModuleScope JiraPS {
 
                 Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1
             }
+
+            It "maps loose object payloads to key-based request JSON" {
+                $linkPayload = [PSCustomObject]@{
+                    outwardIssue = [PSCustomObject]@{ key = "TEST-10" }
+                    type         = [PSCustomObject]@{ name = "Composition" }
+                }
+
+                Add-JiraIssueLink -Issue $issueKey -IssueLink $linkPayload
+
+                Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -ParameterFilter {
+                    $parsed = $Body | ConvertFrom-Json
+                    $parsed.type.name -eq "Composition" -and
+                    $parsed.outwardIssue.key -eq "TEST-10" -and
+                    -not $parsed.type.id -and
+                    -not $parsed.outwardIssue.id
+                }
+            }
+
+            It "maps id-based refs to id-based request JSON" {
+                $linkPayload = [PSCustomObject]@{
+                    outwardIssue = [PSCustomObject]@{ id = "10001" }
+                    type         = [PSCustomObject]@{ id = "10000" }
+                }
+
+                Add-JiraIssueLink -Issue $issueKey -IssueLink $linkPayload
+
+                Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraPS -Exactly -Times 1 -ParameterFilter {
+                    $parsed = $Body | ConvertFrom-Json
+                    $parsed.type.id -eq "10000" -and
+                    $parsed.outwardIssue.id -eq "10001" -and
+                    -not $parsed.type.name -and
+                    -not $parsed.outwardIssue.key
+                }
+            }
         }
 
         Describe "Input Validation" {
@@ -113,7 +147,7 @@ InModuleScope JiraPS {
                     $string = "invalid-object"
                     $incompleteObject = [PSCustomObject]@{ type = "foo" }
 
-                    { Add-JiraIssueLink -Issue $issueKey -IssueLink $string } | Should -Throw -ErrorId 'ParameterProperties.Incomplete,Add-JiraIssueLink'
+                    { Add-JiraIssueLink -Issue $issueKey -IssueLink $string -ErrorAction Stop } | Should -Throw -ExpectedMessage "*Cannot convert a string to AtlassianPS.JiraPS.IssueLinkCreateRequest*"
                     { Add-JiraIssueLink -Issue $issueKey -IssueLink $incompleteObject } | Should -Throw -ErrorId 'ParameterProperties.Incomplete,Add-JiraIssueLink'
                 }
 
@@ -124,7 +158,7 @@ InModuleScope JiraPS {
                     }
 
                     { Add-JiraIssueLink -Issue $issueKey -IssueLink $invalidTypeObject -ErrorAction Stop } |
-                        Should -Throw -ExpectedMessage "*IssueLink property 'type' must include either a non-empty 'name' or 'id'.*"
+                        Should -Throw -ExpectedMessage "*IssueLinkCreateRequest property 'type' must include either a non-empty 'name' or 'id'.*"
                 }
 
                 It "rejects malformed inward/outward issue objects in -IssueLink payload" {
@@ -134,7 +168,7 @@ InModuleScope JiraPS {
                     }
 
                     { Add-JiraIssueLink -Issue $issueKey -IssueLink $invalidIssueObject -ErrorAction Stop } |
-                        Should -Throw -ExpectedMessage "*IssueLink property 'outwardIssue' must include either a non-empty 'key' or 'id'.*"
+                        Should -Throw -ExpectedMessage "*IssueLinkCreateRequest property 'outwardIssue' must include either a non-empty 'key' or 'id'.*"
                 }
             }
         }

--- a/Tests/Functions/Public/Get-JiraIssueLinkType.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraIssueLinkType.Unit.Tests.ps1
@@ -64,7 +64,13 @@ InModuleScope JiraPS {
 
         Describe "Signature" {
             Context "Parameter Types" {
-                # TODO: Add parameter type validation tests
+                It "has a parameter '<parameter>' of type '<type>'" -TestCases @(
+                    @{ parameter = 'LinkType'; type = 'AtlassianPS.JiraPS.IssueLinkType' }
+                    @{ parameter = 'Credential'; type = 'PSCredential' }
+                ) {
+                    param($parameter, $type)
+                    (Get-Command -Name Get-JiraIssueLinkType) | Should -HaveParameter $parameter -Type $type
+                }
             }
 
             Context "Mandatory Parameters" {}
@@ -123,7 +129,11 @@ InModuleScope JiraPS {
         Describe "Input Validation" {
             Context "Type Validation - Positive Cases" {}
 
-            Context "Type Validation - Negative Cases" {}
+            Context "Type Validation - Negative Cases" {
+                It "uses transformer errors for invalid link type input" {
+                    { Get-JiraIssueLinkType -LinkType (Get-Date) -ErrorAction Stop } | Should -Throw -ExpectedMessage "*Cannot convert value of type*IssueLinkType*"
+                }
+            }
         }
     }
 }

--- a/Tests/Functions/Public/Get-JiraUser.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraUser.Unit.Tests.ps1
@@ -68,7 +68,17 @@ InModuleScope JiraPS {
 
             Mock ConvertTo-JiraUser -ModuleName JiraPS {
                 Write-MockDebugInfo 'ConvertTo-JiraUser'
-                $InputObject
+                $user = [AtlassianPS.JiraPS.User]@{
+                    Name         = $InputObject.name
+                    AccountId    = $InputObject.accountId
+                    DisplayName  = $InputObject.displayName
+                    EmailAddress = $InputObject.emailAddress
+                    Active       = $InputObject.active
+                    RestUrl      = $InputObject.self
+                }
+                $user | Add-Member -NotePropertyName self -NotePropertyValue $InputObject.self -Force
+                $user | Add-Member -NotePropertyName groups -NotePropertyValue $InputObject.groups -Force
+                $user
             }
 
             # Return information of the current user
@@ -109,7 +119,15 @@ InModuleScope JiraPS {
 
         Describe "Signature" {
             Context "Parameter Types" {
-                # TODO: Add parameter type validation tests
+                It "has a parameter '<parameter>' of type '<type>'" -TestCases @(
+                    @{ parameter = 'InputObject'; type = 'AtlassianPS.JiraPS.User[]' }
+                    @{ parameter = 'UserName'; type = 'String[]' }
+                    @{ parameter = 'AccountId'; type = 'String[]' }
+                    @{ parameter = 'Credential'; type = 'PSCredential' }
+                ) {
+                    param($parameter, $type)
+                    (Get-Command -Name Get-JiraUser) | Should -HaveParameter $parameter -Type $type
+                }
             }
 
             Context "Mandatory Parameters" {}

--- a/Tests/Functions/Public/Remove-JiraIssueLink.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Remove-JiraIssueLink.Unit.Tests.ps1
@@ -45,7 +45,11 @@ InModuleScope JiraPS {
             Mock Resolve-JiraIssueObject -ModuleName JiraPS {
                 Write-MockDebugInfo 'Resolve-JiraIssueObject' 'InputObject'
                 if ($InputObject.Key -eq 'TEST-01') {
-                    return (Get-JiraIssue -Key 'TEST-01')
+                    return [AtlassianPS.JiraPS.Issue]@{
+                        IssueLinks = [AtlassianPS.JiraPS.IssueLink[]]@(
+                            [AtlassianPS.JiraPS.IssueLink]@{ Id = 1234 }
+                        )
+                    }
                 }
                 $InputObject
             }

--- a/Tests/Functions/Public/Remove-JiraIssueLink.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Remove-JiraIssueLink.Unit.Tests.ps1
@@ -35,8 +35,9 @@ InModuleScope JiraPS {
                 Write-MockDebugInfo 'Get-JiraIssue' 'Key'
                 # We don't care about the content of any field except for the id of the issuelinks
                 $issue = [AtlassianPS.JiraPS.Issue]@{
+                    Key        = 'TEST-01'
                     IssueLinks = [AtlassianPS.JiraPS.IssueLink[]]@(
-                        [AtlassianPS.JiraPS.IssueLink]@{ Id = 1234 }
+                        [AtlassianPS.JiraPS.IssueLink]::new('1234')
                     )
                 }
                 return $issue
@@ -46,8 +47,9 @@ InModuleScope JiraPS {
                 Write-MockDebugInfo 'Resolve-JiraIssueObject' 'InputObject'
                 if ($InputObject.Key -eq 'TEST-01') {
                     return [AtlassianPS.JiraPS.Issue]@{
+                        Key        = 'TEST-01'
                         IssueLinks = [AtlassianPS.JiraPS.IssueLink[]]@(
-                            [AtlassianPS.JiraPS.IssueLink]@{ Id = 1234 }
+                            [AtlassianPS.JiraPS.IssueLink]::new('1234')
                         )
                     }
                 }

--- a/Tests/Functions/Public/Remove-JiraIssueLink.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Remove-JiraIssueLink.Unit.Tests.ps1
@@ -42,6 +42,14 @@ InModuleScope JiraPS {
                 return $issue
             }
 
+            Mock Resolve-JiraIssueObject -ModuleName JiraPS {
+                Write-MockDebugInfo 'Resolve-JiraIssueObject' 'InputObject'
+                if ($InputObject.Key -eq 'TEST-01') {
+                    return (Get-JiraIssue -Key 'TEST-01')
+                }
+                $InputObject
+            }
+
             Mock Invoke-JiraMethod -ModuleName JiraPS -ParameterFilter { $Method -eq 'Delete' -and $URI -like "/rest/api/*/issueLink/1234" } {
                 Write-MockDebugInfo 'Invoke-JiraMethod' 'Method', 'Uri'
             }
@@ -61,7 +69,8 @@ InModuleScope JiraPS {
 
             Context "Parameter Types" {
                 It "has a parameter '<parameter>' of type '<type>'" -TestCases @(
-                    @{ parameter = 'IssueLink'; type = 'Object[]' }
+                    @{ parameter = 'IssueLink'; type = 'AtlassianPS.JiraPS.IssueLink[]' }
+                    @{ parameter = 'Issue'; type = 'AtlassianPS.JiraPS.Issue[]' }
                     @{ parameter = 'Credential'; type = 'PSCredential' }
                 ) {
                     param($parameter, $type)
@@ -80,12 +89,18 @@ InModuleScope JiraPS {
                     $issueLink = Get-JiraIssueLink -Id 1234
                     $issue = Get-JiraIssue -Key TEST-01
                     { Remove-JiraIssueLink -IssueLink $issueLink } | Should -Not -Throw
-                    { Remove-JiraIssueLink -IssueLink $issue } | Should -Not -Throw
+                    { Remove-JiraIssueLink -Issue $issue } | Should -Not -Throw
                     Should -Invoke -CommandName Invoke-JiraMethod -Exactly -Times 2
                 }
 
                 It "Accepts a AtlassianPS.JiraPS.Issue object over the pipeline" {
                     { Get-JiraIssue -Key TEST-01 | Remove-JiraIssueLink } | Should -Not -Throw
+                    Should -Invoke -CommandName Invoke-JiraMethod -Exactly -Times 1
+                }
+
+                It "Resolves string stubs passed to -Issue" {
+                    { Remove-JiraIssueLink -Issue 'TEST-01' } | Should -Not -Throw
+                    Should -Invoke -CommandName Resolve-JiraIssueObject -Exactly -Times 1 -ParameterFilter { $InputObject.Key -eq 'TEST-01' }
                     Should -Invoke -CommandName Invoke-JiraMethod -Exactly -Times 1
                 }
 
@@ -103,7 +118,7 @@ InModuleScope JiraPS {
 
             Context "Negative cases" {
                 It "Validates pipeline input" {
-                    { @{id = 1 } | Remove-JiraIssueLink -ErrorAction Stop } | Should -Throw -ExpectedMessage "*Invalid Type*"
+                    { @{ id = 1 } | Remove-JiraIssueLink -ErrorAction Stop } | Should -Throw -ExpectedMessage "*Cannot convert value of type*IssueLink*"
                 }
             }
         }

--- a/Tests/Integration/IssueLinks.Integration.Tests.ps1
+++ b/Tests/Integration/IssueLinks.Integration.Tests.ps1
@@ -207,6 +207,22 @@ InModuleScope JiraPS {
                     { $pipelineIssue | Add-JiraIssueLink -IssueLink $issueLink } |
                         Should -Not -Throw
                 }
+
+                It "accepts typed issue-link create request payloads" {
+                    if (-not $sourceIssue -or -not $targetIssue) {
+                        Set-ItResult -Skipped -Because "JIRA_TEST_PROJECT not configured"
+                        return
+                    }
+
+                    $linkTypes = Get-JiraIssueLinkType
+                    $issueLink = [AtlassianPS.JiraPS.IssueLinkCreateRequest]@{
+                        type         = [AtlassianPS.JiraPS.IssueLinkTypeRef]@{ name = $linkTypes[0].Name }
+                        outwardIssue = [AtlassianPS.JiraPS.LinkedIssueRef]@{ key = $targetIssue.Key }
+                    }
+
+                    { Add-JiraIssueLink -Issue $sourceIssue.Key -IssueLink $issueLink } |
+                        Should -Not -Throw
+                }
             }
         }
 

--- a/docs/en-US/commands/Add-JiraIssueLink.md
+++ b/docs/en-US/commands/Add-JiraIssueLink.md
@@ -15,7 +15,7 @@ Adds a link between two Issues on Jira
 ## SYNTAX
 
 ```powershell
-Add-JiraIssueLink [-Issue] <Issue> [-IssueLink] <Object[]> [[-Comment] <string>]
+Add-JiraIssueLink [-Issue] <Issue> [-IssueLink] <IssueLink[]> [[-Comment] <string>]
  [[-Credential] <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -131,9 +131,10 @@ HelpMessage: ''
 ### -IssueLink
 
 Issue Link to be created.
+Accepts `AtlassianPS.JiraPS.IssueLink` values and compatible object payloads that include issue-link fields (`type`, `inwardIssue`, `outwardIssue`).
 
 ```yaml
-Type: Object[]
+Type: IssueLink[]
 DefaultValue: ''
 SupportsWildcards: false
 Aliases: []

--- a/docs/en-US/commands/Add-JiraIssueLink.md
+++ b/docs/en-US/commands/Add-JiraIssueLink.md
@@ -15,22 +15,22 @@ Adds a link between two Issues on Jira
 ## SYNTAX
 
 ```powershell
-Add-JiraIssueLink [-Issue] <Issue> [-IssueLink] <IssueLink[]> [[-Comment] <string>]
+Add-JiraIssueLink [-Issue] <Issue> [-IssueLink] <IssueLinkCreateRequest[]> [[-Comment] <string>]
  [[-Credential] <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-Creates a new link of the specified type between two Issue.
+Creates a new link of the specified type between two issues.
 
 ## EXAMPLES
 
 ### EXAMPLE 1
 
 ```powershell
-$_issueLink = [PSCustomObject]@{
-    outwardIssue = [PSCustomObject]@{key = "TEST-10"}
-    type = [PSCustomObject]@{name = "Composition"}
+$_issueLink = [AtlassianPS.JiraPS.IssueLinkCreateRequest]@{
+    outwardIssue = [AtlassianPS.JiraPS.LinkedIssueRef]@{ key = "TEST-10" }
+    type = [AtlassianPS.JiraPS.IssueLinkTypeRef]@{ name = "Composition" }
 }
 Add-JiraIssueLink -Issue TEST-01 -IssueLink $_issueLink
 ```
@@ -131,10 +131,12 @@ HelpMessage: ''
 ### -IssueLink
 
 Issue Link to be created.
-Accepts `AtlassianPS.JiraPS.IssueLink` values and compatible object payloads that include issue-link fields (`type`, `inwardIssue`, `outwardIssue`).
+Accepts `AtlassianPS.JiraPS.IssueLinkCreateRequest` values and compatible payload objects that include issue-link create fields (`type`, `inwardIssue`, `outwardIssue`).
+The nested `type` object must include `name` or `id`.
+The nested issue references must include `key` or `id`.
 
 ```yaml
-Type: IssueLink[]
+Type: IssueLinkCreateRequest[]
 DefaultValue: ''
 SupportsWildcards: false
 Aliases: []
@@ -184,8 +186,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### AtlassianPS.JiraPS.Issue
 
-The JIRA issue that should be linked
-The JIRA issue link that should be used
+The Jira issue that should be linked.
+
+### AtlassianPS.JiraPS.IssueLinkCreateRequest
+
+The issue-link create request payload that should be used.
 
 ## OUTPUTS
 

--- a/docs/en-US/commands/Get-JiraIssueLinkType.md
+++ b/docs/en-US/commands/Get-JiraIssueLinkType.md
@@ -23,7 +23,7 @@ Get-JiraIssueLinkType [-Credential <pscredential>] [<CommonParameters>]
 ### _Search
 
 ```powershell
-Get-JiraIssueLinkType [-LinkType] <Object> [-Credential <pscredential>] [<CommonParameters>]
+Get-JiraIssueLinkType [-LinkType] <IssueLinkType> [-Credential <pscredential>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -80,7 +80,7 @@ HelpMessage: ''
 The Issue Type name or ID to search.
 
 ```yaml
-Type: Object
+Type: IssueLinkType
 DefaultValue: ''
 SupportsWildcards: false
 Aliases: []

--- a/docs/en-US/commands/Get-JiraUser.md
+++ b/docs/en-US/commands/Get-JiraUser.md
@@ -37,7 +37,7 @@ Get-JiraUser [-AccountId] <string[]> [-Exact] [-IncludeInactive] [-MaxResults <u
 ### ByInputObject
 
 ```powershell
-Get-JiraUser [-InputObject] <Object[]> [-Exact] [-IncludeInactive] [-Credential <pscredential>]
+Get-JiraUser [-InputObject] <User[]> [-Exact] [-IncludeInactive] [-Credential <pscredential>]
  [<CommonParameters>]
 ```
 
@@ -215,7 +215,7 @@ HelpMessage: ''
 User Object of the user.
 
 ```yaml
-Type: Object[]
+Type: User[]
 DefaultValue: ''
 SupportsWildcards: false
 Aliases: []

--- a/docs/en-US/commands/Get-JiraUser.md
+++ b/docs/en-US/commands/Get-JiraUser.md
@@ -111,6 +111,15 @@ Set-JiraIssue TEST-1 -Assignee $user.AccountId
 Searches for a user by name, then uses their account ID to assign an issue.
 This pattern is useful when migrating scripts from Data Center to Cloud.
 
+### EXAMPLE 8
+
+```powershell
+Get-JiraUser -UserName user1 | Get-JiraUser
+```
+
+Refreshes user objects by piping existing `AtlassianPS.JiraPS.User` output back through `Get-JiraUser`.
+Use `-UserName` / `-AccountId` for string-based lookups, and `-InputObject` when requerying existing user objects.
+
 ## PARAMETERS
 
 ### -AccountId
@@ -212,7 +221,9 @@ HelpMessage: ''
 
 ### -InputObject
 
-User Object of the user.
+User object(s) to refresh from Jira.
+Use this parameter when you already have `AtlassianPS.JiraPS.User` objects and want to requery the latest data.
+For string-based lookup, use `-UserName` (Data Center / generic) or `-AccountId` (Cloud).
 
 ```yaml
 Type: User[]
@@ -324,6 +335,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ### String[]
 
 Username, name, or e-mail address
+
+### AtlassianPS.JiraPS.User[]
+
+Existing user object(s) to refresh from Jira via `-InputObject`.
 
 ## OUTPUTS
 

--- a/docs/en-US/commands/Remove-JiraIssueLink.md
+++ b/docs/en-US/commands/Remove-JiraIssueLink.md
@@ -14,8 +14,17 @@ Removes a issue link from a JIRA issue
 
 ## SYNTAX
 
+### ByIssueLink (Default)
+
 ```powershell
-Remove-JiraIssueLink [-IssueLink] <Object[]> [[-Credential] <pscredential>] [-WhatIf] [-Confirm]
+Remove-JiraIssueLink [-IssueLink] <IssueLink[]> [[-Credential] <pscredential>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+### ByIssue
+
+```powershell
+Remove-JiraIssueLink [-Issue] <Issue[]> [[-Credential] <pscredential>] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
@@ -91,15 +100,34 @@ HelpMessage: ''
 
 IssueLink to delete
 
-If a `AtlassianPS.JiraPS.Issue` is provided, all issueLinks will be deleted.
-
 ```yaml
-Type: Object[]
+Type: IssueLink[]
 DefaultValue: ''
 SupportsWildcards: false
 Aliases: []
 ParameterSets:
-- Name: (All)
+- Name: ByIssueLink
+  Position: 0
+  IsRequired: true
+  ValueFromPipeline: true
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Issue
+
+Issue whose links should all be removed.
+
+```yaml
+Type: Issue[]
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: ByIssue
   Position: 0
   IsRequired: true
   ValueFromPipeline: true
@@ -143,6 +171,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### AtlassianPS.JiraPS.Issue
+
+### AtlassianPS.JiraPS.IssueLink
 
 
 ## OUTPUTS


### PR DESCRIPTION
## Summary
- Split `Add-JiraIssueLink` input from the response model by introducing dedicated create DTOs: `IssueLinkCreateRequest`, `IssueLinkTypeRef`, and `LinkedIssueRef`.
- Add `IssueLinkCreateRequestTransformation` for typed and loose payload binding, with strict nested-shape validation and clear argument-transformation errors for malformed `type`/issue refs.
- Keep `IssueLink` as the response/domain type, update cmdlet help/changelog for the breaking contract, and extend unit + integration coverage (including typed payload Cloud integration).

## Test plan
- [x] `pwsh -NoLogo -NonInteractive -NoProfile -Command "Set-Location '/Users/LIO2MU/projects/AtlassianPS/agents/issue-611/JiraPS'; Invoke-Pester -Path 'Tests/Functions/Public/Add-JiraIssueLink.Unit.Tests.ps1'"`
- [x] `pwsh -NoLogo -NonInteractive -NoProfile -Command "Set-Location '/Users/LIO2MU/projects/AtlassianPS/agents/issue-611/JiraPS'; Invoke-Pester -Path 'Tests/Functions/Public/Remove-JiraIssueLink.Unit.Tests.ps1'"`
- [x] `pwsh -NoLogo -NonInteractive -NoProfile -Command "Set-Location '/Users/LIO2MU/projects/AtlassianPS/agents/issue-611/JiraPS'; Invoke-Build -Task Lint"`
- [x] `pwsh -NoLogo -NonInteractive -NoProfile -Command "Set-Location '/Users/LIO2MU/projects/AtlassianPS/agents/issue-611/JiraPS'; Invoke-Build -Task Build, Test"`
- [x] `pwsh -NoLogo -NonInteractive -NoProfile -Command "Set-Location '/Users/LIO2MU/projects/AtlassianPS/agents/issue-611/JiraPS'; Invoke-Pester -Path 'Tests/Help.Tests.ps1'"`
- [x] `pwsh -NoLogo -NonInteractive -NoProfile -Command 'Set-Location "/Users/LIO2MU/projects/AtlassianPS/agents/issue-611/JiraPS"; Get-Content ".env" | Where-Object { $_ -and -not $_.Trim().StartsWith("#") } | ForEach-Object { $parts = $_ -split "=", 2; if ($parts.Count -eq 2) { [Environment]::SetEnvironmentVariable($parts[0].Trim(), $parts[1].Trim(), "Process") } }; [Environment]::SetEnvironmentVariable("CI_JIRA_TYPE", "Cloud", "Process"); Invoke-Build -Task TestIntegration -Tag "Cloud"'`

Closes #611.

Made with [Cursor](https://cursor.com)