### PR TITLE
Cancel JiraPS v3 release preparation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-## v3.0.0 - 2026-08-29
-
 This release focuses on Cloud and Data Center compatibility, safer typing, and better automation ergonomics.
 
 ### Highlights for users

--- a/JiraPS/JiraPS.psd1
+++ b/JiraPS/JiraPS.psd1
@@ -4,7 +4,7 @@
     RootModule           = 'JiraPS.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '3.0.0'
+    ModuleVersion        = '2.16.0'
 
     # Supported PSEditions
     CompatiblePSEditions = @('Desktop', 'Core')


### PR DESCRIPTION
## Summary

- restore the JiraPS source manifest to `2.16.0`
- return the pending release notes to `## Unreleased`
- keep JiraPS continuous delivery disabled

## Validation

- `Invoke-Build -Task Build, Test`
- confirmed no `v3.0.0` Git tag or GitHub release exists
- confirmed PSGallery has no JiraPS `3.0.0` package

This reverts `5586d082bffb64319fbde6eafd197f2ef2ca2363`.