### PR TITLE
Upgrade test infrastructure to Pester 5.9.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Standardized lint, unit, and integration test execution on Pester 5.9.x, using 5.9.0 as the clean-install baseline and 5.9.999 as the upper compatibility bound.
 - Stabilized the Server integration `Search.Integration.Tests.ps1` OR-operator case by replacing the non-existent-key branch with a deterministic project-scoped OR predicate (`key = <fixture> OR key != <fixture>`), avoiding an intermittent Jira 11 backend null-deref (`issueObject` null) that failed nightly `integration_tests.yml` runs even when JiraPS behavior was correct.
 - Updated JiraPS shared standards dependency pins to `AtlassianPS.Standards` `0.1.11`, with scripts resolving the required standards version from `Tools/build.requirements.psd1`, validating PSGallery availability across runtimes, running NuGet/PSGallery trust preflight only on Windows PowerShell (Desktop), and then using direct `Install-Module`/`Import-Module` bootstrap before delegating to shared commands (`Tools/update.dependencies.ps1` now honors `-WhatIf` before any bootstrap side effects).
 - Replaced duplicated JiraPS build/test helper internals with shared `AtlassianPS.Standards` primitives for external help generation, orphaned help cleanup, package validation, `.env` loading, and source/release test module resolution.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ For detailed information about writing and debugging tests, see the **[Testing G
 
 Key highlights:
 
-- JiraPS uses **Pester v5.7+** for unit testing
+- JiraPS uses **Pester 5.9.x** for unit testing
 - All tests follow a consistent structure with Context blocks
 - **Test organization**: Tests mirror the module structure
   - `Tests/Functions/Public/` - Public CRUD functions

--- a/JiraPS.build.ps1
+++ b/JiraPS.build.ps1
@@ -92,14 +92,38 @@ Task Lint {
         "$env:BHProjectPath/JiraPS.build.ps1"
     )
 
-    $null = Invoke-AtlassianPSLint `
-        -ProjectPath $env:BHProjectPath `
-        -ModulePath $env:BHModulePath `
-        -BuildScriptPath "$env:BHProjectPath/JiraPS.build.ps1" `
-        -StyleTestPath "$env:BHProjectPath/Tests/Style.Tests.ps1" `
-        -AnalyzerPaths $analyzerPaths `
-        -PesterVerbosity $PesterVerbosity `
-        -Severity @('Error', 'Warning')
+    $lintFailures = @()
+    try {
+        $null = Invoke-AtlassianPSModuleTests `
+            -TestPath "$env:BHProjectPath/Tests/Style.Tests.ps1" `
+            -PesterVerbosity $PesterVerbosity `
+            -MinimumPesterVersion ([Version]'5.9.0') `
+            -MaximumPesterVersion ([Version]'5.9.999')
+    }
+    catch {
+        $lintFailures += $_.Exception.Message
+    }
+
+    Import-JiraPSStandard
+    try {
+        $null = Invoke-AtlassianPSLint `
+            -ProjectPath $env:BHProjectPath `
+            -ModulePath $env:BHModulePath `
+            -BuildScriptPath "$env:BHProjectPath/JiraPS.build.ps1" `
+            -StyleTestPath "$env:BHProjectPath/Tests/Style.Tests.ps1" `
+            -AnalyzerPaths $analyzerPaths `
+            -PesterVerbosity $PesterVerbosity `
+            -Severity @('Error', 'Warning') `
+            -SkipStyleTests
+    }
+    catch {
+        $lintFailures += $_.Exception.Message
+    }
+
+    Import-JiraPSStandard
+    if ($lintFailures.Count -gt 0) {
+        throw ("Lint failed:`n  - " + ($lintFailures -join "`n  - "))
+    }
 }
 
 Task Clean {
@@ -199,6 +223,9 @@ Task Test {
         Where-Object { $_.PSIsContainer -or $_.Name -like '*.Tests.ps1' } |
         Select-Object -ExpandProperty FullName
 
+    Get-Module Pester | Remove-Module -Force -ErrorAction SilentlyContinue
+    Import-Module Pester -MinimumVersion '5.9.0' -MaximumVersion '5.9.999' -Global -Force -ErrorAction Stop
+
     foreach ($testPath in $testPaths) {
         $resultName = (Split-Path -Path $testPath -Leaf) -replace '[^A-Za-z0-9._-]', '-'
         Import-JiraPSStandard
@@ -208,8 +235,8 @@ Task Test {
             -Tag $Tag `
             -ExcludeTag $ExcludeTag `
             -DefaultExcludeTag @('Integration') `
-            -MinimumPesterVersion ([Version]'5.7.0') `
-            -MaximumPesterVersion ([Version]'5.7.999') `
+            -MinimumPesterVersion ([Version]'5.9.0') `
+            -MaximumPesterVersion ([Version]'5.9.999') `
             -ResultOutputPath (Join-Path $env:BHProjectPath "Test-$resultName.xml")
     }
 }

