### PR TITLE
docs: improve website reference navigation

### DIFF
--- a/docs/en-US/about_JiraPS_Authentication.md
+++ b/docs/en-US/about_JiraPS_Authentication.md
@@ -1,6 +1,7 @@
 ---
 locale: en-US
 layout: documentation
+title: Authentication
 online version: https://atlassianps.org/docs/JiraPS/about/authentication.html
 Module Name: JiraPS
 permalink: /docs/JiraPS/about/authentication.html

--- a/docs/en-US/commands/Get-JiraIssueAttachment.md
+++ b/docs/en-US/commands/Get-JiraIssueAttachment.md
@@ -143,7 +143,7 @@ If neither are supplied, this function will run with anonymous access to JIRA.
 
 ## RELATED LINKS
 
-[Get-JiraAttachmentFile](../Get-JiraAttachmentFile/)
+[Get-JiraAttachmentFile](../Get-JiraIssueAttachmentFile/)
 
 [Add-JiraIssueAttachment](../Add-JiraIssueAttachment/)
 

--- a/docs/en-US/commands/Get-JiraIssueAttachmentFile.md
+++ b/docs/en-US/commands/Get-JiraIssueAttachmentFile.md
@@ -148,10 +148,10 @@ If neither are supplied, this function will run with anonymous access to JIRA.
 
 ## RELATED LINKS
 
-[Get-JiraAttachment](../Get-JiraAttachmentFile/)
+[Get-JiraAttachment](../Get-JiraIssueAttachmentFile/)
 
-[Add-JiraIssueAttachmentFile](../Add-JiraIssueAttachmentFile/)
+[Add-JiraIssueAttachmentFile](../Add-JiraIssueAttachment/)
 
 [Get-JiraIssue](../Get-JiraIssue/)
 
-[Remove-JiraIssueAttachmentFile](../Remove-JiraIssueAttachmentFile/)
+[Remove-JiraIssueAttachmentFile](../Remove-JiraIssueAttachment/)

--- a/docs/en-US/commands/Set-JiraConfigServer.md
+++ b/docs/en-US/commands/Set-JiraConfigServer.md
@@ -79,6 +79,6 @@ This can be tracked in [JiraPS#194](https://github.com/AtlassianPS/JiraPS/issues
 
 ## RELATED LINKS
 
-[about_JiraPS_Authentication](../../about/authentication/)
+[about_JiraPS_Authentication](../../about/authentication.html)
 
 [Get-JiraConfigServer](../Get-JiraConfigServer/)

--- a/docs/en-US/commands/index.md
+++ b/docs/en-US/commands/index.md
@@ -1,7 +1,6 @@
 ---
 layout: documentation
 permalink: /docs/JiraPS/commands/
-hide: true
 ---
 # JiraPS commands
 


### PR DESCRIPTION
## Summary
- expose JiraPS guide links from the module overview
- expose the command index for generated website docs
- fix generated related links for attachment and authentication docs
- add the missing Authentication page title

## Validation
- documentation-only change
- validated through the AtlassianPS.github.io generated-site layout and link audits