### PR TITLE
Add website docs indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,12 @@ And once installed, you will be prompted to "Reopen in Container".
 
 ## Tested on
 
-* Windows Powershell v5.1
-* Powershell Core (latest) on Windows
-* Powershell Core (latest) on Ubuntu
-* Powershell Core (latest) on MacOS
+| Configuration | Status |
+| ------------- | ------ |
+| Windows PowerShell v5.1 | [CI workflow](https://github.com/AtlassianPS/JiraPS/actions/workflows/ci.yml) |
+| PowerShell 7 on Windows | [CI workflow](https://github.com/AtlassianPS/JiraPS/actions/workflows/ci.yml) |
+| PowerShell 7 on Ubuntu | [CI workflow](https://github.com/AtlassianPS/JiraPS/actions/workflows/ci.yml) |
+| PowerShell 7 on macOS | [CI workflow](https://github.com/AtlassianPS/JiraPS/actions/workflows/ci.yml) |
 
 ## Acknowledgements
 
@@ -113,4 +115,4 @@ Hopefully this is obvious, but:
   [Submit an Issue]: https://github.com/AtlassianPS/JiraPS/issues/new
   [replicaJunction]: https://github.com/replicaJunction
   [MIT license]: https://github.com/AtlassianPS/JiraPS/blob/master/LICENSE
-  [Contributing]: http://atlassianps.org/docs/Contributing
+  [Contributing]: https://atlassianps.org/docs/Contributing/

--- a/docs/en-US/commands/index.md
+++ b/docs/en-US/commands/index.md
@@ -3,3 +3,79 @@ layout: documentation
 permalink: /docs/JiraPS/commands/
 hide: true
 ---
+# JiraPS commands
+
+JiraPS exports these commands directly without an additional default command prefix.
+
+| Command | Documentation |
+|---|---|
+| `Add-JiraFilterPermission` | [Add-JiraFilterPermission](/docs/JiraPS/commands/Add-JiraFilterPermission/) |
+| `Add-JiraGroupMember` | [Add-JiraGroupMember](/docs/JiraPS/commands/Add-JiraGroupMember/) |
+| `Add-JiraIssueAttachment` | [Add-JiraIssueAttachment](/docs/JiraPS/commands/Add-JiraIssueAttachment/) |
+| `Add-JiraIssueComment` | [Add-JiraIssueComment](/docs/JiraPS/commands/Add-JiraIssueComment/) |
+| `Add-JiraIssueLink` | [Add-JiraIssueLink](/docs/JiraPS/commands/Add-JiraIssueLink/) |
+| `Add-JiraIssueWatcher` | [Add-JiraIssueWatcher](/docs/JiraPS/commands/Add-JiraIssueWatcher/) |
+| `Add-JiraIssueWorklog` | [Add-JiraIssueWorklog](/docs/JiraPS/commands/Add-JiraIssueWorklog/) |
+| `Clear-JiraCache` | [Clear-JiraCache](/docs/JiraPS/commands/Clear-JiraCache/) |
+| `ConvertFrom-AtlassianDocumentFormat` | [ConvertFrom-AtlassianDocumentFormat](/docs/JiraPS/commands/ConvertFrom-AtlassianDocumentFormat/) |
+| `ConvertTo-AtlassianDocumentFormat` | [ConvertTo-AtlassianDocumentFormat](/docs/JiraPS/commands/ConvertTo-AtlassianDocumentFormat/) |
+| `ConvertTo-JiraTable` | [ConvertTo-JiraTable](/docs/JiraPS/commands/ConvertTo-JiraTable/) |
+| `Find-JiraFilter` | [Find-JiraFilter](/docs/JiraPS/commands/Find-JiraFilter/) |
+| `Get-JiraComponent` | [Get-JiraComponent](/docs/JiraPS/commands/Get-JiraComponent/) |
+| `Get-JiraConfigServer` | [Get-JiraConfigServer](/docs/JiraPS/commands/Get-JiraConfigServer/) |
+| `Get-JiraField` | [Get-JiraField](/docs/JiraPS/commands/Get-JiraField/) |
+| `Get-JiraFilter` | [Get-JiraFilter](/docs/JiraPS/commands/Get-JiraFilter/) |
+| `Get-JiraFilterPermission` | [Get-JiraFilterPermission](/docs/JiraPS/commands/Get-JiraFilterPermission/) |
+| `Get-JiraGroup` | [Get-JiraGroup](/docs/JiraPS/commands/Get-JiraGroup/) |
+| `Get-JiraGroupMember` | [Get-JiraGroupMember](/docs/JiraPS/commands/Get-JiraGroupMember/) |
+| `Get-JiraIssue` | [Get-JiraIssue](/docs/JiraPS/commands/Get-JiraIssue/) |
+| `Get-JiraIssueAttachment` | [Get-JiraIssueAttachment](/docs/JiraPS/commands/Get-JiraIssueAttachment/) |
+| `Get-JiraIssueAttachmentFile` | [Get-JiraIssueAttachmentFile](/docs/JiraPS/commands/Get-JiraIssueAttachmentFile/) |
+| `Get-JiraIssueComment` | [Get-JiraIssueComment](/docs/JiraPS/commands/Get-JiraIssueComment/) |
+| `Get-JiraIssueCreateMetadata` | [Get-JiraIssueCreateMetadata](/docs/JiraPS/commands/Get-JiraIssueCreateMetadata/) |
+| `Get-JiraIssueEditMetadata` | [Get-JiraIssueEditMetadata](/docs/JiraPS/commands/Get-JiraIssueEditMetadata/) |
+| `Get-JiraIssueLink` | [Get-JiraIssueLink](/docs/JiraPS/commands/Get-JiraIssueLink/) |
+| `Get-JiraIssueLinkType` | [Get-JiraIssueLinkType](/docs/JiraPS/commands/Get-JiraIssueLinkType/) |
+| `Get-JiraIssueType` | [Get-JiraIssueType](/docs/JiraPS/commands/Get-JiraIssueType/) |
+| `Get-JiraIssueWatcher` | [Get-JiraIssueWatcher](/docs/JiraPS/commands/Get-JiraIssueWatcher/) |
+| `Get-JiraIssueWorklog` | [Get-JiraIssueWorklog](/docs/JiraPS/commands/Get-JiraIssueWorklog/) |
+| `Get-JiraPriority` | [Get-JiraPriority](/docs/JiraPS/commands/Get-JiraPriority/) |
+| `Get-JiraProject` | [Get-JiraProject](/docs/JiraPS/commands/Get-JiraProject/) |
+| `Get-JiraRemoteLink` | [Get-JiraRemoteLink](/docs/JiraPS/commands/Get-JiraRemoteLink/) |
+| `Get-JiraResponseHeaderLogConfiguration` | [Get-JiraResponseHeaderLogConfiguration](/docs/JiraPS/commands/Get-JiraResponseHeaderLogConfiguration/) |
+| `Get-JiraServerInformation` | [Get-JiraServerInformation](/docs/JiraPS/commands/Get-JiraServerInformation/) |
+| `Get-JiraSession` | [Get-JiraSession](/docs/JiraPS/commands/Get-JiraSession/) |
+| `Get-JiraStatus` | [Get-JiraStatus](/docs/JiraPS/commands/Get-JiraStatus/) |
+| `Get-JiraUser` | [Get-JiraUser](/docs/JiraPS/commands/Get-JiraUser/) |
+| `Get-JiraVersion` | [Get-JiraVersion](/docs/JiraPS/commands/Get-JiraVersion/) |
+| `Invoke-JiraIssueTransition` | [Invoke-JiraIssueTransition](/docs/JiraPS/commands/Invoke-JiraIssueTransition/) |
+| `Invoke-JiraMethod` | [Invoke-JiraMethod](/docs/JiraPS/commands/Invoke-JiraMethod/) |
+| `Move-JiraVersion` | [Move-JiraVersion](/docs/JiraPS/commands/Move-JiraVersion/) |
+| `New-JiraFilter` | [New-JiraFilter](/docs/JiraPS/commands/New-JiraFilter/) |
+| `New-JiraGroup` | [New-JiraGroup](/docs/JiraPS/commands/New-JiraGroup/) |
+| `New-JiraIssue` | [New-JiraIssue](/docs/JiraPS/commands/New-JiraIssue/) |
+| `New-JiraIssueLinkRequest` | [New-JiraIssueLinkRequest](/docs/JiraPS/commands/New-JiraIssueLinkRequest/) |
+| `New-JiraSession` | [New-JiraSession](/docs/JiraPS/commands/New-JiraSession/) |
+| `New-JiraUser` | [New-JiraUser](/docs/JiraPS/commands/New-JiraUser/) |
+| `New-JiraVersion` | [New-JiraVersion](/docs/JiraPS/commands/New-JiraVersion/) |
+| `Remove-JiraFilter` | [Remove-JiraFilter](/docs/JiraPS/commands/Remove-JiraFilter/) |
+| `Remove-JiraFilterPermission` | [Remove-JiraFilterPermission](/docs/JiraPS/commands/Remove-JiraFilterPermission/) |
+| `Remove-JiraGroup` | [Remove-JiraGroup](/docs/JiraPS/commands/Remove-JiraGroup/) |
+| `Remove-JiraGroupMember` | [Remove-JiraGroupMember](/docs/JiraPS/commands/Remove-JiraGroupMember/) |
+| `Remove-JiraIssue` | [Remove-JiraIssue](/docs/JiraPS/commands/Remove-JiraIssue/) |
+| `Remove-JiraIssueAttachment` | [Remove-JiraIssueAttachment](/docs/JiraPS/commands/Remove-JiraIssueAttachment/) |
+| `Remove-JiraIssueLink` | [Remove-JiraIssueLink](/docs/JiraPS/commands/Remove-JiraIssueLink/) |
+| `Remove-JiraIssueWatcher` | [Remove-JiraIssueWatcher](/docs/JiraPS/commands/Remove-JiraIssueWatcher/) |
+| `Remove-JiraRemoteLink` | [Remove-JiraRemoteLink](/docs/JiraPS/commands/Remove-JiraRemoteLink/) |
+| `Remove-JiraSession` | [Remove-JiraSession](/docs/JiraPS/commands/Remove-JiraSession/) |
+| `Remove-JiraUser` | [Remove-JiraUser](/docs/JiraPS/commands/Remove-JiraUser/) |
+| `Remove-JiraVersion` | [Remove-JiraVersion](/docs/JiraPS/commands/Remove-JiraVersion/) |
+| `Set-JiraConfigServer` | [Set-JiraConfigServer](/docs/JiraPS/commands/Set-JiraConfigServer/) |
+| `Set-JiraFilter` | [Set-JiraFilter](/docs/JiraPS/commands/Set-JiraFilter/) |
+| `Set-JiraIssue` | [Set-JiraIssue](/docs/JiraPS/commands/Set-JiraIssue/) |
+| `Set-JiraIssueLabel` | [Set-JiraIssueLabel](/docs/JiraPS/commands/Set-JiraIssueLabel/) |
+| `Set-JiraResponseHeaderLogConfiguration` | [Set-JiraResponseHeaderLogConfiguration](/docs/JiraPS/commands/Set-JiraResponseHeaderLogConfiguration/) |
+| `Set-JiraUser` | [Set-JiraUser](/docs/JiraPS/commands/Set-JiraUser/) |
+| `Set-JiraVersion` | [Set-JiraVersion](/docs/JiraPS/commands/Set-JiraVersion/) |
+
+For conceptual documentation, see the [JiraPS about topics](/docs/JiraPS/about/).

--- a/docs/en-US/index.md
+++ b/docs/en-US/index.md
@@ -3,3 +3,16 @@ layout: documentation
 permalink: /docs/JiraPS/about/
 hide: true
 ---
+# JiraPS about topics
+
+JiraPS provides conceptual help for authentication, issue workflows, custom fields, type migration, and classes.
+
+| Topic | Documentation |
+|---|---|
+| `about_JiraPS` | [JiraPS overview](/docs/JiraPS/) |
+| `about_JiraPS_Authentication` | [Authentication](/docs/JiraPS/about/authentication.html) |
+| `about_JiraPS_Classes` | [Classes](/docs/JiraPS/about/classes.html) |
+| `about_JiraPS_CreatingIssues` | [Creating Issues](/docs/JiraPS/about/creating-issues.html) |
+| `about_JiraPS_CustomFields` | [Custom Fields](/docs/JiraPS/about/custom-fields.html) |
+| `about_JiraPS_MigrationV3` | [Migration to v3](/docs/JiraPS/about/migration-v3.html) |
+| `about_JiraPS_UpdatingIssues` | [Updating Issues](/docs/JiraPS/about/updating-issues.html) |


### PR DESCRIPTION
## Summary
- populate JiraPS docs root with the module about-topic index
- populate the command index for website rendering
- normalize README contributing link and tested platform table

## Validation
- `./Tools/setup.ps1` passed with longer timeout after initial local timeouts
- `Invoke-Pester -Path Tests/Help.Tests.ps1` passed: 340 passed, 816 skipped\n- `Invoke-Build -Task Build, Test` passed: 4551 passed, 69 skipped, 252 not run