--- a/Tests/Build.Tests.ps1
+++ b/Tests/Build.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "Validation of build environment" -Tag Unit {
     BeforeAll {

--- a/Tests/Examples.Tests.ps1
+++ b/Tests/Examples.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/Helpers/TestTools.ps1"

--- a/Tests/Functions/Classes/AtlassianPS.JiraPS.Types.Unit.Tests.ps1
+++ b/Tests/Functions/Classes/AtlassianPS.JiraPS.Types.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Classes/ConvertTo-Jira.Roundtrip.Unit.Tests.ps1
+++ b/Tests/Functions/Classes/ConvertTo-Jira.Roundtrip.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/.template.ps1
+++ b/Tests/Functions/Private/.template.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertFrom-URLEncoded.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertFrom-URLEncoded.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-GetParameter.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-GetParameter.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraAttachment.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraAttachment.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraComment.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraComment.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraComponent.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraComponent.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraCreateMetaField.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraCreateMetaField.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraEditMetaField.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraEditMetaField.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraField.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraField.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraFieldAssignment.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraFieldAssignment.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraFilter.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraFilter.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraFilterPermission.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraFilterPermission.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraGroup.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraGroup.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraIssue.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraIssue.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraIssueHistoryEntry.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraIssueHistoryEntry.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraIssueLink.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraIssueLink.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraIssueLinkType.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraIssueLinkType.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraIssueType.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraIssueType.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraLink.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraLink.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraPriority.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraPriority.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraProject.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraProject.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraProjectRole.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraProjectRole.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraRestApiV3Url.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraRestApiV3Url.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraScalarValue.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraScalarValue.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraServerInfo.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraServerInfo.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraSession.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraSession.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraStatus.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraStatus.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraTransition.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraTransition.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraUser.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraUser.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraVersion.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraVersion.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-JiraWorklogitem.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-JiraWorklogitem.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-ParameterHash.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-ParameterHash.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/ConvertTo-URLEncoded.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-URLEncoded.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/Get-JiraCachedResponse.Unit.Tests.ps1
+++ b/Tests/Functions/Private/Get-JiraCachedResponse.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/Invoke-JiraWebRequestSafely.Unit.Tests.ps1
+++ b/Tests/Functions/Private/Invoke-JiraWebRequestSafely.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/Invoke-PaginatedRequest.Unit.Tests.ps1
+++ b/Tests/Functions/Private/Invoke-PaginatedRequest.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/New-JiraWebRequestSplat.Unit.Tests.ps1
+++ b/Tests/Functions/Private/New-JiraWebRequestSplat.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/Resolve-ErrorWebResponse.Unit.Tests.ps1
+++ b/Tests/Functions/Private/Resolve-ErrorWebResponse.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/Resolve-JiraField.Unit.Tests.ps1
+++ b/Tests/Functions/Private/Resolve-JiraField.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/Resolve-JiraGroupPayload.Unit.Tests.ps1
+++ b/Tests/Functions/Private/Resolve-JiraGroupPayload.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/Resolve-JiraRequestContext.Unit.Tests.ps1
+++ b/Tests/Functions/Private/Resolve-JiraRequestContext.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/Resolve-JiraTextFieldPayload.Unit.Tests.ps1
+++ b/Tests/Functions/Private/Resolve-JiraTextFieldPayload.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/Resolve-JiraUserPayload.Unit.Tests.ps1
+++ b/Tests/Functions/Private/Resolve-JiraUserPayload.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/Resolve-JiraWebResponse.Unit.Tests.ps1
+++ b/Tests/Functions/Private/Resolve-JiraWebResponse.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/Set-JiraCachedResponse.Unit.Tests.ps1
+++ b/Tests/Functions/Private/Set-JiraCachedResponse.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/Test-JiraResponseHeaderMatch.Unit.Tests.ps1
+++ b/Tests/Functions/Private/Test-JiraResponseHeaderMatch.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/Test-JiraRichTextField.Unit.Tests.ps1
+++ b/Tests/Functions/Private/Test-JiraRichTextField.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/Test-ServerResponse.Unit.Tests.ps1
+++ b/Tests/Functions/Private/Test-ServerResponse.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Private/Write-JiraResponseHeaderLog.Unit.Tests.ps1
+++ b/Tests/Functions/Private/Write-JiraResponseHeaderLog.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/.template.ps1
+++ b/Tests/Functions/Public/.template.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Add-JiraFilterPermission.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Add-JiraFilterPermission.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Add-JiraGroupMember.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Add-JiraGroupMember.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Add-JiraIssueAttachment.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Add-JiraIssueAttachment.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "")]
 param()
 

