### PR TITLE
test: stabilize server integration OR search case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Stabilized the Server integration `Search.Integration.Tests.ps1` OR-operator case by replacing the non-existent-key branch with a deterministic project-scoped OR predicate (`key = <fixture> OR key != <fixture>`), avoiding an intermittent Jira 11 backend null-deref (`issueObject` null) that failed nightly `integration_tests.yml` runs even when JiraPS behavior was correct.
+
 ## 3.0 - 2026-05-10
 
 This release focuses on Cloud and Data Center compatibility, safer typing, and better automation ergonomics.

--- a/Tests/Integration/Search.Integration.Tests.ps1
+++ b/Tests/Integration/Search.Integration.Tests.ps1
@@ -106,17 +106,17 @@ InModuleScope JiraPS {
                         Set-ItResult -Skipped -Because "JIRA_TEST_PROJECT or JIRA_TEST_ISSUE not configured"
                         return
                     }
-                    # Keep this OR query anchored to issue-key predicates only.
-                    # Jira 11 can intermittently throw an internal server error on
-                    # mixed key/date OR clauses (`key = X OR created >= -Nd`) against
-                    # a fresh DC dataset, which makes the test flaky while not proving
-                    # anything about JiraPS itself.
-                    $jql = "project = $($fixtures.TestProject) AND (key = $($fixtures.TestIssue) OR key = NONEXISTENT-999999)"
+                    # Keep this OR query anchored to project-scoped predicates that only
+                    # reference real indexed issues. Jira 11 can intermittently throw a
+                    # backend null-deref when one OR branch targets a non-existent key,
+                    # which flakes the Server workflow without exercising JiraPS logic.
+                    # This still validates OR parsing while avoiding brittle server behavior.
+                    $jql = "project = $($fixtures.TestProject) AND (key = $($fixtures.TestIssue) OR key != $($fixtures.TestIssue))"
 
                     $results = Get-JiraIssue -Query $jql -ErrorAction Stop
 
                     $results | Should -Not -BeNullOrEmpty -Because "test project always carries JIRA_TEST_ISSUE"
-                    @($results)[0].Project.Key | Should -Be $fixtures.TestProject
+                    @($results).Key | Should -Contain $fixtures.TestIssue
                 }
 
                 It "supports ORDER BY" {


### PR DESCRIPTION
## Summary
- Replace the flaky Server-track OR integration query in `Tests/Integration/Search.Integration.Tests.ps1` with a deterministic project-scoped OR predicate that does not reference a non-existent issue key.
- Keep the OR-operator behavior under test while avoiding the Jira 11 backend null-deref (`issueObject` null) seen in nightly `integration_tests.yml` failures.
- Document the change under `CHANGELOG.md` (`[Unreleased]`) so the stability fix is captured for release notes.

## Test plan
- [x] `pwsh -NoLogo -NonInteractive -NoProfile -Command "Set-Location '/Users/LIO2MU/projects/AtlassianPS/agents/fix-integration-workflow/JiraPS'; Invoke-Build -Task Build, Test"`
- [x] Triggered `Integration Tests` workflow on `fix-integration-workflow` with `track=server` and confirmed successful run: https://github.com/AtlassianPS/JiraPS/actions/runs/25693379507
- [ ] Optional: run `track=both` before merge if you want explicit Cloud + Server confirmation from the workflow-dispatch path.


Made with [Cursor](https://cursor.com)