### PR TITLE
Align JiraPS instruction guidance with release-based testing

### DIFF
--- a/.cursor/rules/jiraps.mdc
+++ b/.cursor/rules/jiraps.mdc
@@ -18,20 +18,19 @@ Cursor reads this file as its always-on rule for the JiraPS workspace.
 3. **User Identity** — `accountId` for Cloud, `username`/`name` for DC
 4. **REST calls** — always go through `Invoke-JiraMethod`
 5. **Tests required** — every function needs `.Unit.Tests.ps1`
-6. **Build before test** — `Invoke-Build -Task Build, Test` (tests run against `Release/`, not source)
+6. **Full-suite validation** — `Invoke-Build -Task Build, Test` before commit
 
 ## Testing During Development
 
 Run the appropriate tests after every change.
-Unit tests should run against `Release/Tests/`, not source paths.
 
 | What you changed | Test command |
 |------------------|--------------|
 | **Any code file** | `Invoke-Build -Task Lint` |
-| **Function** in `JiraPS/Public/` | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/Functions/Public/<FunctionName>.Unit.Tests.ps1` |
-| **Function** in `JiraPS/Private/` | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/Functions/Private/<FunctionName>.Unit.Tests.ps1` |
-| **Test file** | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/<path-under-Tests>` |
-| **Docs** in `docs/**` | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/Help.Tests.ps1` |
+| **Function** in `JiraPS/Public/` | `Invoke-Pester Tests/Functions/Public/<FunctionName>.Unit.Tests.ps1` |
+| **Function** in `JiraPS/Private/` | `Invoke-Pester Tests/Functions/Private/<FunctionName>.Unit.Tests.ps1` |
+| **Test file** | `Invoke-Pester <path-to-that-test-file>` |
+| **Docs** in `docs/**` | `Invoke-Pester Tests/Help.Tests.ps1` |
 
 **Before committing**: Run full `Invoke-Build -Task Build, Test`.
 

--- a/.cursor/rules/jiraps.mdc
+++ b/.cursor/rules/jiraps.mdc
@@ -22,15 +22,16 @@ Cursor reads this file as its always-on rule for the JiraPS workspace.
 
 ## Testing During Development
 
-Run the appropriate tests after every change:
+Run the appropriate tests after every change.
+Unit tests should run against `Release/Tests/`, not source paths.
 
 | What you changed | Test command |
 |------------------|--------------|
 | **Any code file** | `Invoke-Build -Task Lint` |
-| **Function** in `JiraPS/Public/` | `Invoke-Pester Tests/Functions/Public/<FunctionName>.Unit.Tests.ps1` |
-| **Function** in `JiraPS/Private/` | `Invoke-Pester Tests/Functions/Private/<FunctionName>.Unit.Tests.ps1` |
-| **Test file** | `Invoke-Pester <path-to-that-test-file>` |
-| **Docs** in `docs/**` | `Invoke-Pester Tests/Help.Tests.ps1` |
+| **Function** in `JiraPS/Public/` | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/Functions/Public/<FunctionName>.Unit.Tests.ps1` |
+| **Function** in `JiraPS/Private/` | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/Functions/Private/<FunctionName>.Unit.Tests.ps1` |
+| **Test file** | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/<path-under-Tests>` |
+| **Docs** in `docs/**` | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/Help.Tests.ps1` |
 
 **Before committing**: Run full `Invoke-Build -Task Build, Test`.
 

--- a/.github/ai-context/powershell-rules.md
+++ b/.github/ai-context/powershell-rules.md
@@ -141,24 +141,20 @@ If a "not found" branch is part of normal lookup behavior, set the result or wri
 
 ## Running Tests
 
-**IMPORTANT**: Unit tests run against the *built* module in `Release/`, not source files.
-You MUST build before running unit tests. Integration tests load the source manifest directly (no build required) but need live Jira Cloud credentials in `.env`.
+**IMPORTANT**: Use `Invoke-Pester` directly for focused single unit-test loops.
+Use `Invoke-Build -Task Build, Test` as the full-suite validation gate before commit.
+Integration tests load the source manifest directly (no build required) but need live Jira Cloud credentials in `.env`.
 
 ```powershell
 # First time setup (install dependencies)
 ./Tools/setup.ps1
 
-# Unit tests (standard workflow)
+# Focused unit test loop
+Invoke-Pester Tests/Functions/Public/<FunctionName>.Unit.Tests.ps1
+Invoke-Pester Tests/Functions/Private/<FunctionName>.Unit.Tests.ps1
+
+# Full suite validation (pre-commit gate)
 Invoke-Build -Task Build, Test
-
-# Or separately:
-Invoke-Build -Task Build    # Compiles module into Release/
-Invoke-Build -Task Test     # Runs unit tests against Release/ (excludes Integration)
-
-# Focused unit test loop (same Release/ module as CI)
-Invoke-Build -Task Build
-Invoke-Pester ./Release/Tests/Functions/Public/<FunctionName>.Unit.Tests.ps1
-Invoke-Pester ./Release/Tests/Functions/Private/<FunctionName>.Unit.Tests.ps1
 
 # Integration tests (no build needed, requires .env)
 Invoke-Build -Task TestIntegration
@@ -182,8 +178,8 @@ Invoke-Build -Task TestIntegration -ThrottleLimit 8     # More parallelism
 
 ### Common Mistakes
 
-- **Running `Invoke-Pester Tests/...` for final unit-test validation** — bypasses `Release/` and can miss build/packaging regressions
-- **Running `Invoke-Build -Task Test` without building** — Tests will fail or use stale code
+- **Skipping full-suite validation** — always run `Invoke-Build -Task Build, Test` before commit
+- **Treating focused `Invoke-Pester` as final validation** — local loops are faster, but full suite is still required
 - **Forgetting `./Tools/setup.ps1`** — Missing dependencies (Pester, InvokeBuild, etc.)
 - **Running `TestIntegration` without `.env`** — Will fail fast on missing credentials
 

--- a/.github/ai-context/powershell-rules.md
+++ b/.github/ai-context/powershell-rules.md
@@ -155,6 +155,11 @@ Invoke-Build -Task Build, Test
 Invoke-Build -Task Build    # Compiles module into Release/
 Invoke-Build -Task Test     # Runs unit tests against Release/ (excludes Integration)
 
+# Focused unit test loop (same Release/ module as CI)
+Invoke-Build -Task Build
+Invoke-Pester ./Release/Tests/Functions/Public/<FunctionName>.Unit.Tests.ps1
+Invoke-Pester ./Release/Tests/Functions/Private/<FunctionName>.Unit.Tests.ps1
+
 # Integration tests (no build needed, requires .env)
 Invoke-Build -Task TestIntegration
 Invoke-Build -Task TestIntegration -Tag 'Smoke'         # Smoke subset only
@@ -177,7 +182,7 @@ Invoke-Build -Task TestIntegration -ThrottleLimit 8     # More parallelism
 
 ### Common Mistakes
 
-- **Running `Invoke-Pester` directly** — Won't work for unit tests; they expect the compiled module
+- **Running `Invoke-Pester Tests/...` for final unit-test validation** — bypasses `Release/` and can miss build/packaging regressions
 - **Running `Invoke-Build -Task Test` without building** — Tests will fail or use stale code
 - **Forgetting `./Tools/setup.ps1`** — Missing dependencies (Pester, InvokeBuild, etc.)
 - **Running `TestIntegration` without `.env`** — Will fail fast on missing credentials
@@ -194,7 +199,7 @@ When changing PowerShell files:
 2. If user identity is involved: is `accountId` used for Cloud and `username`/`name` for DC?
 3. If text fields are read/written: is ADF conversion conditional on deployment type?
 4. Are tests written/updated?
-5. Do tests pass? (`Invoke-Build -Task Build && Invoke-Build -Task Test`)
+5. Do tests pass? (`Invoke-Build -Task Build, Test`)
 6. If transport/response internals changed: are edge paths covered (request context, session capture, cache branches, paging, and status fallback from exceptions)?
 7. If you developed on macOS/Linux: did the Windows PowerShell 5.1 CI lane pass before merge?
 8. If CI failed: did you follow the [CI Triage Runbook](ci-triage-runbook.md)?

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,15 +18,16 @@ GitHub Copilot reads this file as its repository-level instructions.
 
 ## Testing During Development
 
-Run the appropriate tests after every change:
+Run the appropriate tests after every change.
+Unit tests should run against `Release/Tests/`, not source paths.
 
 | What you changed | Test command |
 |------------------|--------------|
 | **Any code file** | `Invoke-Build -Task Lint` |
-| **Function** in `JiraPS/Public/` | `Invoke-Pester Tests/Functions/Public/<FunctionName>.Unit.Tests.ps1` |
-| **Function** in `JiraPS/Private/` | `Invoke-Pester Tests/Functions/Private/<FunctionName>.Unit.Tests.ps1` |
-| **Test file** | `Invoke-Pester <path-to-that-test-file>` |
-| **Docs** in `docs/**` | `Invoke-Pester Tests/Help.Tests.ps1` |
+| **Function** in `JiraPS/Public/` | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/Functions/Public/<FunctionName>.Unit.Tests.ps1` |
+| **Function** in `JiraPS/Private/` | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/Functions/Private/<FunctionName>.Unit.Tests.ps1` |
+| **Test file** | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/<path-under-Tests>` |
+| **Docs** in `docs/**` | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/Help.Tests.ps1` |
 
 **Before committing**: Run full `Invoke-Build -Task Build, Test`.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,20 +14,19 @@ GitHub Copilot reads this file as its repository-level instructions.
 3. **User Identity** — `accountId` for Cloud, `username`/`name` for DC
 4. **REST calls** — always go through `Invoke-JiraMethod`
 5. **Tests required** — every function needs `.Unit.Tests.ps1`
-6. **Build before test** — `Invoke-Build -Task Build, Test` (tests run against `Release/`, not source)
+6. **Full-suite validation** — `Invoke-Build -Task Build, Test` before commit
 
 ## Testing During Development
 
 Run the appropriate tests after every change.
-Unit tests should run against `Release/Tests/`, not source paths.
 
 | What you changed | Test command |
 |------------------|--------------|
 | **Any code file** | `Invoke-Build -Task Lint` |
-| **Function** in `JiraPS/Public/` | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/Functions/Public/<FunctionName>.Unit.Tests.ps1` |
-| **Function** in `JiraPS/Private/` | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/Functions/Private/<FunctionName>.Unit.Tests.ps1` |
-| **Test file** | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/<path-under-Tests>` |
-| **Docs** in `docs/**` | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/Help.Tests.ps1` |
+| **Function** in `JiraPS/Public/` | `Invoke-Pester Tests/Functions/Public/<FunctionName>.Unit.Tests.ps1` |
+| **Function** in `JiraPS/Private/` | `Invoke-Pester Tests/Functions/Private/<FunctionName>.Unit.Tests.ps1` |
+| **Test file** | `Invoke-Pester <path-to-that-test-file>` |
+| **Docs** in `docs/**` | `Invoke-Pester Tests/Help.Tests.ps1` |
 
 **Before committing**: Run full `Invoke-Build -Task Build, Test`.
 

--- a/.github/instructions/jira-api-compatibility.instructions.md
+++ b/.github/instructions/jira-api-compatibility.instructions.md
@@ -15,6 +15,6 @@ This file applies to all `.ps1` files. It references shared rules.
 3. **ADF** — only use `ConvertTo-ADF`/`ConvertFrom-ADF` for Cloud
 4. **REST calls** — always go through `Invoke-JiraMethod`
 5. **Tests required** — every function needs `.Unit.Tests.ps1`
-6. **Build before unit tests** — run `Invoke-Build -Task Build` and execute unit tests from `./Release/Tests/**`
+6. **Single-test loop** — run individual unit tests directly with `Invoke-Pester Tests/**`; use `Invoke-Build -Task Build, Test` for full-suite validation
 
 For full rules, read `.github/ai-context/powershell-rules.md`.

--- a/.github/instructions/jira-api-compatibility.instructions.md
+++ b/.github/instructions/jira-api-compatibility.instructions.md
@@ -15,5 +15,6 @@ This file applies to all `.ps1` files. It references shared rules.
 3. **ADF** — only use `ConvertTo-ADF`/`ConvertFrom-ADF` for Cloud
 4. **REST calls** — always go through `Invoke-JiraMethod`
 5. **Tests required** — every function needs `.Unit.Tests.ps1`
+6. **Build before unit tests** — run `Invoke-Build -Task Build` and execute unit tests from `./Release/Tests/**`
 
 For full rules, read `.github/ai-context/powershell-rules.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -331,29 +331,32 @@ See [`powershell-rules.md` → Running Tests](.github/ai-context/powershell-rule
 | What you changed | Test command |
 |------------------|--------------|
 | **Any code file** (`.ps1`, `.psm1`) | `Invoke-Build -Task Lint` |
-| **Function** in `JiraPS/Public/` | `Invoke-Pester Tests/Functions/Public/<FunctionName>.Unit.Tests.ps1` |
-| **Function** in `JiraPS/Private/` | `Invoke-Pester Tests/Functions/Private/<FunctionName>.Unit.Tests.ps1` |
-| **Test file** in `Tests/` | `Invoke-Pester <path-to-that-test-file>` |
-| **Documentation** in `docs/**` | `Invoke-Pester Tests/Help.Tests.ps1` |
+| **Function** in `JiraPS/Public/` | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/Functions/Public/<FunctionName>.Unit.Tests.ps1` |
+| **Function** in `JiraPS/Private/` | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/Functions/Private/<FunctionName>.Unit.Tests.ps1` |
+| **Test file** in `Tests/` | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/<path-under-Tests>` |
+| **Documentation** in `docs/**` | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/Help.Tests.ps1` |
 
 **Examples:**
 
 ```powershell
 # After editing JiraPS/Public/Get-JiraIssue.ps1
 Invoke-Build -Task Lint
-Invoke-Pester Tests/Functions/Public/Get-JiraIssue.Unit.Tests.ps1
+Invoke-Build -Task Build
+Invoke-Pester ./Release/Tests/Functions/Public/Get-JiraIssue.Unit.Tests.ps1
 
 # After editing docs/en-US/commands/Get-JiraIssue.md
 Invoke-Build -Task Lint
-Invoke-Pester Tests/Help.Tests.ps1
+Invoke-Build -Task Build
+Invoke-Pester ./Release/Tests/Help.Tests.ps1
 
 # After editing a test file
 Invoke-Build -Task Lint
-Invoke-Pester Tests/Functions/Public/Get-JiraIssue.Unit.Tests.ps1
+Invoke-Build -Task Build
+Invoke-Pester ./Release/Tests/Functions/Public/Get-JiraIssue.Unit.Tests.ps1
 ```
 
 **Why localized tests?**
-- Faster feedback loop — no need to build the entire module for linting or docs
+- Faster feedback loop than running the full `Invoke-Build -Task Build, Test` suite every time
 - `Invoke-Build -Task Lint` runs PSScriptAnalyzer to catch code issues early
 - `Style.Tests.ps1` (encoding, whitespace, line endings) runs with the full test suite
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,8 @@
 ./Tools/setup.ps1
 Invoke-Build -Task Build, Test
 ```
-Tests run against the built module in `Release/` — you must build before testing.
+Use `Invoke-Build -Task Build, Test` as the full-suite validation gate.
+For single unit-test iteration, run `Invoke-Pester` directly against `Tests/...`.
 
 ### Backlog Handling
 - **Out-of-scope ideas go on the board, not into the current PR.**
@@ -300,8 +301,8 @@ Private functions in `JiraPS/Private/` may use minimal comment-based help (`.SYN
 
 ### Build Process
 
-> **IMPORTANT**: Unit tests run against the *built* module in `Release/`, not the source files.
-> You MUST build before running unit tests.
+> **IMPORTANT**: Use `Invoke-Pester` directly for focused single unit-test loops.
+> Use `Invoke-Build -Task Build, Test` as the full-suite validation gate before commit.
 >
 > Integration tests run directly against `JiraPS/JiraPS.psd1` (no build step) and require live Jira Cloud credentials.
 > macOS and Linux contributors cannot execute the Windows PowerShell 5.1 lane locally, so treat that CI lane as a required pre-merge gate.
@@ -331,28 +332,25 @@ See [`powershell-rules.md` → Running Tests](.github/ai-context/powershell-rule
 | What you changed | Test command |
 |------------------|--------------|
 | **Any code file** (`.ps1`, `.psm1`) | `Invoke-Build -Task Lint` |
-| **Function** in `JiraPS/Public/` | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/Functions/Public/<FunctionName>.Unit.Tests.ps1` |
-| **Function** in `JiraPS/Private/` | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/Functions/Private/<FunctionName>.Unit.Tests.ps1` |
-| **Test file** in `Tests/` | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/<path-under-Tests>` |
-| **Documentation** in `docs/**` | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/Help.Tests.ps1` |
+| **Function** in `JiraPS/Public/` | `Invoke-Pester Tests/Functions/Public/<FunctionName>.Unit.Tests.ps1` |
+| **Function** in `JiraPS/Private/` | `Invoke-Pester Tests/Functions/Private/<FunctionName>.Unit.Tests.ps1` |
+| **Test file** in `Tests/` | `Invoke-Pester <path-to-that-test-file>` |
+| **Documentation** in `docs/**` | `Invoke-Pester Tests/Help.Tests.ps1` |
 
 **Examples:**
 
 ```powershell
 # After editing JiraPS/Public/Get-JiraIssue.ps1
 Invoke-Build -Task Lint
-Invoke-Build -Task Build
-Invoke-Pester ./Release/Tests/Functions/Public/Get-JiraIssue.Unit.Tests.ps1
+Invoke-Pester Tests/Functions/Public/Get-JiraIssue.Unit.Tests.ps1
 
 # After editing docs/en-US/commands/Get-JiraIssue.md
 Invoke-Build -Task Lint
-Invoke-Build -Task Build
-Invoke-Pester ./Release/Tests/Help.Tests.ps1
+Invoke-Pester Tests/Help.Tests.ps1
 
 # After editing a test file
 Invoke-Build -Task Lint
-Invoke-Build -Task Build
-Invoke-Pester ./Release/Tests/Functions/Public/Get-JiraIssue.Unit.Tests.ps1
+Invoke-Pester Tests/Functions/Public/Get-JiraIssue.Unit.Tests.ps1
 ```
 
 **Why localized tests?**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,20 +13,19 @@ Claude Code reads this file as its preferred entry point.
 3. **User Identity** — `accountId` for Cloud, `username`/`name` for DC
 4. **REST calls** — always go through `Invoke-JiraMethod`
 5. **Tests required** — every function needs `.Unit.Tests.ps1`
-6. **Build before test** — `Invoke-Build -Task Build, Test` (tests run against `Release/`, not source)
+6. **Full-suite validation** — `Invoke-Build -Task Build, Test` before commit
 
 ## Testing During Development
 
 Run the appropriate tests after every change.
-Unit tests should run against `Release/Tests/`, not source paths.
 
 | What you changed | Test command |
 |------------------|--------------|
 | **Any code file** | `Invoke-Build -Task Lint` |
-| **Function** in `JiraPS/Public/` | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/Functions/Public/<FunctionName>.Unit.Tests.ps1` |
-| **Function** in `JiraPS/Private/` | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/Functions/Private/<FunctionName>.Unit.Tests.ps1` |
-| **Test file** | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/<path-under-Tests>` |
-| **Docs** in `docs/**` | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/Help.Tests.ps1` |
+| **Function** in `JiraPS/Public/` | `Invoke-Pester Tests/Functions/Public/<FunctionName>.Unit.Tests.ps1` |
+| **Function** in `JiraPS/Private/` | `Invoke-Pester Tests/Functions/Private/<FunctionName>.Unit.Tests.ps1` |
+| **Test file** | `Invoke-Pester <path-to-that-test-file>` |
+| **Docs** in `docs/**` | `Invoke-Pester Tests/Help.Tests.ps1` |
 
 **Before committing**: Run full `Invoke-Build -Task Build, Test`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,15 +17,16 @@ Claude Code reads this file as its preferred entry point.
 
 ## Testing During Development
 
-Run the appropriate tests after every change:
+Run the appropriate tests after every change.
+Unit tests should run against `Release/Tests/`, not source paths.
 
 | What you changed | Test command |
 |------------------|--------------|
 | **Any code file** | `Invoke-Build -Task Lint` |
-| **Function** in `JiraPS/Public/` | `Invoke-Pester Tests/Functions/Public/<FunctionName>.Unit.Tests.ps1` |
-| **Function** in `JiraPS/Private/` | `Invoke-Pester Tests/Functions/Private/<FunctionName>.Unit.Tests.ps1` |
-| **Test file** | `Invoke-Pester <path-to-that-test-file>` |
-| **Docs** in `docs/**` | `Invoke-Pester Tests/Help.Tests.ps1` |
+| **Function** in `JiraPS/Public/` | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/Functions/Public/<FunctionName>.Unit.Tests.ps1` |
+| **Function** in `JiraPS/Private/` | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/Functions/Private/<FunctionName>.Unit.Tests.ps1` |
+| **Test file** | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/<path-under-Tests>` |
+| **Docs** in `docs/**` | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/Help.Tests.ps1` |
 
 **Before committing**: Run full `Invoke-Build -Task Build, Test`.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -17,15 +17,16 @@ Antigravity reads this file (named `GEMINI.md` by convention) as its preferred e
 
 ## Testing During Development
 
-Run the appropriate tests after every change:
+Run the appropriate tests after every change.
+Unit tests should run against `Release/Tests/`, not source paths.
 
 | What you changed | Test command |
 |------------------|--------------|
 | **Any code file** | `Invoke-Build -Task Lint` |
-| **Function** in `JiraPS/Public/` | `Invoke-Pester Tests/Functions/Public/<FunctionName>.Unit.Tests.ps1` |
-| **Function** in `JiraPS/Private/` | `Invoke-Pester Tests/Functions/Private/<FunctionName>.Unit.Tests.ps1` |
-| **Test file** | `Invoke-Pester <path-to-that-test-file>` |
-| **Docs** in `docs/**` | `Invoke-Pester Tests/Help.Tests.ps1` |
+| **Function** in `JiraPS/Public/` | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/Functions/Public/<FunctionName>.Unit.Tests.ps1` |
+| **Function** in `JiraPS/Private/` | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/Functions/Private/<FunctionName>.Unit.Tests.ps1` |
+| **Test file** | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/<path-under-Tests>` |
+| **Docs** in `docs/**` | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/Help.Tests.ps1` |
 
 **Before committing**: Run full `Invoke-Build -Task Build, Test`.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -13,20 +13,19 @@ Antigravity reads this file (named `GEMINI.md` by convention) as its preferred e
 3. **User Identity** — `accountId` for Cloud, `username`/`name` for DC
 4. **REST calls** — always go through `Invoke-JiraMethod`
 5. **Tests required** — every function needs `.Unit.Tests.ps1`
-6. **Build before test** — `Invoke-Build -Task Build, Test` (tests run against `Release/`, not source)
+6. **Full-suite validation** — `Invoke-Build -Task Build, Test` before commit
 
 ## Testing During Development
 
 Run the appropriate tests after every change.
-Unit tests should run against `Release/Tests/`, not source paths.
 
 | What you changed | Test command |
 |------------------|--------------|
 | **Any code file** | `Invoke-Build -Task Lint` |
-| **Function** in `JiraPS/Public/` | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/Functions/Public/<FunctionName>.Unit.Tests.ps1` |
-| **Function** in `JiraPS/Private/` | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/Functions/Private/<FunctionName>.Unit.Tests.ps1` |
-| **Test file** | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/<path-under-Tests>` |
-| **Docs** in `docs/**` | `Invoke-Build -Task Build; Invoke-Pester ./Release/Tests/Help.Tests.ps1` |
+| **Function** in `JiraPS/Public/` | `Invoke-Pester Tests/Functions/Public/<FunctionName>.Unit.Tests.ps1` |
+| **Function** in `JiraPS/Private/` | `Invoke-Pester Tests/Functions/Private/<FunctionName>.Unit.Tests.ps1` |
+| **Test file** | `Invoke-Pester <path-to-that-test-file>` |
+| **Docs** in `docs/**` | `Invoke-Pester Tests/Help.Tests.ps1` |
 
 **Before committing**: Run full `Invoke-Build -Task Build, Test`.
 


### PR DESCRIPTION
## Summary
- resolve instruction contradictions around unit-test execution paths
- align AGENTS.md, entrypoint files, and PowerShell rules on Release-based test flow
- update Jira API compatibility instruction quick rule for build-before-unit-test

## Validation
- ./Tools/setup.ps1
- Invoke-Build -Task Build, Test

## Notes
- Instruction-only update focused on consistency and correctness.