--- a/Tests/Functions/Public/Add-JiraIssueComment.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Add-JiraIssueComment.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Add-JiraIssueLink.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Add-JiraIssueLink.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Add-JiraIssueWatcher.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Add-JiraIssueWatcher.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Add-JiraIssueWorklog.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Add-JiraIssueWorklog.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Clear-JiraCache.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Clear-JiraCache.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/ConvertFrom-AtlassianDocumentFormat.Unit.Tests.ps1
+++ b/Tests/Functions/Public/ConvertFrom-AtlassianDocumentFormat.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/ConvertTo-AtlassianDocumentFormat.Unit.Tests.ps1
+++ b/Tests/Functions/Public/ConvertTo-AtlassianDocumentFormat.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/ConvertTo-JiraTable.Unit.Tests.ps1
+++ b/Tests/Functions/Public/ConvertTo-JiraTable.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Find-JiraFilter.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Find-JiraFilter.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraComponent.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraComponent.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraConfigServer.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraConfigServer.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraField.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraField.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraFilter.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraFilter.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraFilterPermission.unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraFilterPermission.unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraGroup.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraGroup.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraGroupMember.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraGroupMember.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraIssue.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraIssue.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraIssueAttachment.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraIssueAttachment.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraIssueAttachmentFile.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraIssueAttachmentFile.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraIssueComment.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraIssueComment.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraIssueCreateMetadata.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraIssueCreateMetadata.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraIssueEditMetadata.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraIssueEditMetadata.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraIssueLink.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraIssueLink.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraIssueLinkType.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraIssueLinkType.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraIssueType.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraIssueType.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraIssueWatcher.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraIssueWatcher.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraIssueWorklog.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraIssueWorklog.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraPriority.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraPriority.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraProject.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraProject.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraRemoteLink.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraRemoteLink.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraResponseHeaderLogConfiguration.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraResponseHeaderLogConfiguration.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraServerInformation.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraServerInformation.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraSession.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraSession.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraStatus.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraStatus.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraUser.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraUser.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Get-JiraVersion.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-JiraVersion.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Invoke-JiraIssueTransition.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Invoke-JiraIssueTransition.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Invoke-JiraMethod.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Invoke-JiraMethod.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "")]
 param()

--- a/Tests/Functions/Public/Move-JiraVersion.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Move-JiraVersion.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/New-JiraFilter.Unit.Tests.ps1
+++ b/Tests/Functions/Public/New-JiraFilter.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/New-JiraGroup.Unit.Tests.ps1
+++ b/Tests/Functions/Public/New-JiraGroup.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/New-JiraIssue.Unit.Tests.ps1
+++ b/Tests/Functions/Public/New-JiraIssue.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/New-JiraIssueLinkRequest.Unit.Tests.ps1
+++ b/Tests/Functions/Public/New-JiraIssueLinkRequest.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/New-JiraSession.Unit.Tests.ps1
+++ b/Tests/Functions/Public/New-JiraSession.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "")]
 param()

