### PR TITLE
Clarify copyright attribution and origin year

### DIFF
--- a/JiraPS.build.ps1
+++ b/JiraPS.build.ps1
@@ -209,6 +209,7 @@ Task Test {
             -ExcludeTag $ExcludeTag `
             -DefaultExcludeTag @('Integration') `
             -MinimumPesterVersion ([Version]'5.7.0') `
+            -MaximumPesterVersion ([Version]'5.7.999') `
             -ResultOutputPath (Join-Path $env:BHProjectPath "Test-$resultName.xml")
     }
 }

--- a/JiraPS/JiraPS.psd1
+++ b/JiraPS/JiraPS.psd1
@@ -19,7 +19,7 @@
     CompanyName          = 'AtlassianPS.org'
 
     # Copyright statement for this module
-    Copyright            = '(c) 2017 AtlassianPS. All rights reserved.'
+    Copyright            = '(c) 2015 AtlassianPS contributors.'
 
     # Description of the functionality provided by this module
     Description          = 'Windows PowerShell module to interact with Atlassian JIRA'

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017 AtlassianPS
+Copyright (c) 2015 AtlassianPS contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

- attribute first-party work to `AtlassianPS contributors`
- use 2015, when the repository's source history begins
- align the module manifest with the license notice
- remove the misleading `All rights reserved` wording from MIT-licensed metadata

## Relicensing scope

This PR does not establish or document contributor consent for the 2017 GPLv3-to-MIT change. It only corrects the current copyright metadata. The historical relicensing question remains separate and unresolved.

## Validation

- `Test-ModuleManifest`
- `Invoke-Build -Task Build, Test` — all unit, help, project, build, and style suites passed
