### PR TITLE
Reduce integration workflow resource usage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,14 +15,14 @@ updates:
   - package-ecosystem: "devcontainers"
     directory: "/.devcontainer"
     schedule:
-      interval: weekly
+      interval: monthly
     labels:
       - dependencies
       - "release:none"
   - package-ecosystem: "docker"
     directory: "/.devcontainer"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "⬆️ "
     labels:
@@ -31,7 +31,7 @@ updates:
   - package-ecosystem: "docker-compose"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "⬆️ "
     labels:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -24,6 +24,11 @@ on:
           - cloud
           - server
           - both
+      debug:
+        description: "Upload Data Center container logs even when tests succeed"
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -62,6 +67,7 @@ jobs:
         with:
           name: Cloud-Integration-Tests
           path: Test-Integration.xml
+          retention-days: 14
         if: always()
 
   server_integration_tests:
@@ -169,18 +175,20 @@ jobs:
         with:
           name: Server-Integration-Tests
           path: Test-Integration.xml
+          retention-days: 14
 
       - name: Capture Jira container logs for debugging
-        if: always()
+        if: ${{ failure() || inputs.debug || runner.debug == '1' }}
         run: docker compose logs jira > jira-container.log
         shell: bash
 
       - name: Upload Jira container logs
-        if: always()
+        if: ${{ failure() || inputs.debug || runner.debug == '1' }}
         uses: actions/upload-artifact@v7
         with:
           name: Server-Jira-Container-Logs
           path: jira-container.log
+          retention-days: 7
 
       - name: Tear down Jira Data Center container
         if: always()

--- a/Tests/Integration/README.md
+++ b/Tests/Integration/README.md
@@ -448,7 +448,7 @@ For **first-party PR branches** (those on `AtlassianPS/JiraPS` itself), the bran
 - **No build required**: tests run directly against source for speed.
 - **Parallel execution**: Cloud uses `ThrottleLimit=6`; Server uses `ThrottleLimit=2` (halved because the AMPS/H2 backend serialises Lucene write commits — see the inline comment on the `server_integration_tests` job for the contention details).
 - **Concurrency control**: weekly + dispatched runs share one concurrency group with `cancel-in-progress: false`, so an in-flight run is never killed by a dispatch retry.
-- **NUnit results artifacts**: `Cloud-Integration-Tests` and `Server-Integration-Tests` (each containing `Test-Integration.xml`); the Server job additionally uploads `Server-Jira-Container-Logs` for post-mortem on failures.
+- **NUnit results artifacts**: `Cloud-Integration-Tests` and `Server-Integration-Tests` (each containing `Test-Integration.xml`) are retained for 14 days. The Server job retains `Server-Jira-Container-Logs` for 7 days after failures, manual runs with `debug` enabled, or runs with GitHub runner debug logging enabled.
 
 ## Troubleshooting
 

--- a/Tests/Tools/WorkflowTriggers.Unit.Tests.ps1
+++ b/Tests/Tools/WorkflowTriggers.Unit.Tests.ps1
@@ -3,13 +3,26 @@
 Describe 'GitHub Actions workflow triggers' -Tag Unit {
     BeforeAll {
         . "$PSScriptRoot/../Helpers/TestTools.ps1"
-        $script:workflowRoot = Join-Path (Resolve-ProjectRoot) '.github/workflows'
+        $script:projectRoot = Resolve-ProjectRoot
+        $script:workflowRoot = Join-Path $script:projectRoot '.github/workflows'
+        $script:integrationWorkflow = Get-Content (Join-Path $script:workflowRoot 'integration_tests.yml') -Raw
     }
 
     It 'runs integration tests weekly and on demand' {
-        $workflow = Get-Content (Join-Path $script:workflowRoot 'integration_tests.yml') -Raw
+        $script:integrationWorkflow | Should -Match 'cron:\s*"0 5 \* \* 0"'
+        $script:integrationWorkflow | Should -Match 'workflow_dispatch:'
+    }
 
-        $workflow | Should -Match 'cron:\s*"0 5 \* \* 0"'
-        $workflow | Should -Match 'workflow_dispatch:'
+    It 'retains integration diagnostics briefly and uploads container logs on demand' {
+        ([regex]::Matches($script:integrationWorkflow, 'retention-days:\s+14')).Count | Should -Be 2
+        ([regex]::Matches($script:integrationWorkflow, 'retention-days:\s+7')).Count | Should -Be 1
+        ([regex]::Matches($script:integrationWorkflow, "failure\(\) \|\| inputs\.debug \|\| runner\.debug == '1'")).Count | Should -Be 2
+    }
+
+    It 'checks routine container dependencies monthly' {
+        $dependabot = Get-Content (Join-Path $script:projectRoot '.github/dependabot.yml') -Raw
+
+        ([regex]::Matches($dependabot, 'package-ecosystem:\s*"(?:devcontainers|docker|docker-compose)"[\s\S]*?interval:\s*"?monthly"?')).Count | Should -Be 3
+        $dependabot | Should -Match 'package-ecosystem:\s*"github-actions"[\s\S]*?interval:\s*"?weekly"?'
     }
 }


### PR DESCRIPTION
## Summary

- move routine container dependency checks to monthly while keeping GitHub Actions weekly
- retain integration results for 14 days and container logs for 7 days
- upload successful Data Center logs only in manual or runner debug mode
- document and test the diagnostic artifact policy

## Validation

- actionlint
- focused workflow tests: 3 passed
- full suite attempt was blocked by conflicting locally installed Pester assemblies; focused tests used the repository-compatible Pester version

## Related pull requests

- AtlassianPS.Configuration #46
- AtlassianPS.Standards #57
- AtlassianPS.github.io #61
- ConfluencePS #265
- JiraAgilePS #50
- JiraPS #713