--- a/Tests/Functions/Public/New-JiraUser.Unit.Tests.ps1
+++ b/Tests/Functions/Public/New-JiraUser.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/New-JiraVersion.Unit.Tests.ps1
+++ b/Tests/Functions/Public/New-JiraVersion.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 param()
 

--- a/Tests/Functions/Public/Remove-JiraFilter.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Remove-JiraFilter.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Remove-JiraFilterPermission.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Remove-JiraFilterPermission.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Remove-JiraGroup.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Remove-JiraGroup.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Remove-JiraGroupMember.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Remove-JiraGroupMember.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Remove-JiraIssue.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Remove-JiraIssue.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Remove-JiraIssueAttachment.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Remove-JiraIssueAttachment.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Remove-JiraIssueLink.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Remove-JiraIssueLink.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Remove-JiraIssueWatcher.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Remove-JiraIssueWatcher.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Remove-JiraRemoteLink.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Remove-JiraRemoteLink.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Remove-JiraSession.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Remove-JiraSession.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "Remove-JiraSession" -Tag 'Unit' {
 

--- a/Tests/Functions/Public/Remove-JiraUser.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Remove-JiraUser.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Remove-JiraVersion.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Remove-JiraVersion.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Resolve-JiraError.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Resolve-JiraError.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Set-JiraConfigServer.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Set-JiraConfigServer.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Set-JiraFilter.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Set-JiraFilter.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Set-JiraIssue.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Set-JiraIssue.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Set-JiraIssueLabel.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Set-JiraIssueLabel.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Set-JiraResponseHeaderLogConfiguration.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Set-JiraResponseHeaderLogConfiguration.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Set-JiraUser.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Set-JiraUser.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Functions/Public/Set-JiraVersion.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Set-JiraVersion.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"

--- a/Tests/Help.Tests.ps1
+++ b/Tests/Help.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/Helpers/TestTools.ps1"

--- a/Tests/Helpers/IntegrationTestTools.Unit.Tests.ps1
+++ b/Tests/Helpers/IntegrationTestTools.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeAll {
     . "$PSScriptRoot/IntegrationTestTools.ps1"

--- a/Tests/Integration/.template.ps1
+++ b/Tests/Integration/.template.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 <#
 .SYNOPSIS

--- a/Tests/Integration/ADF.Integration.Tests.ps1
+++ b/Tests/Integration/ADF.Integration.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../Helpers/TestTools.ps1"

--- a/Tests/Integration/Attachments.Integration.Tests.ps1
+++ b/Tests/Integration/Attachments.Integration.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../Helpers/TestTools.ps1"

--- a/Tests/Integration/Authentication.Integration.Tests.ps1
+++ b/Tests/Integration/Authentication.Integration.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '', Justification = 'Integration tests require plaintext credential conversion for API tokens')]
 param()

--- a/Tests/Integration/Comments.Integration.Tests.ps1
+++ b/Tests/Integration/Comments.Integration.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../Helpers/TestTools.ps1"

--- a/Tests/Integration/Configuration.Integration.Tests.ps1
+++ b/Tests/Integration/Configuration.Integration.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 <#
 .SYNOPSIS

--- a/Tests/Integration/Filters.Integration.Tests.ps1
+++ b/Tests/Integration/Filters.Integration.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../Helpers/TestTools.ps1"

--- a/Tests/Integration/Get-JiraIssue.Integration.Tests.ps1
+++ b/Tests/Integration/Get-JiraIssue.Integration.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../Helpers/TestTools.ps1"

--- a/Tests/Integration/Groups.Integration.Tests.ps1
+++ b/Tests/Integration/Groups.Integration.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../Helpers/TestTools.ps1"

--- a/Tests/Integration/IssueLinks.Integration.Tests.ps1
+++ b/Tests/Integration/IssueLinks.Integration.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 <#
 .SYNOPSIS

--- a/Tests/Integration/IssueWatchers.Integration.Tests.ps1
+++ b/Tests/Integration/IssueWatchers.Integration.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 <#
 .SYNOPSIS

--- a/Tests/Integration/Metadata.Integration.Tests.ps1
+++ b/Tests/Integration/Metadata.Integration.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../Helpers/TestTools.ps1"

--- a/Tests/Integration/New-JiraIssue.Integration.Tests.ps1
+++ b/Tests/Integration/New-JiraIssue.Integration.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../Helpers/TestTools.ps1"

--- a/Tests/Integration/Projects.Integration.Tests.ps1
+++ b/Tests/Integration/Projects.Integration.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../Helpers/TestTools.ps1"

--- a/Tests/Integration/README.md
+++ b/Tests/Integration/README.md
@@ -248,7 +248,7 @@ Its console summary always includes the skipped-test count; when any tests skip,
 Integration tests follow the same Pester v5 patterns as unit tests:
 
 ```powershell
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../Helpers/TestTools.ps1"

--- a/Tests/Integration/Remove-JiraIssue.Integration.Tests.ps1
+++ b/Tests/Integration/Remove-JiraIssue.Integration.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../Helpers/TestTools.ps1"

--- a/Tests/Integration/Search.Integration.Tests.ps1
+++ b/Tests/Integration/Search.Integration.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../Helpers/TestTools.ps1"

--- a/Tests/Integration/Server.Integration.Tests.ps1
+++ b/Tests/Integration/Server.Integration.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 <#
 .SYNOPSIS

--- a/Tests/Integration/ServerInfo.Integration.Tests.ps1
+++ b/Tests/Integration/ServerInfo.Integration.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../Helpers/TestTools.ps1"

--- a/Tests/Integration/Set-JiraIssue.Integration.Tests.ps1
+++ b/Tests/Integration/Set-JiraIssue.Integration.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../Helpers/TestTools.ps1"

--- a/Tests/Integration/Transitions.Integration.Tests.ps1
+++ b/Tests/Integration/Transitions.Integration.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 <#
 .SYNOPSIS

--- a/Tests/Integration/Users.Integration.Tests.ps1
+++ b/Tests/Integration/Users.Integration.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../Helpers/TestTools.ps1"

--- a/Tests/Integration/Versions.Integration.Tests.ps1
+++ b/Tests/Integration/Versions.Integration.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../Helpers/TestTools.ps1"

--- a/Tests/Integration/Worklogs.Integration.Tests.ps1
+++ b/Tests/Integration/Worklogs.Integration.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../Helpers/TestTools.ps1"

--- a/Tests/Invoke-ParallelPester.ps1
+++ b/Tests/Invoke-ParallelPester.ps1
@@ -160,7 +160,8 @@ try {
         Read-DotEnvFile -Path (Join-Path $projectRoot '.env') -ExcludeName (Get-DotEnvExcludedName)
     }
 
-    Import-Module Pester -MinimumVersion 5.0 -Force
+    Get-Module Pester | Remove-Module -Force -ErrorAction SilentlyContinue
+    Import-Module Pester -MinimumVersion '5.9.0' -MaximumVersion '5.9.999' -Force -ErrorAction Stop
     Set-Location $projectRoot
 
     $config = New-PesterConfiguration

--- a/Tests/JiraPS.Tests.ps1
+++ b/Tests/JiraPS.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/Helpers/TestTools.ps1"

--- a/Tests/Project.Tests.ps1
+++ b/Tests/Project.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/Helpers/TestTools.ps1"
@@ -58,7 +58,11 @@ Describe "General project validation" -Tag Unit {
             } #>
 
             It "is loaded in the module" {
-                $commandInModule = $module.Invoke({ Get-Command -Name $args[0] -ErrorAction SilentlyContinue }, $functionName)
+                $commandInModule = InModuleScope JiraPS -Parameters @{ Name = $functionName } {
+                    param($Name)
+
+                    Get-Command -Name $Name -CommandType Function -ErrorAction SilentlyContinue
+                }
 
                 $commandInModule | Should -Not -BeNullOrEmpty -Because "private function '$functionName' should be loaded"
             }

--- a/Tests/README.md
+++ b/Tests/README.md
@@ -13,7 +13,7 @@ This guide explains how to write, run, and debug tests for JiraPS.
 
 ## Test Structure
 
-JiraPS uses [Pester v5.7+](https://pester.dev/) for unit testing. All test files follow one of two standardized templates based on the function type being tested.
+JiraPS uses [Pester 5.9.x](https://pester.dev/) for unit testing. All test files follow one of two standardized templates based on the function type being tested.
 
 ### Directory Organization
 
@@ -54,7 +54,7 @@ JiraPS uses two primary test templates based on function type:
 **Structure**:
 
 ```powershell
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"
@@ -149,7 +149,7 @@ InModuleScope JiraPS {
 **Structure**:
 
 ```powershell
-#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../../Helpers/TestTools.ps1"
@@ -525,7 +525,7 @@ See [`Tests/Functions/Add-JiraFilterPermission.Unit.Tests.ps1`](Functions/Add-Ji
 
 ### Tests Not Running
 
-- Ensure Pester 5.7+ is installed: `Install-Module Pester -MinimumVersion 5.7 -Force`
+- Ensure Pester 5.9.x is installed: `Install-Module Pester -RequiredVersion 5.9.0 -Force`
 - Check for syntax errors in test file
 - Verify module imports correctly in BeforeDiscovery
 

--- a/Tests/Style.Tests.ps1
+++ b/Tests/Style.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "Style rules" -Tag "Unit" {
     BeforeAll {

--- a/Tests/TestTools.Tests.ps1
+++ b/Tests/TestTools.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/Helpers/TestTools.ps1"

--- a/Tests/Tools/SetupScript.Unit.Tests.ps1
+++ b/Tests/Tools/SetupScript.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe 'Tools/setup.ps1' -Tag Unit {
     It 'delegates dependency install to shared standards commands' {

--- a/Tests/Tools/StandardsVersionConsistency.Unit.Tests.ps1
+++ b/Tests/Tools/StandardsVersionConsistency.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe 'AtlassianPS.Standards version consistency' -Tag Unit {
     It 'keeps workflow Standards action pins aligned with build.requirements' {

--- a/Tests/Tools/Update-DependenciesScript.Unit.Tests.ps1
+++ b/Tests/Tools/Update-DependenciesScript.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe 'Tools/update.dependencies.ps1' -Tag Unit {
     It 'delegates dependency updates to the shared standards updater with expected paths and switches' {

--- a/Tools/build.requirements.psd1
+++ b/Tools/build.requirements.psd1
@@ -2,7 +2,7 @@
     @{ ModuleName = "AtlassianPS.Standards"; RequiredVersion = "0.1.11" }
     @{ ModuleName = "InvokeBuild"; RequiredVersion = "5.14.23" }
     @{ ModuleName = "Metadata"; RequiredVersion = "1.5.7" }
-    @{ ModuleName = "Pester"; RequiredVersion = "5.7.1" }
+    @{ ModuleName = "Pester"; RequiredVersion = "5.9.0" }
     @{ ModuleName = "Microsoft.PowerShell.PlatyPS"; RequiredVersion = "1.0.1" }
     @{ ModuleName = "PSScriptAnalyzer"; RequiredVersion = "1.25.0" }
 )


### PR DESCRIPTION
## Summary

- install Pester 5.9.0 and bound lint, unit, and integration execution at 5.9.999
- run style tests explicitly with the same bounds and retain analyzer coverage
- replace private-command discovery through module.Invoke with InModuleScope
- bound parallel integration workers to the accepted Pester range

## Why

Pester 5.9.0 is the reproducible clean-install baseline. The 5.9.999 maximum accepts compatible 5.9.x patches without allowing an unreviewed future major version to change test behavior.

This applies the lessons from AtlassianPS/JiraAgilePS#43.

## Validation

- `Invoke-Build -Task Lint, Build, Test`: 1,661 core tests passed, 1 skipped; all helper, build, help, project, and style suites passed
- cold-cache dependency setup completed successfully
- Windows PowerShell 5.1, Windows PowerShell 7, Ubuntu, and macOS CI are green ([run 32741223108](https://github.com/AtlassianPS/JiraPS/actions/runs/32741223108))
- Cloud and Server integration are green on the rebased head ([run 32743234609](https://github.com/AtlassianPS/JiraPS/actions/runs/32743234609))
- a focused Cloud rerun executed the complete 252-test suite with zero failures ([run 32744135515](https://github.com/AtlassianPS/JiraPS/actions/runs/32744135515))
- `Groups.Integration.Tests.ps1` executed successful cases on both Cloud and Server
